### PR TITLE
Suppress expected error log message in TLS test

### DIFF
--- a/internal/connect/connection_test.go
+++ b/internal/connect/connection_test.go
@@ -9,6 +9,7 @@ import (
 
 func TestCallHTTPSecure(t *testing.T) {
 	ts := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	ts.Config.ErrorLog = Debug
 	ts.StartTLS()
 	defer ts.Close()
 


### PR DESCRIPTION
Stop printing this handshake error message from the test server:

$ go test -v ./internal/connect/ -run TestCallHTTPSecure
=== RUN   TestCallHTTPSecure
2022/01/12 09:59:13 http: TLS handshake error from 127.0.0.1:45444: remote error: tls: bad certificate
--- PASS: TestCallHTTPSecure (0.02s)