### PR TITLE
Use custom UnmarshalJSON() for the Product struct

### DIFF
--- a/internal/connect/client.go
+++ b/internal/connect/client.go
@@ -66,8 +66,7 @@ func registerProduct(product Product, installReleasePkg bool) error {
 // tree and registers the recommended and available products
 func registerProductTree(product Product) error {
 	for _, extension := range product.Extensions {
-		// SCC does not return the Available attribute, only SMT & RMT do.
-		if extension.Recommended && (URLDefault() || extension.Available) {
+		if extension.Recommended && extension.Available {
 			if err := registerProduct(extension, true); err != nil {
 				return err
 			}

--- a/internal/connect/extensions.go
+++ b/internal/connect/extensions.go
@@ -67,9 +67,6 @@ func preformatExtensions(extensions []Product, activations map[string]Activation
 
 	var ret []displayExtension
 	for _, e := range sorted {
-		if URLDefault() {
-			e.Available = true // Only SMT/RMT return this field
-		}
 		_, activated := activations[e.toTriplet()]
 		ret = append(ret, displayExtension{
 			Product:    e,

--- a/internal/connect/extensions_test.go
+++ b/internal/connect/extensions_test.go
@@ -53,12 +53,17 @@ func TestPrintExtensions(t *testing.T) {
 	if found, _ := regexp.MatchString(cmd, output2); found {
 		t.Errorf("Unexpected '%s' found in output", cmd)
 	}
+}
 
-	// test "(Not available)" is not printed when using SCC
-	CFG.BaseURL = defaultBaseURL
-	output3, _ := printExtensions(extensions, activations, true)
+func TestPrintExtensionsSCC(t *testing.T) {
+	extensions := make([]Product, 0)
+	extensionsData := readTestFile("extensions-scc.json", t)
+	json.Unmarshal(extensionsData, &extensions)
+	activations := map[string]Activation{}
+	activations["SUSE-Manager-Server/3.2/x86_64"] = Activation{}
+	output, _ := printExtensions(extensions, activations, true)
 	pattern := `(?m)^.*SUSE Manager Retail Branch Server 3.2 x86_64.*(Not available).*$`
-	if found, _ := regexp.MatchString(pattern, output3); found {
+	if found, _ := regexp.MatchString(pattern, output); found {
 		t.Errorf("Pattern: '%s' should not be found in output", pattern)
 	}
 }

--- a/internal/connect/product.go
+++ b/internal/connect/product.go
@@ -1,6 +1,7 @@
 package connect
 
 import (
+	"encoding/json"
 	"strings"
 )
 
@@ -19,6 +20,22 @@ type Product struct {
 	Recommended  bool   `json:"recommended"`
 	// optional extension products
 	Extensions []Product `json:"extensions,omitempty"`
+}
+
+// UnmarshalJSON custom unmarshaller for Product.
+// Only SMT/RMT send the "available" field in their JSON responses.
+// SCC does not, and the default Unmarshal() sets Available to the
+// boolean zero-value which is false. This sets it to true instead.
+func (p *Product) UnmarshalJSON(data []byte) error {
+	type product Product // use type alias to prevent infinite recursion
+	prod := product{
+		Available: true,
+	}
+	if err := json.Unmarshal(data, &prod); err != nil {
+		return err
+	}
+	*p = Product(prod)
+	return nil
 }
 
 func (p Product) isEmpty() bool {

--- a/internal/connect/product_test.go
+++ b/internal/connect/product_test.go
@@ -1,6 +1,7 @@
 package connect
 
 import (
+	"encoding/json"
 	"testing"
 )
 
@@ -27,5 +28,47 @@ func TestEmptyProduct(t *testing.T) {
 	p3 := Product{Name: "sle-module-basesystem", Version: "15.2", Arch: "x86_64"}
 	if p3.isEmpty() {
 		t.Errorf("expected %v not to be empty", p3)
+	}
+}
+
+func TestUnmarshalJSONsmt(t *testing.T) {
+	jsn := `{"identifier": "product1", "available": true,
+               "extensions": [{"identifier": "extension1", "available": false}]}`
+	var p Product
+	if err := json.Unmarshal([]byte(jsn), &p); err != nil {
+		t.Errorf("Error unmarshalling: %s", err)
+	}
+	if p.Name != "product1" {
+		t.Errorf("Expected p.Name == product1, got %s", p.Name)
+	}
+	if !p.Available {
+		t.Error("Expected p.Aailable == true, got false")
+	}
+	if p.Extensions[0].Name != "extension1" {
+		t.Errorf("Expected p.Extensions[0].Name == product1, got %s", p.Extensions[0].Name)
+	}
+	if p.Extensions[0].Available {
+		t.Error("Expected p.Extensions[0].Available == false, got true")
+	}
+}
+
+func TestUnmarshalJSONscc(t *testing.T) {
+	jsn := `{"identifier": "product1",  "extensions": [{"identifier": "extension1"}]}`
+
+	var p Product
+	if err := json.Unmarshal([]byte(jsn), &p); err != nil {
+		t.Errorf("Error unmarshalling: %s", err)
+	}
+	if p.Name != "product1" {
+		t.Errorf("Expected p.Name == product1, got %s", p.Name)
+	}
+	if !p.Available {
+		t.Error("Expected p.Aailable == true, got false")
+	}
+	if p.Extensions[0].Name != "extension1" {
+		t.Errorf("Expected p.Extensions[0].Name == product1, got %s", p.Extensions[0].Name)
+	}
+	if !p.Extensions[0].Available {
+		t.Error("Expected p.Extensions[0].Available == true, got false")
 	}
 }

--- a/testdata/extensions-scc.json
+++ b/testdata/extensions-scc.json
@@ -1,0 +1,34 @@
+[
+    {
+        "friendly_name": "SUSE Manager Server 3.2 x86_64",
+        "extensions": [],
+        "free": true,
+        "identifier": "SUSE-Manager-Server",
+        "arch": "x86_64",
+        "version": "3.2"
+    },
+    {
+        "friendly_name": "SUSE Manager Proxy 3.2 x86_64",
+        "extensions": [
+            {
+                "friendly_name": "SUSE Manager Retail Branch Server 3.2 x86_64",
+                "version": "3.2",
+                "identifier": "SUSE-Manager-Retail-Branch-Server",
+                "arch": "x86_64",
+                "extensions": [],
+                "free": true
+            }
+        ],
+        "free": true,
+        "version": "3.2",
+        "identifier": "SUSE-Manager-Proxy",
+        "arch": "x86_64"
+    },
+    {
+        "free": false,
+        "version": "8",
+        "identifier": "suse-openstack-cloud",
+        "arch": "x86_64",
+        "friendly_name": "SUSE OpenStack Cloud 8 x86_64"
+    }
+]


### PR DESCRIPTION
Unlike SMT/RMT, SCC does not return an "available" field in it's
JSON response, and the default UnmarshalJSON sets Available to
false which is incorrect.

This was worked around in a couple of places by checking if SCC was
being used and overriding Availble to be true.

This patch adds a custom UnmarshalJSON() so that the default value
for Available is true, and the special checks are removed.