### PR TITLE
Add status value constants

### DIFF
--- a/connect/extensions.go
+++ b/connect/extensions.go
@@ -81,8 +81,7 @@ func getExtensions() ([]Product, error) {
 		return []Product{}, err
 	}
 
-	// TODO: maybe make status constants?
-	if statuses[base.toTriplet()].Status != "Registered" {
+	if statuses[base.toTriplet()].Status != registered {
 		return []Product{}, ErrListExtensionsUnregistered
 	}
 

--- a/connect/status.go
+++ b/connect/status.go
@@ -7,6 +7,11 @@ import (
 	"text/template"
 )
 
+const (
+	registered    = "Registered"
+	notRegistered = "Not Registered"
+)
+
 var (
 	//go:embed status-text.tmpl
 	statusTemplate string
@@ -72,10 +77,10 @@ func getStatuses() (map[string]Status, error) {
 			Identifier: product.Name,
 			Version:    product.Version,
 			Arch:       product.Arch,
-			Status:     "Not Registered",
+			Status:     notRegistered,
 		}
 		if activation, ok := activations[product.toTriplet()]; ok {
-			status.Status = "Registered"
+			status.Status = registered
 			if !activation.isFree() {
 				status.RegCode = activation.RegCode
 				layout := "2006-01-02 15:04:05 MST"


### PR DESCRIPTION
With constants instead of string literals it's easier to avoid typos.