### PR TITLE
Add http client timeout

### DIFF
--- a/internal/connect/connection.go
+++ b/internal/connect/connection.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"net/url"
+	"time"
 )
 
 type authType int
@@ -85,7 +86,7 @@ func callHTTP(verb, path string, body []byte, query map[string]string, auth auth
 			TLSClientConfig: &tls.Config{InsecureSkipVerify: CFG.Insecure},
 			Proxy:           proxyWithAuth,
 		}
-		httpclient = &http.Client{Transport: tr}
+		httpclient = &http.Client{Transport: tr, Timeout: 60 * time.Second}
 	}
 	req, err := http.NewRequest(verb, CFG.BaseURL, bytes.NewReader(body))
 	if err != nil {


### PR DESCRIPTION
The original Ruby version has a 60 second timeout. This was missed
in the rewrite causing the client to hang indefinitely.