### PR TITLE
Use DefaultTransport defaults + client timeout

### DIFF
--- a/internal/connect/connection.go
+++ b/internal/connect/connection.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"net/url"
+	"time"
 )
 
 type authType int
@@ -81,11 +82,11 @@ func proxyWithAuth(req *http.Request) (*url.URL, error) {
 
 func callHTTP(verb, path string, body []byte, query map[string]string, auth authType) ([]byte, error) {
 	if httpclient == nil {
-		tr := &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: CFG.Insecure},
-			Proxy:           proxyWithAuth,
-		}
-		httpclient = &http.Client{Transport: tr}
+		// use defaults from DefaultTransport
+		tr := http.DefaultTransport.(*http.Transport).Clone()
+		tr.TLSClientConfig = &tls.Config{InsecureSkipVerify: CFG.Insecure}
+		tr.Proxy = proxyWithAuth
+		httpclient = &http.Client{Transport: tr, Timeout: 60 * time.Second}
 	}
 	req, err := http.NewRequest(verb, CFG.BaseURL, bytes.NewReader(body))
 	if err != nil {


### PR DESCRIPTION
If starting with empty Transport, many settings are not properly
initialized (e.g. there are no timeouts set). Adding changes on top of
cloned DefaultTransport solves the problem.
In addition, default Client had no timeout set so non-responsive API
would hold the client forever.