### PR TITLE
Simplify mocking of external commands

### DIFF
--- a/internal/connect/system.go
+++ b/internal/connect/system.go
@@ -8,19 +8,14 @@ import (
 	"strings"
 )
 
-var execCommand = exec.Command
-
-func execute(cmd []string, quiet bool, validExitCodes []int) ([]byte, error) {
+// Assign function for running external commands to a variable so it can be mocked by tests.
+var execute = func(cmd []string, quiet bool, validExitCodes []int) ([]byte, error) {
 	Debug.Printf("Executing: %s Quiet: %v\n", cmd, quiet)
 	var stderr, stdout bytes.Buffer
-	comm := execCommand(cmd[0], cmd[1:]...)
+	comm := exec.Command(cmd[0], cmd[1:]...)
 	comm.Stdout = &stdout
 	comm.Stderr = &stderr
-	// init env only if not set by (mocked) execCommand()
-	if len(comm.Env) == 0 {
-		comm.Env = os.Environ()
-	}
-	comm.Env = append(comm.Env, "LC_ALL=C")
+	comm.Env = append(os.Environ(), "LC_ALL=C")
 	err := comm.Run()
 	exitCode := comm.ProcessState.ExitCode()
 	Debug.Printf("Return code: %d\n", exitCode)

--- a/internal/connect/zypper_test.go
+++ b/internal/connect/zypper_test.go
@@ -1,48 +1,8 @@
 package connect
 
 import (
-	"fmt"
-	"os"
-	"os/exec"
 	"testing"
 )
-
-const (
-	testCaseInstalledProducts       = "testCaseInstalledProducts"
-	testCaseInstalledProductsNoBase = "testCaseInstalledProductsNoBase"
-)
-
-var zypperExecTestCase = ""
-
-func zypperExecMock(command string, args ...string) *exec.Cmd {
-	cs := []string{"-test.run=TestZypperHelper", "--", command}
-	cs = append(cs, args...)
-	cmd := exec.Command(os.Args[0], cs...)
-	cmd.Env = os.Environ()
-	cmd.Env = append(cmd.Env, "GO_WANT_HELPER_PROCESS=1")
-	cmd.Env = append(cmd.Env, "GO_TESTCASE="+zypperExecTestCase)
-	return cmd
-}
-
-// This is not a real test. It's used for mocking output of commands.
-func TestZypperHelper(t *testing.T) {
-	// if ran directly, do nothing
-	if os.Getenv("GO_WANT_HELPER_PROCESS") != "1" {
-		return
-	}
-	testcase := os.Getenv("GO_TESTCASE")
-	switch testcase {
-	case testCaseInstalledProducts:
-		os.Stdout.Write(readTestFile("products.xml", t))
-		os.Exit(0)
-	case testCaseInstalledProductsNoBase:
-		os.Stdout.Write(readTestFile("products-no-base.xml", t))
-		os.Exit(0)
-	default:
-		fmt.Fprintf(os.Stderr, "Error: unexpected testcase=%s\n", testcase)
-		os.Exit(1)
-	}
-}
 
 func TestParseProductsXML(t *testing.T) {
 	products, err := parseProductsXML(readTestFile("products.xml", t))
@@ -71,9 +31,9 @@ func TestParseServicesXML(t *testing.T) {
 }
 
 func TestInstalledProducts(t *testing.T) {
-	zypperExecTestCase = testCaseInstalledProducts
-	execCommand = zypperExecMock
-	defer func() { execCommand = exec.Command }()
+	execute = func(_ []string, _ bool, _ []int) ([]byte, error) {
+		return readTestFile("products.xml", t), nil
+	}
 
 	products, err := installedProducts()
 	if err != nil {
@@ -88,9 +48,9 @@ func TestInstalledProducts(t *testing.T) {
 }
 
 func TestBaseProduct(t *testing.T) {
-	zypperExecTestCase = testCaseInstalledProducts
-	execCommand = zypperExecMock
-	defer func() { execCommand = exec.Command }()
+	execute = func(_ []string, _ bool, _ []int) ([]byte, error) {
+		return readTestFile("products.xml", t), nil
+	}
 
 	base, err := baseProduct()
 	if err != nil {
@@ -102,10 +62,9 @@ func TestBaseProduct(t *testing.T) {
 }
 
 func TestBaseProductError(t *testing.T) {
-	zypperExecTestCase = testCaseInstalledProductsNoBase
-	execCommand = zypperExecMock
-	defer func() { execCommand = exec.Command }()
-
+	execute = func(_ []string, _ bool, _ []int) ([]byte, error) {
+		return readTestFile("products-no-base.xml", t), nil
+	}
 	_, err := baseProduct()
 	if err != ErrCannotDetectBaseProduct {
 		t.Errorf("Unexpected error: %s", err)


### PR DESCRIPTION
Our execute() function encapsulates the calls to exec.Command
and exec.Run. So it's much easier to substitute it at test time.

We don't use testing.Parallel(), so there is no danger modifying
the execute package variable.

Also any test that invokes code that calls execute() should first
replace the execute function, so no tests should be calling the
original execute function. Therefore there is no need to restore
it at the end of a test that replaces it.