### PR TITLE
Add Product.IsEmpty()

### DIFF
--- a/connect/product.go
+++ b/connect/product.go
@@ -19,6 +19,10 @@ type Product struct {
 	Extensions []Product `json:"extensions,omitempty"`
 }
 
+func (p Product) isEmpty() bool {
+	return p.Name == "" || p.Version == "" || p.Arch == ""
+}
+
 func (p Product) toTriplet() string {
 	return p.Name + "/" + p.Version + "/" + p.Arch
 }

--- a/connect/product_test.go
+++ b/connect/product_test.go
@@ -12,3 +12,20 @@ func TestDistroTarget(t *testing.T) {
 		t.Errorf("got: %s, expected: %s", got, expect)
 	}
 }
+
+func TestEmptyProduct(t *testing.T) {
+	p1 := Product{}
+	if !p1.isEmpty() {
+		t.Errorf("expected %v to be empty", p1)
+	}
+
+	p2 := Product{Name: "Dummy"}
+	if !p2.isEmpty() {
+		t.Errorf("expected %v to be empty", p2)
+	}
+
+	p3 := Product{Name: "sle-module-basesystem", Version: "15.2", Arch: "x86_64"}
+	if p3.isEmpty() {
+		t.Errorf("expected %v not to be empty", p3)
+	}
+}


### PR DESCRIPTION
In original ruby code it was just 'if product', in golang we need to
make this test more explicit.