### PR TITLE
Implement hwinfo

### DIFF
--- a/cmd/suseconnect.go
+++ b/cmd/suseconnect.go
@@ -144,8 +144,8 @@ func main() {
 			flag.Usage()
 			os.Exit(1)
 		} else {
-			// TODO call register()
-			fmt.Println("register() to be implemented")
+			err := connect.Register()
+			exitOnError(err)
 		}
 	}
 	if writeConfig {

--- a/connect/client.go
+++ b/connect/client.go
@@ -2,7 +2,21 @@ package connect
 
 import (
 	"fmt"
+	"os"
 )
+
+// Register announces the system, activates the
+// product on SCC and adds the service to the system
+func Register() error {
+	printInformation("register")
+	err := announceOrUpdate()
+	if err != nil {
+		return err
+	}
+
+	// TODO remainder of Register()
+	return nil
+}
 
 // Deregister deregisters the system
 func Deregister() error {
@@ -96,6 +110,35 @@ func removeOrRefreshService(service Service) error {
 	}
 	fmt.Println("-> Removing service from system ...")
 	return removeService(service.Name)
+}
+
+// UpdateSystem resend the system's hardware details on SCC
+func UpdateSystem(distroTarget, instanceDataFile string) error {
+	fmt.Printf("\nUpdating system details on %s ...\n", CFG.BaseURL)
+	var instanceData []byte
+	if instanceDataFile != "" {
+		var err error
+		instanceData, err = os.ReadFile(instanceDataFile)
+		if err != nil {
+			return err
+		}
+	}
+	sysInfoBody, err := makeSysInfoBody(distroTarget, CFG.Namespace, instanceData)
+	if err != nil {
+		return err
+	}
+	return updateSystem(sysInfoBody)
+}
+
+// announceOrUpdate Announces the system to the server, receiving and storing its
+// credentials. When already announced, sends the current hardware details to the server
+func announceOrUpdate() error {
+	if IsRegistered() {
+		return UpdateSystem("", "")
+	}
+
+	// TODO remainder of announceOrUpdate()
+	return nil
 }
 
 // IsRegistered returns true if there is a valid credentials file

--- a/connect/hwinfo.go
+++ b/connect/hwinfo.go
@@ -119,3 +119,18 @@ func privateIP(ip net.IP) bool {
 	}
 	return false
 }
+
+func hostname() string {
+	name, err := os.Hostname()
+	// TODO the Ruby version has this "(none)" check - why?
+	if err == nil && name != "" && name != "(none)" {
+		return name
+	}
+	Debug.Print(err)
+	ip, err := getPrivateIPAddr()
+	if err != nil {
+		Debug.Print(err)
+		return ""
+	}
+	return ip
+}

--- a/connect/hwinfo.go
+++ b/connect/hwinfo.go
@@ -1,0 +1,30 @@
+package connect
+
+import (
+	"bufio"
+	"bytes"
+	"strings"
+)
+
+func lscpu() (map[string]string, error) {
+	output, err := execute([]string{"lscpu"}, false, nil)
+	if err != nil {
+		return nil, err
+	}
+	return lscpu2map(output), nil
+}
+
+func lscpu2map(b []byte) map[string]string {
+	m := make(map[string]string)
+	scanner := bufio.NewScanner(bytes.NewReader(b))
+	for scanner.Scan() {
+		line := scanner.Text()
+		parts := strings.SplitN(line, ":", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		key, val := strings.TrimSpace(parts[0]), strings.TrimSpace(parts[1])
+		m[key] = val
+	}
+	return m
+}

--- a/connect/hwinfo.go
+++ b/connect/hwinfo.go
@@ -134,3 +134,28 @@ func hostname() string {
 	}
 	return ip
 }
