### PR TITLE
Add basic string set implementation

### DIFF
--- a/internal/connect/client.go
+++ b/internal/connect/client.go
@@ -103,14 +103,14 @@ func Deregister() error {
 		return err
 	}
 	installed, _ := installedProducts()
-	installedIDs := make(map[string]struct{}, 0)
+	installedIDs := NewStringSet()
 	for _, prod := range installed {
-		installedIDs[prod.Name] = struct{}{}
+		installedIDs.Add(prod.Name)
 	}
 
 	dependencies := make([]Product, 0)
 	for _, e := range tree.toExtensionsList() {
-		if _, found := installedIDs[e.Name]; found {
+		if installedIDs.Contains(e.Name) {
 			dependencies = append(dependencies, e)
 		}
 	}

--- a/internal/connect/migration.go
+++ b/internal/connect/migration.go
@@ -28,9 +28,9 @@ func Rollback() error {
 	if err != nil {
 		return err
 	}
-	installedIDs := make(map[string]struct{}, 0)
+	installedIDs := NewStringSet()
 	for _, prod := range installed {
-		installedIDs[prod.Name] = struct{}{}
+		installedIDs.Add(prod.Name)
 	}
 
 	tree, err := showProduct(base)
@@ -41,7 +41,7 @@ func Rollback() error {
 	// Get all installed products in right order
 	extensions := make([]Product, 0)
 	for _, e := range tree.toExtensionsList() {
-		if _, found := installedIDs[e.Name]; found {
+		if installedIDs.Contains(e.Name) {
 			extensions = append(extensions, e)
 		}
 	}

--- a/internal/connect/stringset.go
+++ b/internal/connect/stringset.go
@@ -1,0 +1,40 @@
+package connect
+
+// StringSet is used to implement a set of strings
+type StringSet struct {
+	m map[string]struct{}
+}
+
+// NewStringSet constructor for StringSet.
+// The set can be initialized with zero or more strings.
+func NewStringSet(strs ...string) StringSet {
+	ss := StringSet{}
+	ss.m = make(map[string]struct{})
+	for _, s := range strs {
+		ss.m[s] = struct{}{}
+	}
+	return ss
+}
+
+// Add string(s) to set
+func (ss StringSet) Add(strs ...string) {
+	for _, s := range strs {
+		ss.m[s] = struct{}{}
+	}
+}
+
+// Delete s from set
+func (ss StringSet) Delete(s string) {
+	delete(ss.m, s)
+}
+
+// Contains returns true if s is in the set
+func (ss StringSet) Contains(s string) bool {
+	_, ok := ss.m[s]
+	return ok
+}
+
+// Len returns the number of strings in the set
+func (ss StringSet) Len() int {
+	return len(ss.m)
+}

--- a/internal/connect/stringset_test.go
+++ b/internal/connect/stringset_test.go
@@ -1,0 +1,34 @@
+package connect
+
+import (
+	"testing"
+)
+
+func TestStringSet(t *testing.T) {
+	ss := NewStringSet()
+	ss.Add("cat")
+	ss.Add("dog")
+	ss.Add("dog")
+	if ss.Len() != 2 {
+		t.Fatal("Len() should be 2")
+	}
+	if !ss.Contains("dog") {
+		t.Fatal("Should have found dog")
+	}
+
+	ss2 := NewStringSet("dog", "cat", "mouse")
+	if ss2.Len() != 3 {
+		t.Fatal("Len() should be 3")
+	}
+	ss2.Add("bird", "fish")
+	if ss2.Len() != 5 {
+		t.Fatal("Len() should be 5")
+	}
+	ss2.Delete("cat")
+	if ss2.Contains("cat") {
+		t.Fatal("Should not have found cat")
+	}
+	if ss2.Len() != 4 {
+		t.Fatal("Len() should be 4")
+	}
+}


### PR DESCRIPTION
Go does not provide a set implementation, nor does its  standard
library. We use the common idiom of maps with strings as keys and
empty structs as values. But it's tedious to read and write.
This commit abstracts away the implementation details.