### PR TITLE
Delegate free() calls back to Go (bsc#1195729)

### DIFF
--- a/libsuseconnect/libsuseconnect.go
+++ b/libsuseconnect/libsuseconnect.go
@@ -51,6 +51,11 @@ func set_log_callback(logCallback C.logLineFunc) {
 	// TODO: add other levels?
 }
 
+//export free_string
+func free_string(str *C.char) {
+	C.free(unsafe.Pointer(str))
+}
+
 //export announce_system
 func announce_system(clientParams, distroTarget *C.char) *C.char {
 	loadConfig(C.GoString(clientParams))

--- a/yast/lib/suse/connect/yast.rb
+++ b/yast/lib/suse/connect/yast.rb
@@ -2,13 +2,6 @@ require 'json'
 require 'fiddle/import'
 require 'suse/toolkit/shim_utils'
 
-module Stdio
-  extend Fiddle::Importer
-  dlload 'libc.so.6'
-  typealias 'pointer', 'void*'
-  extern 'void free(pointer)'
-end
-
 module GoConnect
   extend Fiddle::Importer
   dlload 'libsuseconnect.so'
@@ -16,6 +9,7 @@ module GoConnect
 
   #callback type: void log_line(int, string)
   extern 'void set_log_callback(void*)'
+  extern 'void free_string(string)'
   extern 'string announce_system(string, string)'
   extern 'string update_system(string, string)'
   extern 'string credentials(string)'

--- a/yast/lib/suse/toolkit/shim_utils.rb
+++ b/yast/lib/suse/toolkit/shim_utils.rb
@@ -19,7 +19,7 @@ module SUSE
 
       def _consume_str(ptr)
         s = ptr.to_s()
-        Stdio.free(ptr.to_i)
+        GoConnect.free_string(ptr.to_i)
         return s
       end
 


### PR DESCRIPTION
Direct import from libc causes problems when custom malloc
implementation like jemalloc is used. Passing the pointer back to Go
seems to be the safest way to handle memory management as both
allocation and freeing is done on the same side and there is no explicit
imports.