### PR TITLE
Add announceSystem() api call

### DIFF
--- a/connect/api.go
+++ b/connect/api.go
@@ -10,6 +10,24 @@ const (
 	APIVersion = "v4"
 )
 
+// announceSystem announces a system to SCC
+// https://scc.suse.com/connect/v4/documentation#/subscriptions/post_subscriptions_systems
+// The body parameter is produced by makeSysInfoBody()
+func announceSystem(body []byte) (string, string, error) {
+	resp, err := callHTTP("POST", "/connect/subscriptions/systems", body, nil, authToken)
+	if err != nil {
+		return "", "", err
+	}
+	var creds struct {
+		Login     string `json:"login"`
+		Passoword string `json:"password"`
+	}
+	if err = json.Unmarshal(resp, &creds); err != nil {
+		return "", "", err
+	}
+	return creds.Login, creds.Passoword, nil
+}
+
 func upToDate() bool {
 	// REVIST 404 case - see original
 	// Should fail in any case. 422 error means that the endpoint is there and working right

--- a/connect/api_test.go
+++ b/connect/api_test.go
@@ -7,6 +7,26 @@ import (
 	"testing"
 )
 
+func TestAnnounceSystem(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		io.WriteString(w, `{"login":"test-user","password":"test-password"}`)
+	}))
+	defer ts.Close()
+
+	CFG.BaseURL = ts.URL
+	user, password, err := announceSystem(nil)
+	if err != nil {
+		t.Fatalf("Unexpected error: %s", err)
+	}
+	if user != "test-user" {
+		t.Errorf("Expected user: \"test-user\", got: \"%s\"", user)
+	}
+	if password != "test-password" {
+		t.Errorf("Expected password: \"test-password\", got: \"%s\"", password)
+	}
+}
+
 func TestGetActivations(t *testing.T) {
 	response := readTestFile("activations.json", t)
 	createTestCredentials("", "", t)


### PR DESCRIPTION
The payload gets passed as a parameter, unlike the Ruby version.