### PR TITLE
Switch yast-test to upstream

### DIFF
--- a/Dockerfile.yast
+++ b/Dockerfile.yast
@@ -5,12 +5,11 @@ RUN zypper --no-gpg-checks --non-interactive install 'rubygem(ffi)'
 RUN rm -r /usr/lib64/ruby/gems/*/gems/suse-connect-*
 
 # invalidate github cache
-ADD https://api.github.com/repos/skazi0/yast-registration/git/refs/heads/connect-ng-test-updates version.json
+ADD https://api.github.com/repos/yast/yast-registration/git/refs/heads/master version.json
 
 WORKDIR /yast-registration
 
-#RUN git clone --depth 1 https://github.com/yast/yast-registration.git /yast-registration
-RUN git clone --depth 1 https://github.com/skazi0/yast-registration.git --branch connect-ng-test-updates /yast-registration
+RUN git clone --depth 1 https://github.com/yast/yast-registration.git /yast-registration
 
 COPY out/libsuseconnect.so /usr/lib64
 COPY yast/lib /usr/lib64/ruby/vendor_ruby/2.7.0


### PR DESCRIPTION
YaST testsuite updates were merged so they can be used directly from
master branch instead of fork.