+
+// readValues calls read_values from SUSE/s390-tools
+func readValues(arg string) ([]byte, error) {
+	output, err := execute([]string{"read_values", arg}, false, nil)
+	if err != nil {
+		return nil, err
+	}
+	return output, nil
+}
+
+// readValues2map parses the output of "read_values -s" on s390
+func readValues2map(b []byte) map[string]string {
+	br := bufio.NewScanner(bytes.NewReader(b))
+	m := make(map[string]string)
+	for br.Scan() {
+		line := br.Text()
+		parts := strings.SplitN(line, ":", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		key, val := strings.TrimSpace(parts[0]), strings.TrimSpace(parts[1])
+		m[key] = val
+	}
+	return m
+}

--- a/connect/hwinfo.go
+++ b/connect/hwinfo.go
@@ -3,6 +3,7 @@ package connect
 import (
 	"bufio"
 	"bytes"
+	"net"
 	"os"
 	"regexp"
 	"strings"
@@ -91,4 +92,30 @@ func uuid() (string, error) {
 		return "", nil
 	}
 	return out, nil
+}
+
+// getPrivateIPAddr returns the first private IP address on the host
+func getPrivateIPAddr() (string, error) {
+	addrs, err := net.InterfaceAddrs()
+	if err != nil {
+		return "", err
+	}
+	for _, addr := range addrs {
+		ip, _, _ := net.ParseCIDR(addr.String())
+		if privateIP(ip) {
+			return ip.String(), nil
+		}
+	}
+	return "", nil
+}
+
+// privateIP returns true if ip is in a RFC1918 range
+func privateIP(ip net.IP) bool {
+	for _, block := range []string{"10.0.0.0/8", "192.168.0.0/16", "172.16.0.0/12"} {
+		_, ipNet, _ := net.ParseCIDR(block)
+		if ipNet.Contains(ip) {
+			return true
+		}
+	}
+	return false
 }

--- a/connect/hwinfo_test.go
+++ b/connect/hwinfo_test.go
@@ -1,6 +1,7 @@
 package connect
 
 import (
+	"net"
 	"testing"
 )
 
@@ -64,5 +65,25 @@ func TestFindCloudProviderNoCloud(t *testing.T) {
 	got := findCloudProvider(readTestFile("dmidecode_qemu.txt", t))
 	if got != "" {
 		t.Errorf("findCloudProvider()==%s, expected \"\"", got)
+	}
+}
+
+func TestPrivateIP(t *testing.T) {
+	var tests = []struct {
+		ip      string
+		private bool
+	}{
+		{"10.0.1.1", true},
+		{"192.168.100.10", true},
+		{"172.18.10.10", true},
+		{"8.8.8.8", false},
+		{"172.15.0.1", false},
+	}
+	for _, test := range tests {
+		ip := net.ParseIP(test.ip)
+		got := privateIP(ip)
+		if got != test.private {
+			t.Errorf("Got privateIP(%s)==%v, expected %v", test.ip, got, test.private)
+		}
 	}
 }

--- a/connect/hwinfo_test.go
+++ b/connect/hwinfo_test.go
@@ -31,3 +31,38 @@ func TestLscpu2mapVirtual(t *testing.T) {
 		t.Errorf("Hypervisor vendor should be KVM")
 	}
 }
+
+func TestFindCloudProviderAWS(t *testing.T) {
+	got := findCloudProvider(readTestFile("dmidecode_aws.txt", t))
+	if got != "amazon" {
+		t.Errorf("findCloudProvider()==%s, expected amazon", got)
+	}
+}
+
+func TestFindCloudProviderAWSLarge(t *testing.T) {
+	got := findCloudProvider(readTestFile("dmidecode_aws_large.txt", t))
+	if got != "Amazon" {
+		t.Errorf("findCloudProvider()==%s, expected Amazon", got)
+	}
+}
+
+func TestFindCloudProviderAzure(t *testing.T) {
+	got := findCloudProvider(readTestFile("dmidecode_azure.txt", t))
+	if got != "Microsoft" {
+		t.Errorf("findCloudProvider()==%s, expected Microsoft", got)
+	}
+}
+
+func TestFindCloudProviderGoogle(t *testing.T) {
+	got := findCloudProvider(readTestFile("dmidecode_google.txt", t))
+	if got != "Google" {
+		t.Errorf("findCloudProvider()==%s, expected Google", got)
+	}
+}
+
+func TestFindCloudProviderNoCloud(t *testing.T) {
+	got := findCloudProvider(readTestFile("dmidecode_qemu.txt", t))
+	if got != "" {
+		t.Errorf("findCloudProvider()==%s, expected \"\"", got)
+	}
+}

