### PR TITLE
Add Service struct and UpgradeProduct API

### DIFF
--- a/connect/activation.go
+++ b/connect/activation.go
@@ -11,20 +11,12 @@ type Activation struct {
 	Type      string    `json:"type"`
 	StartsAt  time.Time `json:"starts_at"`
 	ExpiresAt time.Time `json:"expires_at"`
-	Service   struct {
-		Product struct {
-			Name       string `json:"name"`
-			Version    string `json:"version"`
-			Arch       string `json:"arch"`
-			Identifier string `json:"identifier"`
-			Free       bool   `json:"free"`
-		} `json:"product"`
-	} `json:"service"`
+	Service   Service   `json:"service"`
 }
 
 func (a Activation) toTriplet() string {
 	p := a.Service.Product
-	return p.Identifier + "/" + p.Version + "/" + p.Arch
+	return p.Name + "/" + p.Version + "/" + p.Arch
 }
 
 func (a Activation) isFree() bool {

--- a/connect/api.go
+++ b/connect/api.go
@@ -52,8 +52,21 @@ func GetProduct(productQuery Product) (Product, error) {
 		return remoteProduct, err
 	}
 	err = json.Unmarshal(resp, &remoteProduct)
+	return remoteProduct, err
+}
+
+func upgradeProduct(product Product) (Service, error) {
+	// NOTE: this can add some extra attributes to json payload which
+	//       seem to be safely ignored by the API.
+	payload, err := json.Marshal(product)
+	remoteService := Service{}
 	if err != nil {
-		return remoteProduct, err
+		return remoteService, err
 	}
-	return remoteProduct, nil
+	resp, err := callHTTP("PUT", "/connect/systems/products", payload, nil, authSystem)
+	if err != nil {
+		return remoteService, err
+	}
+	err = json.Unmarshal(resp, &remoteService)
+	return remoteService, err
 }

--- a/connect/product.go
+++ b/connect/product.go
@@ -9,14 +9,14 @@ type Product struct {
 	Name    string `xml:"name,attr" json:"identifier"`
 	Version string `xml:"version,attr" json:"version"`
 	Arch    string `xml:"arch,attr" json:"arch"`
-	Summary string `xml:"summary,attr"`
-	IsBase  bool   `xml:"isbase,attr"`
+	Summary string `xml:"summary,attr" json:"-"`
+	IsBase  bool   `xml:"isbase,attr" json:"-"`
 
-	FriendlyName string `json:"friendly_name"`
+	FriendlyName string `json:"friendly_name,omitempty"`
 	Available    bool   `json:"available"`
 	Free         bool   `json:"free"`
 	// optional extension products
-	Extensions []Product `json:"extensions"`
+	Extensions []Product `json:"extensions,omitempty"`
 }
 
 func (p Product) toTriplet() string {

--- a/connect/service.go
+++ b/connect/service.go
@@ -1,0 +1,10 @@
+package connect
+
+// Service represents an installed service or service information from API
+type Service struct {
+	ID            int     `json:"id"`
+	URL           string  `json:"url"`
+	Name          string  `json:"name"`
+	Product       Product `json:"product"`
+	ObsoletedName string  `json:"obsoleted_service_name"`
+}

--- a/testdata/service.json
+++ b/testdata/service.json
@@ -1,0 +1,83 @@
+{
+    "id": 2187,
+    "name": "SUSE_Linux_Enterprise_Micro_5.0_x86_64",
+    "url": "https://scc.suse.com/access/services/2187?credentials=SUSE_Linux_Enterprise_Micro_5.0_x86_64",
+    "obsoleted_service_name": "",
+    "product": {
+        "id": 2202,
+        "name": "SUSE Linux Enterprise Micro",
+        "identifier": "SUSE-MicroOS",
+        "former_identifier": "SUSE-MicroOS",
+        "version": "5.0",
+        "release_type": null,
+        "arch": "x86_64",
+        "friendly_name": "SUSE Linux Enterprise Micro 5.0 x86_64",
+        "friendly_version": "5.0",
+        "product_class": "MICROOS-X86",
+        "cpe": "cpe:/o:suse:suse-microos:5.0",
+        "free": false,
+        "description": "SUSE Linux Enterprise Micro 5.0",
+        "release_stage": "released",
+        "eula_url": "",
+        "repositories": [
+            {
+                "id": 4936,
+                "url": "https://updates.suse.com/SUSE/Updates/SUSE-MicroOS/5.0/x86_64/update/",
+                "name": "SUSE-MicroOS-5.0-Updates",
+                "distro_target": "sle-15-x86_64",
+                "description": "SUSE-MicroOS-5.0-Updates for sle-15-x86_64",
+                "enabled": true,
+                "autorefresh": true,
+                "installer_updates": false
+            },
+            {
+                "id": 4937,
+                "url": "https://updates.suse.com/SUSE/Updates/SUSE-MicroOS/5.0/x86_64/update_debug/",
+                "name": "SUSE-MicroOS-5.0-Debuginfo-Updates",
+                "distro_target": "sle-15-x86_64",
+                "description": "SUSE-MicroOS-5.0-Debuginfo-Updates for sle-15-x86_64",
+                "enabled": false,
+                "autorefresh": true,
+                "installer_updates": false
+            },
+            {
+                "id": 4938,
+                "url": "https://updates.suse.com/SUSE/Products/SUSE-MicroOS/5.0/x86_64/product/",
+                "name": "SUSE-MicroOS-5.0-Pool",
+                "distro_target": "sle-15-x86_64",
+                "description": "SUSE-MicroOS-5.0-Pool for sle-15-x86_64",
+                "enabled": true,
+                "autorefresh": false,
+                "installer_updates": false
+            },
+            {
+                "id": 4939,
+                "url": "https://updates.suse.com/SUSE/Products/SUSE-MicroOS/5.0/x86_64/product_debug/",
+                "name": "SUSE-MicroOS-5.0-Debuginfo-Pool",
+                "distro_target": "sle-15-x86_64",
+                "description": "SUSE-MicroOS-5.0-Debuginfo-Pool for sle-15-x86_64",
+                "enabled": false,
+                "autorefresh": false,
+                "installer_updates": false
+            },
+            {
+                "id": 4940,
+                "url": "https://updates.suse.com/SUSE/Products/SUSE-MicroOS/5.0/x86_64/product_source/",
+                "name": "SUSE-MicroOS-5.0-Source-Pool",
+                "distro_target": "sle-15-x86_64",
+                "description": "SUSE-MicroOS-5.0-Source-Pool for sle-15-x86_64",
+                "enabled": false,
+                "autorefresh": false,
+                "installer_updates": false
+            }
+        ],
+        "product_type": "base",
+        "predecessor_ids": [],
+        "online_predecessor_ids": [],
+        "offline_predecessor_ids": [],
+        "shortname": "SUSE Linux Enterprise Micro",
+        "recommended": false,
+        "migration_extra": false,
+        "extensions": null
+    }
+}


### PR DESCRIPTION
Service will hold the service description as returned by the API.
It also replaced local struct in Activation.

Product struct was modified to be used as PUT payload for added upgrade
API call.