### PR TITLE
Extract ReleaseType from zypper output

### DIFF
--- a/internal/connect/product.go
+++ b/internal/connect/product.go
@@ -17,7 +17,8 @@ type Product struct {
 	IsBase  bool   `xml:"isbase,attr" json:"base"`
 
 	FriendlyName string `json:"friendly_name,omitempty"`
-	ReleaseType  string `json:"release_type,omitempty"`
+	ReleaseType  string `xml:"registerrelease,attr" json:"release_type,omitempty"`
+	ProductLine  string `xml:"productline,attr"`
 	Available    bool   `json:"available"`
 	Free         bool   `json:"free"`
 	Recommended  bool   `json:"recommended"`

--- a/internal/connect/zypper_test.go
+++ b/internal/connect/zypper_test.go
@@ -1,6 +1,8 @@
 package connect
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -14,6 +16,40 @@ func TestParseProductsXML(t *testing.T) {
 	}
 	if products[0].ToTriplet() != "SUSE-MicroOS/5.0/x86_64" {
 		t.Errorf("Expected SUSE-MicroOS/5.0/x86_64 Got %s", products[0].ToTriplet())
+	}
+}
+
+func TestParseProductsXML_ReleaseType(t *testing.T) {
+	CFG.FsRoot = t.TempDir()
+	// write test OEM file
+	testRT := "SLES-OEM-TEST"
+	oemDir := filepath.Join(CFG.FsRoot, oemPath)
+	if err := os.MkdirAll(oemDir, 0755); err != nil {
+		t.Fatalf("Error creating OEM dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(oemDir, "sles"), []byte(testRT), 0600); err != nil {
+		t.Fatalf("Error writing OEM file: %v", err)
+	}
+
+	products, err := parseProductsXML(readTestFile("products-rt.xml", t))
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+	}
+
+	if products[0].ReleaseType != "" {
+		t.Errorf("Expected empty ReleaseType Got %v", products[0].ReleaseType)
+	}
+	if products[1].ReleaseType != testRT {
+		t.Errorf("Expected ReleaseType=%v Got %v", testRT, products[1].ReleaseType)
+	}
+	if products[2].ReleaseType != testRT {
+		t.Errorf("Expected ReleaseType=%v Got %v", testRT, products[2].ReleaseType)
+	}
+	if products[3].ReleaseType != "rel2" {
+		t.Errorf("Expected ReleaseType=rel2 Got %v", products[3].ReleaseType)
+	}
+	if products[4].ReleaseType != "" {
+		t.Errorf("Expected empty ReleaseType Got %v", products[4].ReleaseType)
 	}
 }
 

--- a/testdata/products-rt.xml
+++ b/testdata/products-rt.xml
@@ -1,0 +1,10 @@
+<?xml version='1.0'?>
+<stream>
+  <product-list>
+    <product name="suse-openstack-cloud" version="8" release="0" arch="x86_64" productline="suse-openstack-cloud" registerrelease=""></product>
+    <product name="SLES" version="12.5" release="0" arch="x86_64" productline="sles" registerrelease=""></product>
+    <product name="SLES-OEM-test1" productline="sles" registerrelease="rel1"></product>
+    <product name="SLES-OEM-test2" productline="" registerrelease="rel2"></product>
+    <product name="SLES-OEM-test3" productline="" registerrelease=""></product>
+  </product-list>
+</stream>


### PR DESCRIPTION
This is added to match original behavior for custom/OEM release types.

Original code change: https://github.com/SUSE/connect/pull/24/files#diff-947d0f660915c13c25028887223e8a202b48d34bb7f47c9780c013ce3b819562R83
Current version in Ruby: https://github.com/SUSE/connect/blob/master/lib/suse/connect/zypper/product.rb#L31