### PR TITLE
Add deactivateProduct() API call

### DIFF
--- a/DIFFERENCES.md
+++ b/DIFFERENCES.md
@@ -1,3 +1,9 @@
 # Functional differences between Go and Ruby implementations of SUSEConnect:
 
 - empty `namespace` config/argument is treated the same as no namespace
+- null string values received from API are silently converted to empty strings
+  when data is received. when the same data is sent back to API, fields with
+  "omitempty" tag will not be included in JSON (example: Product.release_type).
+- API calls which pass JSON body as "query" (e.g. upgradeProduct() or
+  deactivateProduct()) can include unexpected attributes (mostly bools) which
+  don't support "omitempty" tag. API seems to ignore these correctly.

--- a/connect/api.go
+++ b/connect/api.go
@@ -68,3 +68,19 @@ func upgradeProduct(product Product) (Service, error) {
 	err = json.Unmarshal(resp, &remoteService)
 	return remoteService, err
 }
+
+func deactivateProduct(product Product) (Service, error) {
+	// NOTE: this can add some extra attributes to json payload which
+	//       seem to be safely ignored by the API.
+	payload, err := json.Marshal(product)
+	remoteService := Service{}
+	if err != nil {
+		return remoteService, err
+	}
+	resp, err := callHTTP("DELETE", "/connect/systems/products", payload, nil, authSystem)
+	if err != nil {
+		return remoteService, err
+	}
+	err = json.Unmarshal(resp, &remoteService)
+	return remoteService, err
+}

--- a/connect/product.go
+++ b/connect/product.go
@@ -13,6 +13,7 @@ type Product struct {
 	IsBase  bool   `xml:"isbase,attr" json:"-"`
 
 	FriendlyName string `json:"friendly_name,omitempty"`
+	ReleaseType  string `json:"release_type,omitempty"`
 	Available    bool   `json:"available"`
 	Free         bool   `json:"free"`
 	// optional extension products

--- a/testdata/service_inactive.json
+++ b/testdata/service_inactive.json
@@ -1,0 +1,93 @@
+{
+    "id": 1931,
+    "name": "Basesystem_Module_15_SP2_x86_64",
+    "url": "https://scc.suse.com/access/services/1931?credentials=Basesystem_Module_15_SP2_x86_64",
+    "obsoleted_service_name": "",
+    "product": {
+        "id": 1946,
+        "name": "Basesystem Module",
+        "identifier": "sle-module-basesystem",
+        "former_identifier": "sle-module-basesystem",
+        "version": "15.2",
+        "release_type": null,
+        "arch": "x86_64",
+        "friendly_name": "Basesystem Module 15 SP2 x86_64",
+        "friendly_version": "15 SP2",
+        "product_class": "MODULE",
+        "cpe": "cpe:/o:suse:sle-module-basesystem:15:sp2",
+        "free": true,
+        "description": "\\u003cp\\u003e The SUSE Linux Enterprise Basesystem Module delivers the base system of the product. \\u003c/p\\u003e",
+        "release_stage": "released",
+        "eula_url": "",
+        "repositories": [
+            {
+                "id": 3999,
+                "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Basesystem/15-SP2/x86_64/update/",
+                "name": "SLE-Module-Basesystem15-SP2-Updates",
+                "distro_target": "sle-15-x86_64",
+                "description": "SLE-Module-Basesystem15-SP2-Updates for sle-15-x86_64",
+                "enabled": true,
+                "autorefresh": true,
+                "installer_updates": false
+            },
+            {
+                "id": 4000,
+                "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Basesystem/15-SP2/x86_64/update_debug/",
+                "name": "SLE-Module-Basesystem15-SP2-Debuginfo-Updates",
+                "distro_target": "sle-15-x86_64",
+                "description": "SLE-Module-Basesystem15-SP2-Debuginfo-Updates for sle-15-x86_64",
+                "enabled": false,
+                "autorefresh": true,
+                "installer_updates": false
+            },
+            {
+                "id": 4001,
+                "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Basesystem/15-SP2/x86_64/product/",
+                "name": "SLE-Module-Basesystem15-SP2-Pool",
+                "distro_target": "sle-15-x86_64",
+                "description": "SLE-Module-Basesystem15-SP2-Pool for sle-15-x86_64",
+                "enabled": true,
+                "autorefresh": false,
+                "installer_updates": false
+            },
+            {
+                "id": 4002,
+                "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Basesystem/15-SP2/x86_64/product_debug/",
+                "name": "SLE-Module-Basesystem15-SP2-Debuginfo-Pool",
+                "distro_target": "sle-15-x86_64",
+                "description": "SLE-Module-Basesystem15-SP2-Debuginfo-Pool for sle-15-x86_64",
+                "enabled": false,
+                "autorefresh": false,
+                "installer_updates": false
+            },
+            {
+                "id": 4003,
+                "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Basesystem/15-SP2/x86_64/product_source/",
+                "name": "SLE-Module-Basesystem15-SP2-Source-Pool",
+                "distro_target": "sle-15-x86_64",
+                "description": "SLE-Module-Basesystem15-SP2-Source-Pool for sle-15-x86_64",
+                "enabled": false,
+                "autorefresh": false,
+                "installer_updates": false
+            }
+        ],
+        "product_type": "module",
+        "predecessor_ids": [
+            1576,
+            1772
+        ],
+        "online_predecessor_ids": [
+            1576,
+            1772
+        ],
+        "offline_predecessor_ids": [
+            1212,
+            1368,
+            1440
+        ],
+        "shortname": "Basesystem-Module",
+        "recommended": false,
+        "migration_extra": false,
+        "extensions": null
+    }
+}

--- a/testdata/service_inactive_smt.json
+++ b/testdata/service_inactive_smt.json
@@ -1,0 +1,7 @@
+{
+    "obsoleted_service_name": "SMT_DUMMY_NOREMOVE_SERVICE",
+    "id": 1,
+    "product": {},
+    "name": "SMT_DUMMY_NOREMOVE_SERVICE",
+    "url": "http://SMT_DUMMY_NOREMOVE_SERVICE"
+}


### PR DESCRIPTION
This is used in both registration and deregistration.
Additional Product field was added to match original implementation.

Some behavior differences wrt original implementation were noted in
DIFFERENCES.md