--- a/connect/hwinfo_test.go
+++ b/connect/hwinfo_test.go
@@ -1,0 +1,33 @@
+package connect
+
+import (
+	"testing"
+)
+
+func TestLscpu2mapPhysical(t *testing.T) {
+	m := lscpu2map(readTestFile("lscpu_phys.txt", t))
+
+	if m["CPU(s)"] != "8" {
+		t.Errorf("Found %s CPU(s), expected 8", m["CPU(s)"])
+	}
+	if m["Socket(s)"] != "1" {
+		t.Errorf("Found %s Sockets(s), expected 1", m["Socket(s)"])
+	}
+	if _, ok := m["Hypervisor vendor"]; ok {
+		t.Errorf("Hypervisor vendor should not be set")
+	}
+}
+
+func TestLscpu2mapVirtual(t *testing.T) {
+	m := lscpu2map(readTestFile("lscpu_virt.txt", t))
+
+	if m["CPU(s)"] != "1" {
+		t.Errorf("Found %s CPU(s), expected 1", m["CPU(s)"])
+	}
+	if m["Socket(s)"] != "1" {
+		t.Errorf("Found %s Sockets(s), expected 1", m["Socket(s)"])
+	}
+	if hv, ok := m["Hypervisor vendor"]; !ok || hv != "KVM" {
+		t.Errorf("Hypervisor vendor should be KVM")
+	}
+}

--- a/connect/hwinfo_test.go
+++ b/connect/hwinfo_test.go
@@ -87,3 +87,19 @@ func TestPrivateIP(t *testing.T) {
 		}
 	}
 }
+
+func TestReadValues2map(t *testing.T) {
+	m := readValues2map(readTestFile("read_values_s.txt", t))
+	expect := map[string]string{
+		"VM00 CPUs Total":      "1",
+		"LPAR CPUs Total":      "6",
+		"VM00 IFLs":            "1",
+		"LPAR CPUs IFL":        "6",
+		"VM00 Control Program": "z/VM    6.1.0",
+	}
+	for k, v := range expect {
+		if m[k] != expect[k] {
+			t.Errorf("m[%s]==%s, expected %s", k, m[k], v)
+		}
+	}
+}

--- a/testdata/dmidecode_aws.txt
+++ b/testdata/dmidecode_aws.txt
@@ -1,0 +1,18 @@
+# dmidecode 3.1
+Getting SMBIOS data from sysfs.
+SMBIOS 2.7 present.
+
+Handle 0x0100, DMI type 1, 27 bytes
+System Information
+	Manufacturer: Xen
+	Product Name: HVM domU
+	Version: 4.2.amazon
+	Serial Number: ec266d00-0a79-7089-68d5-82cc396381c1
+	UUID: EC266D00-0A79-7089-68D5-82CC396381C1
+	Wake-up Type: Power Switch
+	SKU Number: Not Specified
+	Family: Not Specified
+
+Handle 0x2000, DMI type 32, 11 bytes
+System Boot Information
+	Status: No errors detected

--- a/testdata/dmidecode_aws_large.txt
+++ b/testdata/dmidecode_aws_large.txt
@@ -1,0 +1,14 @@
+# dmidecode 3.2
+Getting SMBIOS data from sysfs.
+SMBIOS 2.7 present.
+
+Handle 0x0001, DMI type 1, 27 bytes
+System Information
+	Manufacturer: Amazon EC2
+	Product Name: c5n.9xlarge
+	Version: Not Specified
+	Serial Number: ec23a21e-0460-7b8c-2643-e83f662813a7
+	UUID: ec23a21e-0460-7b8c-2643-e83f662813a7
+	Wake-up Type: Power Switch
+	SKU Number: Not Specified
+	Family: Not Specified

--- a/testdata/dmidecode_azure.txt
+++ b/testdata/dmidecode_azure.txt
@@ -1,0 +1,27 @@
+# dmidecode 3.0
+Getting SMBIOS data from sysfs.
+SMBIOS 2.3 present.
+
+Handle 0x0001, DMI type 1, 25 bytes
+System Information
+	Manufacturer: Microsoft Corporation
+	Product Name: Virtual Machine
+	Version: 7.0
+	Serial Number: 0000-0005-0960-9066-4444-7097-88
+	UUID: 75F3B846-6985-9C4B-835F-12D4A8C73BA7
+	Wake-up Type: Power Switch
+
+Handle 0x004E, DMI type 12, 5 bytes
+System Configuration Options
+	Option 1: To Be Filled By O.E.M.
+	Option 2: To Be Filled By O.E.M.
+	Option 3: To Be Filled By O.E.M.
+
+Handle 0x014F, DMI type 23, 13 bytes
+System Reset
+	Status: Disabled
+	Watchdog Timer: Not Present
+
+Handle 0x0150, DMI type 32, 20 bytes
+System Boot Information
+	Status: No errors detected

