### PR TITLE
Fix product tree traversal (bsc#1197398)

### DIFF
--- a/internal/connect/client.go
+++ b/internal/connect/client.go
@@ -70,7 +70,9 @@ func registerProductTree(product Product) error {
 			if err := registerProduct(extension, true); err != nil {
 				return err
 			}
-			return registerProductTree(extension)
+			if err := registerProductTree(extension); err != nil {
+				return err
+			}
 		}
 	}
 	return nil


### PR DESCRIPTION
The tree registration was going only until first hit, possibly missing
some branches.