### PR TITLE
Fix error from zypper refresh

### DIFF
--- a/connect/credentials.go
+++ b/connect/credentials.go
@@ -99,8 +99,7 @@ func (c Credentials) write() error {
 		}
 	}
 	buf := bytes.Buffer{}
-	fmt.Fprintln(&buf, "username=", c.Username)
-	fmt.Fprintln(&buf, "password=", c.Password)
+	fmt.Fprintf(&buf, "username=%s\npassword=%s\n", c.Username, c.Password)
 	return os.WriteFile(c.Filename, buf.Bytes(), 0600)
 }
 

--- a/connect/credentials_test.go
+++ b/connect/credentials_test.go
@@ -1,6 +1,7 @@
 package connect
 
 import (
+	"os"
 	"strings"
 	"testing"
 )
@@ -49,6 +50,19 @@ func TestWriteReadDeleteSystem(t *testing.T) {
 	path := systemCredentialsFile()
 	if fileExists(path) {
 		t.Error("File was not deleted: ", path)
+	}
+}
+
+func TestWriteCredentials(t *testing.T) {
+	CFG.FsRoot = t.TempDir()
+	if err := writeSystemCredentials("user1", "pass1"); err != nil {
+		t.Fatalf("Unexpected error: %s", err)
+	}
+	expected := "username=user1\npassword=pass1\n"
+	contents, _ := os.ReadFile(systemCredentialsFile())
+	got := string(contents)
+	if got != expected {
+		t.Errorf("Expected %#v, got %#v", expected, got)
 	}
 }
 


### PR DESCRIPTION
The credentials file has an extra space due to fmt.Println adding
a space between arguments. When there are existing files in
/etc/zypp/credentials.d/ from the Ruby version, zypper raises a
"Not all credentials files are eqivalent" error.