### PR TITLE
Allow loading Config from any path

### DIFF
--- a/internal/connect/config.go
+++ b/internal/connect/config.go
@@ -31,6 +31,15 @@ type Config struct {
 	NoZypperRefresh  bool
 }
 
+// NewConfig returns a Config with defaults
+func NewConfig() Config {
+	return Config{
+		Path:     defaultConfigPath,
+		BaseURL:  defaultBaseURL,
+		Insecure: defaultInsecure,
+	}
+}
+
 func (c Config) toYAML() []byte {
 	buf := bytes.Buffer{}
 	fmt.Fprintf(&buf, "---\n")
@@ -51,13 +60,10 @@ func (c Config) Save() error {
 	return os.WriteFile(c.Path, data, 0644)
 }
 
-// Load sets the defaults and tries to read
-// and merge settings from /etc/SUSEConnect
+// Load tries to read and merge the settings from Path.
+// Ignore errors as it's quite normal that Path does not exist.
 func (c *Config) Load() {
-	c.Path = defaultConfigPath
-	c.BaseURL = defaultBaseURL
-	c.Insecure = defaultInsecure
-	f, err := os.Open(defaultConfigPath)
+	f, err := os.Open(c.Path)
 	if err != nil {
 		Debug.Println(err)
 		return

--- a/internal/connect/config_test.go
+++ b/internal/connect/config_test.go
@@ -1,6 +1,7 @@
 package connect
 
 import (
+	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
@@ -41,5 +42,20 @@ func TestParseConfig2(t *testing.T) {
 	parseConfig(r, &c)
 	if !reflect.DeepEqual(c, expect) {
 		t.Errorf("got %+v, expected %+v", c, expect)
+	}
+}
+
+func TestSaveLoad(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "SUSEConnect.test")
+	c1 := NewConfig()
+	c1.Path = path
+	if err := c1.Save(); err != nil {
+		t.Fatalf("Unable to write config: %s", err)
+	}
+	c2 := NewConfig()
+	c2.Path = path
+	c2.Load()
+	if !reflect.DeepEqual(c1, c2) {
+		t.Errorf("got %+v, expected %+v", c2, c1)
 	}
 }

--- a/internal/connect/main.go
+++ b/internal/connect/main.go
@@ -14,7 +14,7 @@ const (
 
 var (
 	// CFG is the global struct for config
-	CFG Config
+	CFG = NewConfig()
 	// Debug logger for debugging output
 	Debug *log.Logger
 )


### PR DESCRIPTION
Currently it's hard coded to /etc/SUSEConnect.
YaST-Registration requires that it can be something different.
This commit allows that by separating out the setting of defaults
from the Load() method.