### PR TITLE
Use versioned obsoletes and provides

### DIFF
--- a/suseconnect-ng.spec
+++ b/suseconnect-ng.spec
@@ -30,10 +30,10 @@ Source1:        %name-rpmlintrc
 BuildRequires:  golang-packaging
 BuildRequires:  go >= 1.16
 BuildRequires:  zypper
-Obsoletes:      SUSEConnect
-Provides:       SUSEConnect
-Obsoletes:      zypper-migration-plugin
-Provides:       zypper-migration-plugin
+Obsoletes:      SUSEConnect <= 2:0
+Provides:       SUSEConnect = 2:0
+Obsoletes:      zypper-migration-plugin <= 2:0
+Provides:       zypper-migration-plugin = 2:0
 %if 0%{?fedora} || 0%{?rhel} || 0%{?centos_version}
 Requires:       ca-certificates
 %else


### PR DESCRIPTION
The old versions had no epoch, use epoch 2 version 0 so that the
obsoleted packages still have enough space for newer versions that this
package still obsoletes.

This is to fix the warning:
W: self-obsoletion SUSEConnect obsoletes SUSEConnect
The package obsoletes itself.  This is known to cause errors in various tools
and should thus be avoided, usually by using appropriately versioned Obsoletes
and/or Provides and avoiding unversioned ones.