--- a/testdata/dmidecode_google.txt
+++ b/testdata/dmidecode_google.txt
@@ -1,0 +1,18 @@
+# dmidecode 3.0
+Scanning /dev/mem for entry point.
+SMBIOS 2.4 present.
+
+Handle 0x0100, DMI type 1, 27 bytes
+System Information
+	Manufacturer: Google
+	Product Name: Google Compute Engine
+	Version: Not Specified
+	Serial Number: GoogleCloud-28570BE051B627017F196DB87226F476
+	UUID: 28570BE0-51B6-2701-7F19-6DB87226F476
+	Wake-up Type: Power Switch
+	SKU Number: Not Specified
+	Family: Not Specified
+
+Handle 0x2000, DMI type 32, 11 bytes
+System Boot Information
+	Status: No errors detected

--- a/testdata/dmidecode_qemu.txt
+++ b/testdata/dmidecode_qemu.txt
@@ -1,0 +1,18 @@
+# dmidecode 3.2
+Getting SMBIOS data from sysfs.
+SMBIOS 2.8 present.
+
+Handle 0x0100, DMI type 1, 27 bytes
+System Information
+	Manufacturer: QEMU
+	Product Name: Standard PC (i440FX + PIIX, 1996)
+	Version: pc-i440fx-focal
+	Serial Number: Not Specified
+	UUID: 2bd63558-79aa-4ee2-9973-6eb37150c728
+	Wake-up Type: Power Switch
+	SKU Number: Not Specified
+	Family: Not Specified
+
+Handle 0x2000, DMI type 32, 11 bytes
+System Boot Information
+	Status: No errors detected

--- a/testdata/lscpu_phys.txt
+++ b/testdata/lscpu_phys.txt
@@ -1,0 +1,25 @@
+Architecture:          x86_64
+CPU op-mode(s):        32-bit, 64-bit
+Byte Order:            Little Endian
+CPU(s):                8
+On-line CPU(s) list:   0-7
+Thread(s) per core:    2
+Core(s) per socket:    4
+Socket(s):             1
+NUMA node(s):          1
+Vendor ID:             GenuineIntel
+CPU family:            6
+Model:                 42
+Model name:            Intel(R) Core(TM) i7-2600 CPU @ 3.40GHz
+Stepping:              7
+CPU MHz:               3366.000
+BogoMIPS:              6784.77
+Virtualization:        VT-x
+L1d cache:             32K
+L1i cache:             32K
+L2 cache:              256K
+L3 cache:              8192K
+NUMA node0 CPU(s):     0-7
+NUMA node1 CPU(s):
+
+Badly formatted attribute

--- a/testdata/lscpu_virt.txt
+++ b/testdata/lscpu_virt.txt
@@ -1,0 +1,23 @@
+Architecture:          x86_64
+CPU op-mode(s):        32-bit, 64-bit
+Byte Order:            Little Endian
+CPU(s):                1
+On-line CPU(s) list:   0
+Thread(s) per core:    1
+Core(s) per socket:    1
+Socket(s):             1
+NUMA node(s):          1
+Vendor ID:             AuthenticAMD
+CPU family:            6
+Model:                 2
+Model name:            QEMU Virtual CPU version 1.4.2
+Stepping:              3
+CPU MHz:               2094.724
+BogoMIPS:              4189.44
+Virtualization:        AMD-V
+Hypervisor vendor:     KVM
+Virtualization type:   full
+L1d cache:             64K
+L1i cache:             64K
+L2 cache:              512K
+NUMA node0 CPU(s):     0

--- a/testdata/read_values_s.txt
+++ b/testdata/read_values_s.txt
@@ -1,0 +1,13 @@
+Type: 2827
+Sequence Code: 0000000000069A27
+CPUs Total: 22
+CPUs IFL: 0
+LPAR Number: 15
+LPAR Name: LPF
+LPAR Characteristics: Shared
+LPAR CPUs Total: 6
+LPAR CPUs IFL: 6
+VM00 Name: LINUX209
+VM00 Control Program: z/VM    6.1.0
+VM00 CPUs Total: 1
+VM00 IFLs: 1


### PR DESCRIPTION
This will be used on x86_64 and arm64 to find the CPU and socket
count, and "Hypervisor vendor" on VMs. A map[string]string is
returned. The callers can lookup relevant keys and convert the
value to another type as needed.