### PR TITLE
Implement language for SCC error messages

### DIFF
--- a/cmd/suseconnect.go
+++ b/cmd/suseconnect.go
@@ -78,6 +78,11 @@ func main() {
 		connect.CFG.Namespace = namespace
 		writeConfig = true
 	}
+	if lang, ok := os.LookupEnv("LANG"); ok {
+		if lang != "" {
+			connect.CFG.Language = lang
+		}
+	}
 	if status {
 		output, err := connect.GetProductStatuses("json")
 		exitOnError(err)

--- a/connect/config.go
+++ b/connect/config.go
@@ -13,7 +13,6 @@ import (
 const (
 	defaultConfigPath = "/etc/SUSEConnect"
 	defaultBaseURL    = "https://scc.suse.com"
-	defaultLang       = "en_US.UTF-8"
 	defaultInsecure   = false
 )
 
@@ -32,7 +31,9 @@ func (c Config) toYAML() []byte {
 	fmt.Fprintf(&buf, "---\n")
 	fmt.Fprintf(&buf, "url: %s\n", c.BaseURL)
 	fmt.Fprintf(&buf, "insecure: %v\n", c.Insecure)
-	fmt.Fprintf(&buf, "language: %s\n", c.Language)
+	if c.Language != "" {
+		fmt.Fprintf(&buf, "language: %s\n", c.Language)
+	}
 	if c.Namespace != "" {
 		fmt.Fprintf(&buf, "namespace: %s\n", c.Namespace)
 	}
@@ -50,7 +51,6 @@ func (c Config) Save() error {
 func (c *Config) Load() {
 	c.Path = defaultConfigPath
 	c.BaseURL = defaultBaseURL
-	c.Language = defaultLang
 	c.Insecure = defaultInsecure
 	f, err := os.Open(defaultConfigPath)
 	if err != nil {

--- a/connect/connection.go
+++ b/connect/connection.go
@@ -24,7 +24,9 @@ func addHeaders(req *http.Request) {
 	req.Header.Add("Content-Type", "application/json")
 	accept := "application/json,application/vnd.scc.suse.com." + APIVersion + "+json"
 	req.Header.Add("Accept", accept)
-	req.Header.Add("Accept-Language", CFG.Language)
+	if CFG.Language != "" {
+		req.Header.Add("Accept-Language", CFG.Language)
+	}
 	// REVISIT "Accept-Encoding" - disable gzip commpression on debug?
 	req.Header.Add("User-Agent", AppName+"/"+Version)
 	// REVISIT Close - unlike Ruby, Go does not close by default


### PR DESCRIPTION
Following the Ruby version. Only add as a http header if it's
in the environment and not blank, or from /etc/SUSEConnect.
Also don't write it to /etc/SUSEConnect if it's blank.