### PR TITLE
Simplify list-extensions template

### DIFF
--- a/internal/connect/extensions-list.tmpl
+++ b/internal/connect/extensions-list.tmpl
@@ -1,13 +1,11 @@
-{{ define "extension" }}
+{{ "\x1b[1m"}}AVAILABLE EXTENSIONS AND MODULES{{"\x1b[0m" }}
+{{ range . }}
 {{ .Indent }}{{ "\x1b[1m"}}{{ .Product.FriendlyName }}{{"\x1b[0m" -}}
 {{ if not .Product.Available }}{{ " \x1b[31m(Not available)\x1b[0m" }}{{ end -}}
 {{ if .Activated }}{{ " \x1b[33m(Activated)\x1b[0m" }}{{ end }}
 {{ if .Activated }}{{ .Indent }}Deactivate with: {{ .ConnectCmd }} {{"\x1b[31m-d\x1b[0m"}} -p {{ .Code -}}
 {{ else }}{{ .Indent }}Activate with: {{ .ConnectCmd }} -p {{ .Code }}{{ if not .Product.Free }} -r {{"\x1b[32m\x1b[1mADDITIONAL REGCODE\x1b[0m"}}{{ end }}{{ end }}
-{{ range .Subextensions }}{{ template "extension" . }}{{ end -}}
-{{ end -}}
-{{ "\x1b[1m"}}AVAILABLE EXTENSIONS AND MODULES{{"\x1b[0m" }}
-{{ range . }}{{ template "extension" . }}{{ end }}
+{{ end }}
 
 {{ "\x1b[1m"}}REMARKS{{"\x1b[0m"}}
 


### PR DESCRIPTION
The template was nested to mimic the original template used to print
tree structure of extensions. As go templates are more limited than
ruby's erb, some pre-formatting done in the go code.
With that in place, there's no point in having the template recursive
since all of the indentations are generated in go.
After this commit, pre-formatting returns flat list of extensions
prepared for printing and only some basic formatting is added in the
template. This makes the template easier to understand and more robust.