### PR TITLE
Remove dependency on systemd

### DIFF
--- a/internal/connect/hwinfo.go
+++ b/internal/connect/hwinfo.go
@@ -57,9 +57,8 @@ func getHwinfo() (hwinfo, error) {
 	}
 
 	if hw.Arch == archARM {
-		if hw.Hypervisor, err = hypervisor(); err != nil {
-			return hwinfo{}, err
-		}
+		// ignore errors to avoid failing on systems without systemd
+		hw.Hypervisor, _ = hypervisor()
 	}
 
 	if hw.Arch == archS390 {

--- a/suseconnect-ng.spec
+++ b/suseconnect-ng.spec
@@ -51,12 +51,12 @@ Requires:       dmidecode
 %ifarch s390x
 Requires:       s390-tools
 %endif
-Requires:       systemd
 Requires:       zypper
 # lscpu is only used on those
 %ifarch x86_64 aarch64
 Requires:       util-linux
 %endif
+Recommends:     systemd
 
 %description
 This package provides a command line tool for connecting a


### PR DESCRIPTION
This is only needed for detecting hypervisor on arm64. We don't want or
need to install systemd on all systems where SUSEConnect is used.

See https://github.com/SUSE/connect/pull/467 for discussion.