### PR TITLE
Fix list-extensions format

### DIFF
--- a/connect/extensions-list.tmpl
+++ b/connect/extensions-list.tmpl
@@ -6,10 +6,9 @@
 {{ else }}{{ .Indent }}Activate with: {{ .ConnectBinary }} -p {{ .Code }}{{ if not .Product.Free }} -r {{"\x1b[32m\x1b[1mADDITIONAL REGCODE\x1b[0m"}}{{ end }}{{ end }}
 {{ range .Subextensions }}{{ template "extension" . }}{{ end -}}
 {{ end -}}
-{{ "\x1b[1m"}}AVAILABLE EXTENSIONS AND MODULES{{"\x1b[0m" -}}
-{{ range . }}
-{{ template "extension" . }}
-{{ end }}
+{{ "\x1b[1m"}}AVAILABLE EXTENSIONS AND MODULES{{"\x1b[0m" }}
+{{ range . }}{{ template "extension" . }}{{ end }}
+
 {{ "\x1b[1m"}}REMARKS{{"\x1b[0m"}}
 
 {{"\x1b[31m"}}(Not available){{"\x1b[0m"}} The module/extension is {{"\x1b[1m"}}not{{"\x1b[0m"}} enabled on your RMT/SMT


### PR DESCRIPTION
If there were more than one top-level extension, there were some
unwanted empty lines added. After this change the output should look
exactly like in ruby version.