### PR TITLE
Complete credentials file handling

### DIFF
--- a/connect/api.go
+++ b/connect/api.go
@@ -15,7 +15,7 @@ const (
 func UpToDate() bool {
 	// REVIST 404 case - see original
 	// Should fail in any case. 422 error means that the endpoint is there and working right
-	_, err := callHTTP("GET", "/connect/repositories/installer", nil, nil, Credentials{})
+	_, err := callHTTP("GET", "/connect/repositories/installer", nil, nil, authNone)
 	if err == nil {
 		return false
 	}
@@ -28,9 +28,9 @@ func UpToDate() bool {
 }
 
 // GetActivations returns a map keyed by "Identifier/Version/Arch"
-func GetActivations(creds Credentials) (map[string]Activation, error) {
+func GetActivations() (map[string]Activation, error) {
 	activeMap := make(map[string]Activation)
-	resp, err := callHTTP("GET", "/connect/systems/activations", nil, nil, creds)
+	resp, err := callHTTP("GET", "/connect/systems/activations", nil, nil, authSystem)
 	if err != nil {
 		return activeMap, err
 	}

--- a/connect/api_test.go
+++ b/connect/api_test.go
@@ -9,10 +9,7 @@ import (
 
 func TestGetActivations(t *testing.T) {
 	response := readTestFile("activations.json", t)
-	CFG.FsRoot = t.TempDir()
-	if err := writeSystemCredentials("user1", "pass1"); err != nil {
-		t.Fatalf("Unexpected error: %s", err)
-	}
+	createTestCredentials("", "", t)
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -41,10 +38,8 @@ func TestGetActivationsRequest(t *testing.T) {
 		url        = "/connect/systems/activations"
 		gotRequest *http.Request
 	)
-	CFG.FsRoot = t.TempDir()
-	if err := writeSystemCredentials(user, password); err != nil {
-		t.Fatalf("Unexpected error: %s", err)
-	}
+	createTestCredentials(user, password, t)
+
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		gotRequest = r // make request available outside this func after call
 		w.Header().Set("Content-Type", "application/json")
@@ -65,10 +60,8 @@ func TestGetActivationsRequest(t *testing.T) {
 }
 
 func TestGetActivationsError(t *testing.T) {
-	CFG.FsRoot = t.TempDir()
-	if err := writeSystemCredentials("user1", "pass1"); err != nil {
-		t.Fatalf("Unexpected error: %s", err)
-	}
+	createTestCredentials("", "", t)
+
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "", http.StatusInternalServerError)
 	}))

--- a/connect/client.go
+++ b/connect/client.go
@@ -14,9 +14,10 @@ func Deregister() error {
 	return fmt.Errorf("Deregister not implemented yet")
 }
 
-// IsRegistered returns true if the system credentials file exists
+// IsRegistered returns true if there is a valid credentials file
 func IsRegistered() bool {
-	return fileExists(defaulCredPath)
+	_, err := getCredentials()
+	return err == nil
 }
 
 // URLDefault returns true if using https://scc.suse.com

--- a/connect/connection_test.go
+++ b/connect/connection_test.go
@@ -14,13 +14,13 @@ func TestCallHTTPSecure(t *testing.T) {
 
 	CFG.BaseURL = ts.URL
 	CFG.Insecure = false
-	_, err := callHTTP("GET", "/", nil, nil, Credentials{})
+	_, err := callHTTP("GET", "/", nil, nil, authNone)
 	if err == nil {
 		t.Error("Expecting certificate error. Got none.")
 	}
 
 	CFG.Insecure = true
-	_, err = callHTTP("GET", "/", nil, nil, Credentials{})
+	_, err = callHTTP("GET", "/", nil, nil, authNone)
 	if err != nil {
 		t.Errorf("Unexpected error: %s", err)
 	}

--- a/connect/credentials.go
+++ b/connect/credentials.go
@@ -1,13 +1,17 @@
 package connect
 
 import (
+	"bytes"
+	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"regexp"
 )
 
 const (
-	defaulCredPath = "/etc/zypp/credentials.d/SCCcredentials"
+	defaulCredentialsDir  = "/etc/zypp/credentials.d"
+	globalCredentialsFile = "/etc/zypp/credentials.d/SCCcredentials"
 )
 
 var (
@@ -15,24 +19,52 @@ var (
 	passMatch = regexp.MustCompile(`(?m)^\s*password\s*=\s*(\S+)\s*$`)
 )
 
-// Credentials stores the SCC credentials
-// TODO service credentials
+// Credentials stores the SCC or service credentials
 type Credentials struct {
+	Filename string
 	Username string
 	Password string
 }
 
+func (c Credentials) String() string {
+	return fmt.Sprintf("file: %s, username: %s, password: REDACTED",
+		c.Filename, c.Username)
+}
+
+func systemCredentialsFile() string {
+	return filepath.Join(CFG.FsRoot, globalCredentialsFile)
+}
+
+func serviceCredentialsFile(service string) string {
+	return filepath.Join(CFG.FsRoot, defaulCredentialsDir, service)
+}
+
+// getCredentials reads the system credentials from the SCCcredentials file
 func getCredentials() (Credentials, error) {
-	Debug.Printf("Reading credientials from %s", defaulCredPath)
-	f, err := os.Open(defaulCredPath)
+	path := systemCredentialsFile()
+	if !fileExists(path) {
+		return Credentials{}, ErrMissingCredentialsFile
+	}
+	return readCredentials(path)
+}
+
+func readCredentials(path string) (Credentials, error) {
+	Debug.Print("Reading credentials: ", path)
+	f, err := os.Open(path)
 	if err != nil {
 		return Credentials{}, err
 	}
 	defer f.Close()
-	return parseCredientials(f)
+	creds, err := parseCredentials(f)
+	if err != nil {
+		return Credentials{}, err
+	}
+	creds.Filename = path
+	Debug.Print("Credentials read: ", creds)
+	return creds, nil
 }
 
-func parseCredientials(r io.Reader) (Credentials, error) {
+func parseCredentials(r io.Reader) (Credentials, error) {
 	content, err := io.ReadAll(r)
 	if err != nil {
 		return Credentials{}, err
@@ -43,4 +75,48 @@ func parseCredientials(r io.Reader) (Credentials, error) {
 		return Credentials{}, ErrMalformedSccCredFile
 	}
 	return Credentials{Username: uMatch[1], Password: pMatch[1]}, nil
+}
+
+func (c Credentials) write() error {
+	Debug.Print("Writing credentials: ", c)
+	dir := filepath.Dir(c.Filename)
+	if !fileExists(dir) {
+		err := os.MkdirAll(dir, 0755)
+		if err != nil {
+			return err
+		}
+	}
+	buf := bytes.Buffer{}
+	fmt.Fprintln(&buf, "username=", c.Username)
+	fmt.Fprintln(&buf, "password=", c.Password)
+	return os.WriteFile(c.Filename, buf.Bytes(), 0600)
+}
+
+func writeSystemCredentials(login, password string) error {
+	path := systemCredentialsFile()
+	c := Credentials{Filename: path, Username: login, Password: password}
+	return c.write()
+}
+
+func writeServiceCredentials(serviceName string) error {
+	c, err := getCredentials()
+	if err != nil {
+		return err
+	}
+	path := serviceCredentialsFile(serviceName)
+	s := Credentials{
+		Filename: path,
+		Username: c.Username,
+		Password: c.Password}
+	return s.write()
+}
+
+func removeSystemCredentials() error {
+	path := systemCredentialsFile()
+	return removeFile(path)
+}
+
+func removeServiceCredentials(serviceName string) error {
+	path := serviceCredentialsFile(serviceName)
+	return removeFile(path)
 }

--- a/connect/credentials_test.go
+++ b/connect/credentials_test.go
@@ -5,23 +5,73 @@ import (
 	"testing"
 )
 
-func TestParseCredientials(t *testing.T) {
+func TestParseCredentials(t *testing.T) {
 	var tests = []struct {
 		input       string
 		expectCreds Credentials
 		expectErr   error
 	}{
-		{"username=user1\npassword=pass1", Credentials{"user1", "pass1"}, nil},
-		{" \n username = user1 \n password = pass1 \n", Credentials{"user1", "pass1"}, nil},
-		{"username = user1 \n junk \n password = pass1 \n", Credentials{"user1", "pass1"}, nil},
+		{"username=user1\npassword=pass1", Credentials{"", "user1", "pass1"}, nil},
+		{" \n username = user1 \n password = pass1 \n", Credentials{"", "user1", "pass1"}, nil},
+		{"username = user1 \n junk \n password = pass1 \n", Credentials{"", "user1", "pass1"}, nil},
 		{"USERNAME = user1 \n passed = pass1", Credentials{}, ErrMalformedSccCredFile},
 		{"username= \n password = \n", Credentials{}, ErrMalformedSccCredFile},
 	}
 
 	for _, test := range tests {
-		got, err := parseCredientials(strings.NewReader(test.input))
+		got, err := parseCredentials(strings.NewReader(test.input))
 		if err != test.expectErr || got != test.expectCreds {
-			t.Errorf("ParseCredientials() == %+v, %s, expected %+v, %s", got, err, test.expectCreds, test.expectErr)
+			t.Errorf("ParseCredentials() == %+v, %s, expected %+v, %s", got, err, test.expectCreds, test.expectErr)
 		}
+	}
+}
+
+func TestWriteReadDeleteSystem(t *testing.T) {
+	CFG.FsRoot = t.TempDir()
+	_, err := getCredentials()
+	if err != ErrMissingCredentialsFile {
+		t.Fatalf("Expected [%s], got [%s]", ErrMissingCredentialsFile, err)
+	}
+	if err := writeSystemCredentials("user1", "pass1"); err != nil {
+		t.Fatalf("Unexpected error: %s", err)
+	}
+	c, err := getCredentials()
+	if err != nil {
+		t.Fatalf("Unexpected error: %s", err)
+	}
+	if c.Username != "user1" || c.Password != "pass1" {
+		t.Errorf("Unexpected user1 and pass1. Got: %s and %s",
+			c.Username, c.Password)
+	}
+	if err := removeSystemCredentials(); err != nil {
+		t.Errorf("Unexpected error: %s", err)
+	}
+	path := systemCredentialsFile()
+	if fileExists(path) {
+		t.Error("File was not deleted: ", path)
+	}
+}
+
+func TestWriteReadDeleteService(t *testing.T) {
+	CFG.FsRoot = t.TempDir()
+	if err := writeSystemCredentials("user1", "pass1"); err != nil {
+		t.Fatalf("Unexpected error: %s", err)
+	}
+	if err := writeServiceCredentials("service1"); err != nil {
+		t.Fatalf("Unexpected error: %s", err)
+	}
+	path := serviceCredentialsFile("service1")
+	rc, err := readCredentials(path)
+	if err != nil {
+		t.Fatalf("Unexpected error: %s", err)
+	}
+	if rc.Username != "user1" || rc.Password != "pass1" {
+		t.Errorf("Got: %s and %s, expected user1 and pass1", rc.Username, rc.Password)
+	}
+	if err := removeServiceCredentials("service1"); err != nil {
+		t.Errorf("Unexpected error: %s", err)
+	}
+	if fileExists(path) {
+		t.Error("File was not deleted: ", path)
 	}
 }

--- a/connect/errors.go
+++ b/connect/errors.go
@@ -6,8 +6,9 @@ import (
 )
 
 var (
-	ErrMalformedSccCredFile = errors.New("Unable to parse credentials")
-	ErrSystemNotRegistered  = errors.New("System not registered")
+	ErrMalformedSccCredFile   = errors.New("Unable to parse credentials")
+	ErrMissingCredentialsFile = errors.New("Credentials file is missing")
+	ErrSystemNotRegistered    = errors.New("System not registered")
 )
 
 // ExecuteError is returned from execute() on error

--- a/connect/helpers_test.go
+++ b/connect/helpers_test.go
@@ -15,3 +15,18 @@ func readTestFile(name string, t *testing.T) []byte {
 	}
 	return data
 }
+
+func createTestCredentials(username, password string, t *testing.T) {
+	if username == "" {
+		username = "test"
+	}
+	if password == "" {
+		password = "test"
+	}
+	CFG.FsRoot = t.TempDir()
+	err := writeSystemCredentials(username, password)
+	if err != nil {
+		_, filename, num, _ := runtime.Caller(1)
+		t.Fatalf("\n%s:%d: %s", filepath.Base(filename), num, err)
+	}
+}

--- a/connect/status.go
+++ b/connect/status.go
@@ -56,11 +56,7 @@ func getStatuses() ([]Status, error) {
 
 	activations := make(map[string]Activation) // default empty map
 	if IsRegistered() {
-		creds, err := getCredentials()
-		if err != nil {
-			return statuses, err
-		}
-		activations, err = GetActivations(creds)
+		activations, err = GetActivations()
 		if err != nil {
 			return statuses, err
 		}

--- a/connect/system.go
+++ b/connect/system.go
@@ -56,3 +56,11 @@ func fileExists(path string) bool {
 	}
 	return true
 }
+
+func removeFile(path string) error {
+	Debug.Print("Removing file: ", path)
+	if !fileExists(path) {
+		return nil
+	}
+	return os.Remove(path)
+}


### PR DESCRIPTION
Add methods to read, write and remove the system credentials
and service credentials files. These files are absolute from
/ or from the directory specified with --root.