### PR TITLE
Add helper function for tests to read files from testdata

### DIFF
--- a/connect/api_test.go
+++ b/connect/api_test.go
@@ -4,18 +4,14 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"testing"
 )
 
 func TestGetActivations(t *testing.T) {
+	response := readTestFile("activations.json", t)
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		f, err := os.Open("../testdata/activations.json")
-		if err != nil {
-			t.Fatal(err)
-		}
-		io.Copy(w, f)
+		w.Write(response)
 	}))
 	defer ts.Close()
 

--- a/connect/helpers_test.go
+++ b/connect/helpers_test.go
@@ -1,0 +1,17 @@
+package connect
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func readTestFile(name string, t *testing.T) []byte {
+	data, err := os.ReadFile(filepath.Join("../testdata", name))
+	if err != nil {
+		_, filename, num, _ := runtime.Caller(1)
+		t.Fatalf("\n%s:%d: %s", filepath.Base(filename), num, err)
+	}
+	return data
+}


### PR DESCRIPTION
Many tests read files from ../testdata. This patch moves the
repeatitive error checking and calls to t.Fatal() out to a
helper function. It can be called from any *_test.go, and that
filename and line number will be printed if there is an error.

For example: if activations.json got deleted:

--- FAIL: TestGetActivations (0.00s)
    helpers_test.go:14:
        api_test.go:11: open ../testdata/activations.json: no such file or directory