### PR TITLE
Remove quiet param from execute() and zypperRun()

### DIFF
--- a/internal/connect/hwinfo.go
+++ b/internal/connect/hwinfo.go
@@ -103,7 +103,7 @@ func cpuinfoS390(hw *hwinfo) error {
 }
 
 func arch() (string, error) {
-	output, err := execute([]string{"uname", "-i"}, false, nil)
+	output, err := execute([]string{"uname", "-i"}, nil)
 	if err != nil {
 		return "", err
 	}
@@ -111,7 +111,7 @@ func arch() (string, error) {
 }
 
 func lscpu() (map[string]string, error) {
-	output, err := execute([]string{"lscpu"}, false, nil)
+	output, err := execute([]string{"lscpu"}, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -134,7 +134,7 @@ func lscpu2map(b []byte) map[string]string {
 }
 
 func cloudProvider() string {
-	output, err := execute([]string{"dmidecode", "-t", "system"}, false, nil)
+	output, err := execute([]string{"dmidecode", "-t", "system"}, nil)
 	if err != nil {
 		return ""
 	}
@@ -153,7 +153,7 @@ func findCloudProvider(b []byte) string {
 }
 
 func hypervisor() (string, error) {
-	output, err := execute([]string{"systemd-detect-virt", "-v"}, false, []int{0, 1})
+	output, err := execute([]string{"systemd-detect-virt", "-v"}, []int{0, 1})
 	if err != nil {
 		return "", err
 	}
@@ -172,7 +172,7 @@ func uuid() (string, error) {
 		}
 		return string(content), nil
 	}
-	output, err := execute([]string{"dmidecode", "-s", "system-uuid"}, false, nil)
+	output, err := execute([]string{"dmidecode", "-s", "system-uuid"}, nil)
 	if err != nil {
 		return "", err
 	}
@@ -247,7 +247,7 @@ func hostname() string {
 
 // readValues calls read_values from SUSE/s390-tools
 func readValues(arg string) ([]byte, error) {
-	output, err := execute([]string{"read_values", arg}, false, nil)
+	output, err := execute([]string{"read_values", arg}, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/connect/system.go
+++ b/internal/connect/system.go
@@ -9,8 +9,8 @@ import (
 )
 
 // Assign function for running external commands to a variable so it can be mocked by tests.
-var execute = func(cmd []string, quiet bool, validExitCodes []int) ([]byte, error) {
-	Debug.Printf("Executing: %s Quiet: %v\n", cmd, quiet)
+var execute = func(cmd []string, validExitCodes []int) ([]byte, error) {
+	Debug.Printf("Executing: %s\n", cmd)
 	var stderr, stdout bytes.Buffer
 	comm := exec.Command(cmd[0], cmd[1:]...)
 	comm.Stdout = &stdout
@@ -35,9 +35,6 @@ var execute = func(cmd []string, quiet bool, validExitCodes []int) ([]byte, erro
 		output = bytes.TrimSuffix(output, []byte("\n"))
 		ee := ExecuteError{Commmand: cmd, ExitCode: exitCode, Output: output, Err: err}
 		return nil, ee
-	}
-	if quiet {
-		return nil, nil
 	}
 	out := stdout.Bytes()
 	out = bytes.TrimSuffix(out, []byte("\n"))
@@ -69,7 +66,7 @@ func removeFile(path string) error {
 }
 
 func isRootFSWritable() bool {
-	_, err := execute([]string{"test", "-w", "/"}, true, []int{zypperOK})
+	_, err := execute([]string{"test", "-w", "/"}, []int{zypperOK})
 	return err == nil
 }
 

--- a/internal/connect/zypper.go
+++ b/internal/connect/zypper.go
@@ -31,13 +31,13 @@ const (
 	zypperInfoReposSkipped    = 106 // Some repository had to be disabled temporarily because it failed to refresh
 )
 
-func zypperRun(args []string, quiet bool, validExitCodes []int) ([]byte, error) {
+func zypperRun(args []string, validExitCodes []int) ([]byte, error) {
 	cmd := []string{zypperPath}
 	if CFG.FsRoot != "" {
 		cmd = append(cmd, "--root", CFG.FsRoot)
 	}
 	cmd = append(cmd, args...)
-	output, err := execute(cmd, quiet, validExitCodes)
+	output, err := execute(cmd, validExitCodes)
 	if err != nil {
 		if ee, ok := err.(ExecuteError); ok {
 			return nil, ZypperError{ExitCode: ee.ExitCode, Output: ee.Output}
@@ -49,7 +49,7 @@ func zypperRun(args []string, quiet bool, validExitCodes []int) ([]byte, error) 
 // installedProducts returns installed products
 func installedProducts() ([]Product, error) {
 	args := []string{"--disable-repositories", "--xmlout", "--non-interactive", "products", "-i"}
-	output, err := zypperRun(args, false, []int{zypperOK})
+	output, err := zypperRun(args, []int{zypperOK})
 	if err != nil {
 		return []Product{}, err
 	}
@@ -70,7 +70,7 @@ func parseProductsXML(xmlDoc []byte) ([]Product, error) {
 func installedServices() ([]Service, error) {
 	args := []string{"--xmlout", "--non-interactive", "services", "-d"}
 	// Don't fail when zypper exits with 6 (no repositories)
-	output, err := zypperRun(args, false, []int{zypperOK, zypperErrNoRepos})
+	output, err := zypperRun(args, []int{zypperOK, zypperErrNoRepos})
 	if err != nil {
 		return []Service{}, err
 	}
@@ -102,7 +102,7 @@ func baseProduct() (Product, error) {
 }
 
 func zypperDistroTarget() (string, error) {
-	output, err := zypperRun([]string{"targetos"}, false, []int{zypperOK})
+	output, err := zypperRun([]string{"targetos"}, []int{zypperOK})
 	if err != nil {
 		return "", err
 	}
@@ -115,7 +115,7 @@ func addService(serviceURL, serviceName string, refresh bool) error {
 		return err
 	}
 	args := []string{"--non-interactive", "addservice", "-t", "ris", serviceURL, serviceName}
-	_, err := zypperRun(args, true, []int{zypperOK})
+	_, err := zypperRun(args, []int{zypperOK})
 	if err != nil {
 		return err
 	}
@@ -135,7 +135,7 @@ func removeService(serviceName string) error {
 	Debug.Println("Removing service: ", serviceName)
 
 	args := []string{"--non-interactive", "removeservice", serviceName}
-	_, err := zypperRun(args, true, []int{zypperOK})
+	_, err := zypperRun(args, []int{zypperOK})
 	if err != nil {
 		return err
 	}
@@ -144,19 +144,19 @@ func removeService(serviceName string) error {
 
 func enableServiceAutorefresh(serviceName string) error {
 	args := []string{"--non-interactive", "modifyservice", "-r", serviceName}
-	_, err := zypperRun(args, true, []int{zypperOK})
+	_, err := zypperRun(args, []int{zypperOK})
 	return err
 }
 
 func refreshService(serviceName string) error {
 	args := []string{"--non-interactive", "refs", serviceName}
-	_, err := zypperRun(args, true, []int{zypperOK})
+	_, err := zypperRun(args, []int{zypperOK})
 	return err
 }
 
 func refreshAllServices() error {
 	args := []string{"--non-interactive", "refs"}
-	_, err := zypperRun(args, true, []int{zypperOK})
+	_, err := zypperRun(args, []int{zypperOK})
 	return err
 }
 
@@ -166,7 +166,7 @@ func installReleasePackage(identifier string) error {
 	}
 	// return if the rpm is already installed
 	args := []string{"rpm", "-q", identifier + "-release"}
-	if _, err := execute(args, false, nil); err == nil {
+	if _, err := execute(args, nil); err == nil {
 		return nil
 	}
 
@@ -181,7 +181,7 @@ func installReleasePackage(identifier string) error {
 	args = []string{"--no-refresh", "--non-interactive", "install", "--no-recommends",
 		"--auto-agree-with-product-licenses", "-t", "product", identifier}
 
-	_, err := zypperRun(args, false, validExitCodes)
+	_, err := zypperRun(args, validExitCodes)
 	return err
 }
 
@@ -190,12 +190,12 @@ func removeReleasePackage(identifier string) error {
 		return nil
 	}
 	args := []string{"--no-refresh", "--non-interactive", "remove", "-t", "product", identifier}
-	_, err := zypperRun(args, true, []int{zypperOK, zypperInfoCapNotFound})
+	_, err := zypperRun(args, []int{zypperOK, zypperInfoCapNotFound})
 	return err
 }
 
 func setReleaseVersion(version string) error {
 	args := []string{"--non-interactive", "--releasever", version, "ref", "-f"}
-	_, err := zypperRun(args, true, []int{zypperOK})
+	_, err := zypperRun(args, []int{zypperOK})
 	return err
 }

--- a/internal/connect/zypper_test.go
+++ b/internal/connect/zypper_test.go
@@ -31,7 +31,7 @@ func TestParseServicesXML(t *testing.T) {
 }
 
 func TestInstalledProducts(t *testing.T) {
-	execute = func(_ []string, _ bool, _ []int) ([]byte, error) {
+	execute = func(_ []string, _ []int) ([]byte, error) {
 		return readTestFile("products.xml", t), nil
 	}
 
@@ -48,7 +48,7 @@ func TestInstalledProducts(t *testing.T) {
 }
 
 func TestBaseProduct(t *testing.T) {
-	execute = func(_ []string, _ bool, _ []int) ([]byte, error) {
+	execute = func(_ []string, _ []int) ([]byte, error) {
 		return readTestFile("products.xml", t), nil
 	}
 
@@ -62,7 +62,7 @@ func TestBaseProduct(t *testing.T) {
 }
 
 func TestBaseProductError(t *testing.T) {
-	execute = func(_ []string, _ bool, _ []int) ([]byte, error) {
+	execute = func(_ []string, _ []int) ([]byte, error) {
 		return readTestFile("products-no-base.xml", t), nil
 	}
 	_, err := baseProduct()


### PR DESCRIPTION
The quiet param was copied from the Ruby SUSEConnect in the rewrite.
But it seems pointless as callers ignore the returned output anyway.

Removing it improves readability.