### PR TITLE
Make requirement for go 1.16 explicit.

### DIFF
--- a/suseconnect-ng.spec
+++ b/suseconnect-ng.spec
@@ -28,6 +28,7 @@ Group:          System/Management
 Source:         connect-ng-%{version}.tar.xz
 Source1:        %name-rpmlintrc
 BuildRequires:  golang-packaging
+BuildRequires:  go >= 1.16
 
 %description
 This package provides a command line tool for connecting a
@@ -45,7 +46,7 @@ product subscriptions and enable the product repositories/services locally.
 find %_builddir/..
 %goprep %{import_path}
 find %_builddir/..
-go list -m all
+go list all
 %gobuild cmd
 go build -buildmode=c-shared -o %_builddir/go/src/github.com/SUSE/connect-ng/ext/libsuseconnect.so ext/main.go
 find %_builddir/..


### PR DESCRIPTION
Make requirement for go 1.16 explicit.

This requirement is due to requiring the module embed.

The result is that it will only build on SLE_15_SP1, SLE_15_SP3
openSUSE_Factory, openSUSE_Leap_15.3, and openSUSE_Tumbleweed. This
removes the possibility to build on SLE_15 (SP0), and SLE_15_SP2 and
anything before SLE_15, and before openSUSE_Leap_15.3.

Also run go list all during the build without -m to be compatible with
earlier go versions to aid debugging and to also list all packages
instead of only modules.