### PR TITLE
Switch from rubygem-ffi to fiddle

### DIFF
--- a/Dockerfile.yast
+++ b/Dockerfile.yast
@@ -1,7 +1,5 @@
 FROM registry.opensuse.org/yast/head/containers/yast-ruby:latest
 
-RUN zypper --no-gpg-checks --non-interactive install 'rubygem(ffi)'
-
 RUN rm -r /usr/lib64/ruby/gems/*/gems/suse-connect-*
 
 # invalidate github cache

--- a/suseconnect-ng.spec
+++ b/suseconnect-ng.spec
@@ -97,7 +97,6 @@ suseconnect-ng functions.
 Summary:        Ruby bindings for libsuseconnect library.
 Group:          System/Management
 Requires:       libsuseconnect
-Requires:       rubygem(ffi)
 %description -n suseconnect-ruby-bindings
 This package provides bindings needed to use libsuseconnect from Ruby scripts.
 

--- a/yast/README.md
+++ b/yast/README.md
@@ -32,7 +32,7 @@ Northbound the shim provides the same interface to Yast as the Ruby SUSEConnect.
 
 YaST passes strings and hashes as parameters. The hashes will be converted to JSON and passed on to libsuseconnect as strings.
 
-Southbound the shim uses the Ruby [FFI](https://github.com/ffi/ffi) (Foreign Function Interface) gem to interface with the C library provided by libsuseconnect. Libsuseconnect will return JSON with the results or error details if there was a problem. The shim will raise an exception if there was an error. Otherwise the results will be returned in whatever form YaST is expecting.
+Southbound the shim uses the Ruby [Fiddle](https://github.com/ruby/fiddle) FFI (Foreign Function Interface) extension to interface with the C library provided by libsuseconnect. Libsuseconnect will return JSON with the results or error details if there was a problem. The shim will raise an exception if there was an error. Otherwise the results will be returned in whatever form YaST is expecting.
 
 Note that generic OpenStruct is used for most structures instead of specific classes like in Ruby SUSEConnect. This should not be a problem because most SUSEConnect structures are anyway based on OpenStruct.
 

--- a/yast/lib/suse/connect/yast.rb
+++ b/yast/lib/suse/connect/yast.rb
@@ -1,38 +1,39 @@
 require 'json'
-require 'ffi'
+require 'fiddle/import'
 require 'suse/toolkit/shim_utils'
 
 module Stdio
-  extend FFI::Library
-  ffi_lib FFI::Platform::LIBC
-  attach_function :free, [ :pointer ], :void
+  extend Fiddle::Importer
+  dlload 'libc.so.6'
+  typealias 'pointer', 'void*'
+  extern 'void free(pointer)'
 end
 
 module GoConnect
-  extend FFI::Library
-  ffi_lib 'suseconnect'
+  extend Fiddle::Importer
+  dlload 'libsuseconnect.so'
+  typealias 'string', 'char*'
 
-  callback :log_line, [:int, :string], :void
-  attach_function :set_log_callback, [:log_line], :void
-
-  attach_function :announce_system, [:string, :string], :pointer
-  attach_function :update_system, [:string, :string], :pointer
-  attach_function :credentials, [:string], :pointer
-  attach_function :create_credentials_file, [:string, :string, :string], :pointer
-  attach_function :curlrc_credentials, [], :pointer
-  attach_function :show_product, [:string, :string], :pointer
-  attach_function :activated_products, [:string], :pointer
-  attach_function :activate_product, [:string, :string, :string], :pointer
-  attach_function :get_config, [:string], :pointer
-  attach_function :write_config, [:string], :pointer
-  attach_function :update_certificates, [], :pointer
-  attach_function :list_installer_updates, [:string, :string], :pointer
-  attach_function :system_migrations, [:string, :string], :pointer
-  attach_function :offline_system_migrations, [:string, :string, :string], :pointer
-  attach_function :upgrade_product, [:string, :string], :pointer
-  attach_function :synchronize, [:string, :string], :pointer
-  attach_function :system_activations, [:string], :pointer
-  attach_function :search_package, [:string, :string, :string], :pointer
+  #callback type: void log_line(int, string)
+  extern 'void set_log_callback(void*)'
+  extern 'string announce_system(string, string)'
+  extern 'string update_system(string, string)'
+  extern 'string credentials(string)'
+  extern 'string create_credentials_file(string, string, string)'
+  extern 'string curlrc_credentials()'
+  extern 'string show_product(string, string)'
+  extern 'string activated_products(string)'
+  extern 'string activate_product(string, string, string)'
+  extern 'string get_config(string)'
+  extern 'string write_config(string)'
+  extern 'string update_certificates()'
+  extern 'string list_installer_updates(string, string)'
+  extern 'string system_migrations(string, string)'
+  extern 'string offline_system_migrations(string, string, string)'
+  extern 'string upgrade_product(string, string)'
+  extern 'string synchronize(string, string)'
+  extern 'string system_activations(string)'
+  extern 'string search_package(string, string, string)'
 end
 
 module SUSE

--- a/yast/lib/suse/toolkit/shim_utils.rb
+++ b/yast/lib/suse/toolkit/shim_utils.rb
@@ -18,8 +18,8 @@ module SUSE
       end
 
       def _consume_str(ptr)
-        s = ptr.get_string(0)
-        Stdio.free(ptr)
+        s = ptr.to_s()
+        Stdio.free(ptr.to_i)
         return s
       end
 


### PR DESCRIPTION
Fiddle is an FFI implementation which is included in standard Ruby.
Switching from FFI gem to Fiddle removes one dependency without loosing
any functionality.