### PR TITLE
Generalize HTTP client code

### DIFF
--- a/connect/api.go
+++ b/connect/api.go
@@ -15,7 +15,7 @@ const (
 func UpToDate() bool {
 	// REVIST 404 case - see original
 	// Should fail in any case. 422 error means that the endpoint is there and working right
-	_, err := DoGET(Credentials{}, "/connect/repositories/installer")
+	_, err := callHTTP("GET", "/connect/repositories/installer", nil, nil, Credentials{})
 	if err == nil {
 		return false
 	}
@@ -29,9 +29,8 @@ func UpToDate() bool {
 
 // GetActivations returns a map keyed by "Identifier/Version/Arch"
 func GetActivations(creds Credentials) (map[string]Activation, error) {
-	urlSuffix := "/connect/systems/activations"
 	activeMap := make(map[string]Activation)
-	resp, err := DoGET(creds, urlSuffix)
+	resp, err := callHTTP("GET", "/connect/systems/activations", nil, nil, creds)
 	if err != nil {
 		return activeMap, err
 	}

--- a/connect/connection_test.go
+++ b/connect/connection_test.go
@@ -7,20 +7,20 @@ import (
 	"testing"
 )
 
-func TestDoGetInsecure(t *testing.T) {
+func TestCallHTTPSecure(t *testing.T) {
 	ts := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
 	ts.StartTLS()
 	defer ts.Close()
 
 	CFG.BaseURL = ts.URL
 	CFG.Insecure = false
-	_, err := DoGET(Credentials{}, "/")
+	_, err := callHTTP("GET", "/", nil, nil, Credentials{})
 	if err == nil {
 		t.Error("Expecting certificate error. Got none.")
 	}
 
 	CFG.Insecure = true
-	_, err = DoGET(Credentials{}, "/")
+	_, err = callHTTP("GET", "/", nil, nil, Credentials{})
 	if err != nil {
 		t.Errorf("Unexpected error: %s", err)
 	}


### PR DESCRIPTION
Allow verbs other than GET.
Provide parameter for request body.
Check range of status codes for success.