### PR TITLE
obs: use an in between branch

### DIFF
--- a/.obs/workflows.yml
+++ b/.obs/workflows.yml
@@ -1,5 +1,5 @@
 workflow:
   steps:
     - branch_package:
-        source_project: systemsmanagement:SCC
+        source_project: home:jzerebecki:CI:suseconnect-ng
         source_package: suseconnect-ng


### PR DESCRIPTION
This branch as many repositories removed instead of only disabled to
make them not be reenabled on branches building PRs.

It also has the _service entries changed from manual to serveronly,
otherwise they won't be rerun by OBS.