### PR TITLE
allow --instance-data together with --regcode

### DIFF
--- a/suseconnect/suseconnect.go
+++ b/suseconnect/suseconnect.go
@@ -147,9 +147,6 @@ func main() {
 			fmt.Print("Please use --instance-data only in combination ")
 			fmt.Print("with --url pointing to your RMT or SMT server\n")
 			os.Exit(1)
-		} else if token != "" && instanceDataFile != "" {
-			fmt.Print("Please use either --regcode or --instance-data\n")
-			os.Exit(1)
 		} else if connect.URLDefault() && token == "" && product == "" {
 			flag.Usage()
 			os.Exit(1)


### PR DESCRIPTION
This is required to allow BYOS instances to access the Public
Cloud update infrastructure.

It was implemented in the Ruby SUSEConnect:
https://github.com/SUSE/connect/pull/462

Closes #78 