### PR TITLE
Don't send unneeded Product fields to API

### DIFF
--- a/internal/connect/api.go
+++ b/internal/connect/api.go
@@ -73,9 +73,7 @@ func showProduct(productQuery Product) (Product, error) {
 }
 
 func upgradeProduct(product Product) (Service, error) {
-	// NOTE: this can add some extra attributes to json payload which
-	//       seem to be safely ignored by the API.
-	payload, err := json.Marshal(product)
+	payload, err := json.Marshal(product.BasicProduct)
 	remoteService := Service{}
 	if err != nil {
 		return remoteService, err
@@ -96,16 +94,12 @@ func downgradeProduct(product Product) (Service, error) {
 
 func activateProduct(product Product, email string) (Service, error) {
 	var payload = struct {
-		Indentifier string `json:"identifier"`
-		Version     string `json:"version"`
-		Arch        string `json:"arch"`
+		BasicProduct
 		ReleaseType string `json:"release_type"`
 		Token       string `json:"token"`
 		Email       string `json:"email"`
 	}{
-		product.Name,
-		product.Version,
-		product.Arch,
+		product.BasicProduct,
 		product.ReleaseType,
 		CFG.Token,
 		email,
@@ -128,9 +122,7 @@ func activateProduct(product Product, email string) (Service, error) {
 }
 
 func deactivateProduct(product Product) (Service, error) {
-	// NOTE: this can add some extra attributes to json payload which
-	//       seem to be safely ignored by the API.
-	payload, err := json.Marshal(product)
+	payload, err := json.Marshal(product.BasicProduct)
 	remoteService := Service{}
 	if err != nil {
 		return remoteService, err
@@ -153,9 +145,12 @@ func deregisterSystem() error {
 func syncProducts(products []Product) ([]Product, error) {
 	remoteProducts := make([]Product, 0)
 	var payload struct {
-		Products []Product `json:"products"`
+		Products []BasicProduct `json:"products"`
 	}
-	payload.Products = products
+	payload.Products = make([]BasicProduct, 0)
+	for _, p := range products {
+		payload.Products = append(payload.Products, p.BasicProduct)
+	}
 	body, err := json.Marshal(payload)
 	if err != nil {
 		return remoteProducts, err

--- a/internal/connect/api_test.go
+++ b/internal/connect/api_test.go
@@ -114,7 +114,7 @@ func TestGetProduct(t *testing.T) {
 	defer ts.Close()
 
 	CFG.BaseURL = ts.URL
-	productQuery := Product{Name: "SLES", Version: "15.2", Arch: "x86_64"}
+	productQuery := NewProduct("SLES", "15.2", "x86_64")
 	product, err := showProduct(productQuery)
 	if err != nil {
 		t.Fatalf("%s", err)
@@ -137,7 +137,7 @@ func TestGetProductError(t *testing.T) {
 	defer ts.Close()
 
 	CFG.BaseURL = ts.URL
-	productQuery := Product{Name: "Dummy"}
+	productQuery := NewProduct("Dummy", "", "")
 	_, err := showProduct(productQuery)
 	if ae, ok := err.(APIError); ok {
 		if ae.Code != http.StatusUnprocessableEntity {
@@ -155,7 +155,7 @@ func TestUpgradeProduct(t *testing.T) {
 	defer ts.Close()
 
 	CFG.BaseURL = ts.URL
-	product := Product{Name: "SUSE-MicroOS", Version: "5.0", Arch: "x86_64"}
+	product := NewProduct("SUSE-MicroOS", "5.0", "x86_64")
 	service, err := upgradeProduct(product)
 	if err != nil {
 		t.Fatalf("%s", err)
@@ -178,7 +178,7 @@ func TestUpgradeProductError(t *testing.T) {
 	defer ts.Close()
 
 	CFG.BaseURL = ts.URL
-	product := Product{Name: "Dummy"}
+	product := NewProduct("Dummy", "", "")
 	_, err := upgradeProduct(product)
 	if ae, ok := err.(APIError); ok {
 		if ae.Code != http.StatusUnprocessableEntity {
@@ -196,7 +196,7 @@ func TestDeactivateProduct(t *testing.T) {
 	defer ts.Close()
 
 	CFG.BaseURL = ts.URL
-	product := Product{Name: "sle-module-basesystem", Version: "15.2", Arch: "x86_64"}
+	product := NewProduct("sle-module-basesystem", "15.2", "x86_64")
 	service, err := deactivateProduct(product)
 	if err != nil {
 		t.Fatalf("%s", err)
@@ -219,7 +219,7 @@ func TestDeactivateProductSMT(t *testing.T) {
 	defer ts.Close()
 
 	CFG.BaseURL = ts.URL
-	product := Product{Name: "SUSE-MicroOS", Version: "5.0", Arch: "x86_64"}
+	product := NewProduct("SUSE-MicroOS", "5.0", "x86_64")
 	service, err := deactivateProduct(product)
 	if err != nil {
 		t.Fatalf("%s", err)
@@ -242,7 +242,7 @@ func TestDeactivateProductError(t *testing.T) {
 	defer ts.Close()
 
 	CFG.BaseURL = ts.URL
-	product := Product{Name: "Dummy"}
+	product := NewProduct("Dummy", "", "")
 	_, err := deactivateProduct(product)
 	if ae, ok := err.(APIError); ok {
 		if ae.Code != http.StatusUnprocessableEntity {

--- a/internal/connect/product.go
+++ b/internal/connect/product.go
@@ -5,11 +5,19 @@ import (
 	"strings"
 )
 
-// Product represents an installed product or product information from API
-type Product struct {
+// BasicProduct represents basic information on product, mostly for API requests
+// where we don't want to send all fields. For strings 'omitempty' tag is enough
+// but for bools, there's no "empty" state so they are always included in JSON.
+type BasicProduct struct {
 	Name    string `xml:"name,attr" json:"identifier"`
 	Version string `xml:"version,attr" json:"version"`
 	Arch    string `xml:"arch,attr" json:"arch"`
+}
+
+// Product represents an installed product or product information from API
+type Product struct {
+	BasicProduct
+	Release string `xml:"release,attr" json:"-"`
 	Summary string `xml:"summary,attr" json:"-"`
 	IsBase  bool   `xml:"isbase,attr" json:"-"`
 
@@ -20,6 +28,11 @@ type Product struct {
 	Recommended  bool   `json:"recommended"`
 	// optional extension products
 	Extensions []Product `json:"extensions,omitempty"`
+}
+
+// NewProduct returns new Product with basic fields set
+func NewProduct(name, version, arch string) Product {
+	return Product{BasicProduct: BasicProduct{Name: name, Version: version, Arch: arch}}
 }
 
 // UnmarshalJSON custom unmarshaller for Product.

--- a/internal/connect/product_test.go
+++ b/internal/connect/product_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestDistroTarget(t *testing.T) {
-	p := Product{Name: "sle-module-basesystem", Version: "15.2", Arch: "x86_64"}
+	p := NewProduct("sle-module-basesystem", "15.2", "x86_64")
 	got := p.distroTarget()
 	expect := "sle-15-x86_64"
 	if got != expect {
@@ -20,12 +20,12 @@ func TestEmptyProduct(t *testing.T) {
 		t.Errorf("expected %v to be empty", p1)
 	}
 
-	p2 := Product{Name: "Dummy"}
+	p2 := NewProduct("Dummy", "", "")
 	if !p2.isEmpty() {
 		t.Errorf("expected %v to be empty", p2)
 	}
 
-	p3 := Product{Name: "sle-module-basesystem", Version: "15.2", Arch: "x86_64"}
+	p3 := NewProduct("sle-module-basesystem", "15.2", "x86_64")
 	if p3.isEmpty() {
 		t.Errorf("expected %v not to be empty", p3)
 	}

--- a/suseconnect/suseconnect.go
+++ b/suseconnect/suseconnect.go
@@ -105,7 +105,7 @@ func main() {
 			os.Exit(1)
 		}
 		parts := strings.Split(product, "/")
-		connect.CFG.Product = connect.Product{Name: parts[0], Version: parts[1], Arch: parts[2]}
+		connect.CFG.Product = connect.NewProduct(parts[0], parts[1], parts[2])
 	}
 	if instanceDataFile != "" {
 		connect.CFG.InstanceDataFile = instanceDataFile


### PR DESCRIPTION
Product structure was split into two parts. BasicProduct with fields
needed to identify the product and Product which embeds BasicProduct
and adds more fields on top.
For API calls which only need the basic fields, BasicProduct part can be
used even if Product was passed.