### PR TITLE
Add flag to import product repo keys (bsc#1174657)

### DIFF
--- a/DIFFERENCES.md
+++ b/DIFFERENCES.md
@@ -55,3 +55,4 @@
   for all expected OpenSSL error cases.
 - In some cases (e.g. when some of intermediate certs in chain is invalid)
   the SSL cert presented to the user will be different than in Ruby version.
+- SUSEConnect has new option --gpg-auto-import-keys (fixes bsc#1174657).

--- a/internal/connect/config.go
+++ b/internal/connect/config.go
@@ -34,7 +34,9 @@ type Config struct {
 	Product          Product
 	InstanceDataFile string
 	Email            string `json:"email"`
-	NoZypperRefresh  bool
+
+	NoZypperRefresh    bool
+	AutoImportRepoKeys bool
 }
 
 // NewConfig returns a Config with defaults

--- a/internal/connect/zypper.go
+++ b/internal/connect/zypper.go
@@ -215,6 +215,10 @@ func InstallReleasePackage(identifier string) error {
 	args = []string{"--no-refresh", "--non-interactive", "install", "--no-recommends",
 		"--auto-agree-with-product-licenses", "-t", "product", identifier}
 
+	if CFG.AutoImportRepoKeys {
+		args = append([]string{"--gpg-auto-import-keys"}, args...)
+	}
+
 	_, err := zypperRun(args, validExitCodes)
 	return err
 }
@@ -256,13 +260,13 @@ func zypperFlags(version string, quiet bool, verbose bool,
 }
 
 // RefreshRepos runs zypper to refresh all repositories
-func RefreshRepos(version string, force, quiet, verbose, nonInteractive, importKeys bool) error {
+func RefreshRepos(version string, force, quiet, verbose, nonInteractive bool) error {
 	args := []string{"ref"}
 	flags := zypperFlags(version, quiet, verbose, nonInteractive, false)
 	if force {
 		args = append(args, "-f")
 	}
-	if importKeys {
+	if CFG.AutoImportRepoKeys {
 		args = append(args, "--gpg-auto-import-keys")
 	}
 	args = append(flags, args...)

--- a/suseconnect/connectUsage.txt
+++ b/suseconnect/connectUsage.txt
@@ -47,5 +47,8 @@ Manage subscriptions at https://scc.suse.com
 Common options:
         --root [PATH]        Path to the root folder, uses the same parameter
                              for zypper.
+        --gpg-auto-import-keys
+                             Automatically trust and import new repository
+                             signing keys.
         --debug              Provide debug output.
     -h, --help               Show this message.

--- a/suseconnect/migration.go
+++ b/suseconnect/migration.go
@@ -58,7 +58,6 @@ func migrationMain() {
 		breakMySystem            bool
 		query                    bool
 		disableRepos             bool
-		autoImportKeys           bool
 		failDupOnlyOnFatalErrors bool
 		migrationNum             int
 		fsRoot                   string
@@ -87,7 +86,7 @@ func migrationMain() {
 	flag.BoolVar(&breakMySystem, "break-my-system", false, "")
 	flag.BoolVar(&query, "query", false, "")
 	flag.BoolVar(&disableRepos, "disable-repos", false, "")
-	flag.BoolVar(&autoImportKeys, "gpg-auto-import-keys", false, "")
+	flag.BoolVar(&connect.CFG.AutoImportRepoKeys, "gpg-auto-import-keys", false, "")
 	flag.BoolVar(&failDupOnlyOnFatalErrors, "strict-errors-dist-migration", false, "")
 	flag.IntVar(&migrationNum, "migration", 0, "")
 	flag.StringVar(&fsRoot, "root", "", "")
@@ -194,7 +193,7 @@ func migrationMain() {
 
 	// This is only necessary, if we run with --root option
 	echo := connect.SetSystemEcho(true)
-	if err := connect.RefreshRepos("", false, quiet, verbose, nonInteractive, autoImportKeys); err != nil {
+	if err := connect.RefreshRepos("", false, quiet, verbose, nonInteractive); err != nil {
 		fmt.Println("repository refresh failed, exiting")
 		os.Exit(1)
 	}
@@ -680,7 +679,7 @@ func applyMigration(migration connect.MigrationPath, systemProducts []connect.Pr
 	}
 
 	echo := connect.SetSystemEcho(true)
-	if err := connect.RefreshRepos(baseProductVersion, true, false, false, false, false); err != nil {
+	if err := connect.RefreshRepos(baseProductVersion, true, false, false, false); err != nil {
 		return fsInconsistent, fmt.Errorf("Refresh of repositories failed: %v", err)
 	}
 	if interrupted {

--- a/suseconnect/suseconnect.go
+++ b/suseconnect/suseconnect.go
@@ -66,6 +66,7 @@ func connectMain() {
 	flag.BoolVar(&listExtensions, "list-extensions", false, "")
 	flag.BoolVar(&rollback, "rollback", false, "")
 	flag.BoolVar(&version, "version", false, "")
+	flag.BoolVar(&connect.CFG.AutoImportRepoKeys, "gpg-auto-import-keys", false, "")
 	flag.StringVar(&baseURL, "url", "", "")
 	flag.StringVar(&fsRoot, "root", "", "")
 	flag.StringVar(&namespace, "namespace", "", "")


### PR DESCRIPTION
When registering products with 3rd party GPG repo keys there was no
option to accept them inside SUSEConnect.
This change adds CLI option to make SUSEConnect auto-import new keys.

Code was refactored to unify with similar function in zypper-migration.