### PR TITLE
Fix list-extensions printing "Not available" when using SCC

### DIFF
--- a/internal/connect/extensions.go
+++ b/internal/connect/extensions.go
@@ -67,6 +67,9 @@ func preformatExtensions(extensions []Product, activations map[string]Activation
 
 	var ret []displayExtension
 	for _, e := range sorted {
+		if URLDefault() {
+			e.Available = true // Only SMT/RMT return this field
+		}
 		_, activated := activations[e.toTriplet()]
 		ret = append(ret, displayExtension{
 			Product:    e,

--- a/internal/connect/extensions_test.go
+++ b/internal/connect/extensions_test.go
@@ -53,4 +53,12 @@ func TestPrintExtensions(t *testing.T) {
 	if found, _ := regexp.MatchString(cmd, output2); found {
 		t.Errorf("Unexpected '%s' found in output", cmd)
 	}
+
+	// test "(Not available)" is not printed when using SCC
+	CFG.BaseURL = defaultBaseURL
+	output3, _ := printExtensions(extensions, activations, true)
+	pattern := `(?m)^.*SUSE Manager Retail Branch Server 3.2 x86_64.*(Not available).*$`
+	if found, _ := regexp.MatchString(pattern, output3); found {
+		t.Errorf("Pattern: '%s' should not be found in output", pattern)
+	}
 }


### PR DESCRIPTION
Only SMT/RMT servers return the Available field in their responses.
SCC does not, so and the zero-value false was used. Fix this by
checking if SCC is being used and if so set Available to true.