### PR TITLE
Disable HTTP/2

### DIFF
--- a/internal/connect/connection.go
+++ b/internal/connect/connection.go
@@ -86,6 +86,7 @@ func callHTTP(verb, path string, body []byte, query map[string]string, auth auth
 		tr := http.DefaultTransport.(*http.Transport).Clone()
 		tr.TLSClientConfig = &tls.Config{InsecureSkipVerify: CFG.Insecure}
 		tr.Proxy = proxyWithAuth
+		tr.ForceAttemptHTTP2 = false
 		httpclient = &http.Client{Transport: tr, Timeout: 60 * time.Second}
 	}
 	req, err := http.NewRequest(verb, CFG.BaseURL, bytes.NewReader(body))


### PR DESCRIPTION
Old implementation only uses HTTP/1.1. With HTTP/2 enabled requests to
SCC API sometimes fail with "http2: response body closed" error.