### PR TITLE
Pass "insecure" to zypper addservice

### DIFF
--- a/internal/connect/zypper.go
+++ b/internal/connect/zypper.go
@@ -3,6 +3,7 @@ package connect
 import (
 	"encoding/xml"
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -146,6 +147,18 @@ func addService(serviceURL, serviceName string, refresh bool) error {
 	// Remove old service which could be modified by a customer
 	if err := removeService(serviceName); err != nil {
 		return err
+	}
+	// pass "insecure" setting to zypper via URL
+	// https://en.opensuse.org/openSUSE:Libzypp_URIs
+	if CFG.Insecure {
+		u, err := url.Parse(serviceURL)
+		if err != nil {
+			return err
+		}
+		q := u.Query()
+		q.Set("ssl_verify", "no")
+		u.RawQuery = q.Encode()
+		serviceURL = u.String()
 	}
 	args := []string{"--non-interactive", "addservice", "-t", "ris", serviceURL, serviceName}
 	_, err := zypperRun(args, []int{zypperOK})


### PR DESCRIPTION
In insecure mode zypper calls can still fail because of untrusted certs.
The cert checks can be disabled by adding ssl_verify=no argument to URLs.
Service adding was the first case where this was found. Maybe more will be needed.

Steps to reproduce:
1. set `insecure: true` in `/etc/SUSEConnect`.
2. `suseconnect --url https://migration-smt2.qa.suse.de/`