### PR TITLE
Fix callHTTP() so connections are reused

### DIFF
--- a/DIFFERENCES.md
+++ b/DIFFERENCES.md
@@ -16,3 +16,4 @@
   when response is non-JSON and has non-success HTTP return code.
   Go version will handle this as "API error" while ruby version will fail to
   parse the response and handle this as "JSON error".
+- The Go HTTP client tries to reuse connections with keep-alive.

--- a/connect/connection_test.go
+++ b/connect/connection_test.go
@@ -19,6 +19,7 @@ func TestCallHTTPSecure(t *testing.T) {
 		t.Error("Expecting certificate error. Got none.")
 	}
 
+	httpclient = nil // force new http client+transport creation
 	CFG.Insecure = true
 	_, err = callHTTP("GET", "/", nil, nil, authNone)
 	if err != nil {


### PR DESCRIPTION
For connection reuse, the http.Client needs to be created
once and reused on subsequent requests. This is recommended
in "go doc http client".