### PR TITLE
Try to use localized error from server response

### DIFF
--- a/internal/connect/connection.go
+++ b/internal/connect/connection.go
@@ -27,6 +27,9 @@ func parseError(body io.Reader) string {
 	var m map[string]interface{}
 	dec := json.NewDecoder(body)
 	if err := dec.Decode(&m); err == nil {
+		if errMsg, ok := m["localized_error"].(string); ok {
+			return errMsg
+		}
 		if errMsg, ok := m["error"].(string); ok {
 			return errMsg
 		}

--- a/internal/connect/connection_test.go
+++ b/internal/connect/connection_test.go
@@ -37,6 +37,17 @@ func TestParseError(t *testing.T) {
 	}
 }
 
+func TestParseErrorLocalized(t *testing.T) {
+	s := `{"type":"error","error":"No subscription with this Registration Code found",
+		  "localized_error":"Keine Subscription mit diesem Registrierungscode gefunden"}`
+	body := strings.NewReader(s)
+	expected := "Keine Subscription mit diesem Registrierungscode gefunden"
+	got := parseError(body)
+	if got != expected {
+		t.Errorf("parseError(), got: %s, expected: %s", got, expected)
+	}
+}
+
 func TestParseErrorNotJson(t *testing.T) {
 	body := strings.NewReader("not json")
 	got := parseError(body)


### PR DESCRIPTION
When the server sends an error response, use the "localized_error"
if provided, otherwise use the "error" key.