### PR TITLE
Print failed command on zypper error like the Ruby

### DIFF
--- a/internal/connect/errors.go
+++ b/internal/connect/errors.go
@@ -3,6 +3,7 @@ package connect
 import (
 	"errors"
 	"fmt"
+	"strings"
 )
 
 // export errors that package main needs
@@ -32,12 +33,14 @@ func (ee ExecuteError) Error() string {
 
 // ZypperError is returned by zypperRun on error
 type ZypperError struct {
+	Commmand []string
 	ExitCode int
 	Output   []byte
 }
 
 func (ze ZypperError) Error() string {
-	return fmt.Sprintf("Error: zypper returned %d with '%s'", ze.ExitCode, ze.Output)
+	return fmt.Sprintf("command '%s' failed\nError: zypper returned %d with '%s'",
+		strings.Join(ze.Commmand, " "), ze.ExitCode, ze.Output)
 }
 
 // APIError is returned on failed HTTP requests

--- a/internal/connect/zypper.go
+++ b/internal/connect/zypper.go
@@ -42,7 +42,7 @@ func zypperRun(args []string, validExitCodes []int) ([]byte, error) {
 	output, err := execute(cmd, validExitCodes)
 	if err != nil {
 		if ee, ok := err.(ExecuteError); ok {
-			return nil, ZypperError{ExitCode: ee.ExitCode, Output: ee.Output}
+			return nil, ZypperError{Commmand: ee.Commmand, ExitCode: ee.ExitCode, Output: ee.Output}
 		}
 	}
 	return output, nil


### PR DESCRIPTION
Reproduce by creating a lock file:
    echo 1 > /run/zypp.pid
    ./suseconnect -s