### PR TITLE
Allow de-register/de-activate a single product

### DIFF
--- a/internal/connect/client.go
+++ b/internal/connect/client.go
@@ -78,7 +78,7 @@ func registerProductTree(product Product) error {
 
 // Deregister deregisters the system
 func Deregister() error {
-	if fileExists("/usr/sbin/registercloudguest") {
+	if fileExists("/usr/sbin/registercloudguest") && CFG.Product.isEmpty() {
 		return fmt.Errorf("SUSE::Connect::UnsupportedOperation: " +
 			"De-registration is disabled for on-demand instances. " +
 			"Use `registercloudguest --clean` instead.")


### PR DESCRIPTION
- When running BYOS proxy instance,
  allow de-registration of a single product

This Fixes #89