### PR TITLE
Add proxy auth support

### DIFF
--- a/DIFFERENCES.md
+++ b/DIFFERENCES.md
@@ -7,3 +7,6 @@
 - API calls which pass JSON body as "query" (e.g. upgradeProduct() or
   deactivateProduct()) can include unexpected attributes (mostly bools) which
   don't support "omitempty" tag. API seems to ignore these correctly.
+- When proxy credentials are incorrect, go version returns different error
+  message than the original ruby one. Both are misleading and don't indicate
+  any proxy related problems.

--- a/connect/credentials_test.go
+++ b/connect/credentials_test.go
@@ -75,3 +75,24 @@ func TestWriteReadDeleteService(t *testing.T) {
 		t.Error("File was not deleted: ", path)
 	}
 }
+
+func TestParseCurlrcCredentials(t *testing.T) {
+	var tests = []struct {
+		input       string
+		expectCreds Credentials
+		expectErr   error
+	}{
+		{"--proxy-user \"meuser1$:mepassord2%\"", Credentials{"", "meuser1$", "mepassord2%"}, nil},
+		{"--proxy-user = \"meuser1$:mepassord2%\"", Credentials{"", "meuser1$", "mepassord2%"}, nil},
+		{"proxy-user = \"meuser1$:mepassord2%\"", Credentials{"", "meuser1$", "mepassord2%"}, nil},
+		{"proxy-user=\"meuser1$:mepassord2%\"", Credentials{"", "meuser1$", "mepassord2%"}, nil},
+		{"", Credentials{}, ErrNoProxyCredentials},
+	}
+
+	for _, test := range tests {
+		got, err := parseCurlrcCredentials(strings.NewReader(test.input))
+		if err != test.expectErr || got != test.expectCreds {
+			t.Errorf("parseCurlrcCredentials() == %+v, %s, expected %+v, %s, input: %s", got, err, test.expectCreds, test.expectErr, test.input)
+		}
+	}
+}

--- a/connect/errors.go
+++ b/connect/errors.go
@@ -12,6 +12,7 @@ var (
 	ErrBaseProductDeactivation    = errors.New("Unable to deactivate base product")
 	ErrCannotDetectBaseProduct    = errors.New("Unable to detect base product")
 	ErrListExtensionsUnregistered = errors.New("System not registered")
+	ErrNoProxyCredentials         = errors.New("Unable to read proxy credentials")
 )
 
 // ExecuteError is returned from execute() on error


### PR DESCRIPTION
If proxy configuration is found in the environment it will be used.
If env variables contain credentials they will be used unless .curlrc
overrides them.