### PR TITLE
Change parse error string and add block comment

### DIFF
--- a/internal/connect/errors.go
+++ b/internal/connect/errors.go
@@ -5,8 +5,9 @@ import (
 	"fmt"
 )
 
+// export errors that package main needs
 var (
-	ErrMalformedSccCredFile       = errors.New("Unable to parse credentials")
+	ErrMalformedSccCredFile       = errors.New("Cannot parse credentials file")
 	ErrMissingCredentialsFile     = errors.New("Credentials file is missing")
 	ErrSystemNotRegistered        = errors.New("System not registered")
 	ErrBaseProductDeactivation    = errors.New("Unable to deactivate base product")


### PR DESCRIPTION
Change the credentials parse error message so it's the same as
the Ruby version.

Add a block doc string for all exported errors. This satisfies
revive without having to add a doc string for each exported error.