### PR TITLE
Unexport api functions

### DIFF
--- a/connect/api.go
+++ b/connect/api.go
@@ -10,9 +10,7 @@ const (
 	APIVersion = "v4"
 )
 
-// UpToDate Checks if API endpoint is up-to-date,
-// useful when dealing with RegistrationProxy errors
-func UpToDate() bool {
+func upToDate() bool {
 	// REVIST 404 case - see original
 	// Should fail in any case. 422 error means that the endpoint is there and working right
 	_, err := callHTTP("GET", "/connect/repositories/installer", nil, nil, authNone)
@@ -27,8 +25,8 @@ func UpToDate() bool {
 	return false
 }
 
-// GetActivations returns a map keyed by "Identifier/Version/Arch"
-func GetActivations() (map[string]Activation, error) {
+// systemActivations returns a map keyed by "Identifier/Version/Arch"
+func systemActivations() (map[string]Activation, error) {
 	activeMap := make(map[string]Activation)
 	resp, err := callHTTP("GET", "/connect/systems/activations", nil, nil, authSystem)
 	if err != nil {
@@ -45,7 +43,7 @@ func GetActivations() (map[string]Activation, error) {
 	return activeMap, nil
 }
 
-func GetProduct(productQuery Product) (Product, error) {
+func showProduct(productQuery Product) (Product, error) {
 	resp, err := callHTTP("GET", "/connect/systems/products", nil, productQuery.toQuery(), authSystem)
 	remoteProduct := Product{}
 	if err != nil {

--- a/connect/api_test.go
+++ b/connect/api_test.go
@@ -18,7 +18,7 @@ func TestGetActivations(t *testing.T) {
 	defer ts.Close()
 
 	CFG.BaseURL = ts.URL
-	activations, err := GetActivations()
+	activations, err := systemActivations()
 	if err != nil {
 		t.Errorf("%s", err)
 	}
@@ -48,7 +48,7 @@ func TestGetActivationsRequest(t *testing.T) {
 	defer ts.Close()
 
 	CFG.BaseURL = ts.URL
-	if _, err := GetActivations(); err != nil {
+	if _, err := systemActivations(); err != nil {
 		t.Fatalf("Unexpected error [%s]", err)
 	}
 
@@ -68,7 +68,7 @@ func TestGetActivationsError(t *testing.T) {
 	defer ts.Close()
 
 	CFG.BaseURL = ts.URL
-	if _, err := GetActivations(); err == nil {
+	if _, err := systemActivations(); err == nil {
 		t.Error("Expecting error. Got none.")
 	}
 }
@@ -95,7 +95,7 @@ func TestGetProduct(t *testing.T) {
 
 	CFG.BaseURL = ts.URL
 	productQuery := Product{Name: "SLES", Version: "15.2", Arch: "x86_64"}
-	product, err := GetProduct(productQuery)
+	product, err := showProduct(productQuery)
 	if err != nil {
 		t.Fatalf("%s", err)
 	}
@@ -118,7 +118,7 @@ func TestGetProductError(t *testing.T) {
 
 	CFG.BaseURL = ts.URL
 	productQuery := Product{Name: "Dummy"}
-	_, err := GetProduct(productQuery)
+	_, err := showProduct(productQuery)
 	if ae, ok := err.(APIError); ok {
 		if ae.Code != http.StatusUnprocessableEntity {
 			t.Fatalf("Expecting APIError(422). Got %s", err)

--- a/connect/client.go
+++ b/connect/client.go
@@ -20,6 +20,12 @@ func IsRegistered() bool {
 	return err == nil
 }
 
+// UpToDate Checks if API endpoint is up-to-date,
+// useful when dealing with RegistrationProxy errors
+func UpToDate() bool {
+	return upToDate()
+}
+
 // URLDefault returns true if using https://scc.suse.com
 func URLDefault() bool {
 	return CFG.BaseURL == defaultBaseURL

--- a/connect/extensions.go
+++ b/connect/extensions.go
@@ -32,7 +32,7 @@ func GetExtensionsList() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	activations, err := GetActivations()
+	activations, err := systemActivations()
 	if err != nil {
 		return "", err
 	}
@@ -86,7 +86,7 @@ func getExtensions() ([]Product, error) {
 		return []Product{}, ErrListExtensionsUnregistered
 	}
 
-	remoteProductData, err := GetProduct(base)
+	remoteProductData, err := showProduct(base)
 	if err != nil {
 		return []Product{}, err
 	}

--- a/connect/status.go
+++ b/connect/status.go
@@ -60,7 +60,7 @@ func getStatuses() (map[string]Status, error) {
 
 	activations := make(map[string]Activation) // default empty map
 	if IsRegistered() {
-		activations, err = GetActivations()
+		activations, err = systemActivations()
 		if err != nil {
 			return statuses, err
 		}


### PR DESCRIPTION
Functions from api.go should not be called directly from outside.
All exported API access functions should go via client.go.