### PR TITLE
Simplify parsing JSON error response

### DIFF
--- a/internal/connect/connection.go
+++ b/internal/connect/connection.go
@@ -25,17 +25,17 @@ var (
 
 // parseError returns the error message from a SCC error response
 func parseError(body io.Reader) string {
-	var m map[string]interface{}
-	dec := json.NewDecoder(body)
-	if err := dec.Decode(&m); err == nil {
-		if errMsg, ok := m["localized_error"].(string); ok {
-			return errMsg
-		}
-		if errMsg, ok := m["error"].(string); ok {
-			return errMsg
-		}
+	var errResp struct {
+		Error          string `json:"error"`
+		LocalizedError string `json:"localized_error"`
 	}
-	return ""
+	if err := json.NewDecoder(body).Decode(&errResp); err != nil {
+		return ""
+	}
+	if errResp.LocalizedError != "" {
+		return errResp.LocalizedError
+	}
+	return errResp.Error
 }
 
 func addHeaders(req *http.Request) {


### PR DESCRIPTION
Use anonymous struct instead of empty interfaces and type assertions.