### PR TITLE
Optional base product in package search

### DIFF
--- a/internal/connect/client.go
+++ b/internal/connect/client.go
@@ -281,6 +281,14 @@ func UpgradeProduct(product Product) (Service, error) {
 }
 
 // SearchPackage returns packages which are available in the extensions tree for given base product
-func SearchPackage(query string, baseProduct Product) ([]SearchPackageResult, error) {
-	return searchPackage(query, baseProduct)
+func SearchPackage(query string, baseProd Product) ([]SearchPackageResult, error) {
+	// default to system base product if empty product passed
+	if baseProd.isEmpty() {
+		var err error
+		baseProd, err = baseProduct()
+		if err != nil {
+			return []SearchPackageResult{}, err
+		}
+	}
+	return searchPackage(query, baseProd)
 }


### PR DESCRIPTION
Original code set product default to Zypper.base_product. As Go doesn't
support default parameter values, explicit passing of empty Product will
now fall back to base product from zypper.

This is required by clients to avoid exporting `baseProduct()` function.