### PR TITLE
go1.18 compatibility: export GOFLAGS="-buildvcs=false" 

### DIFF
--- a/suseconnect-ng.spec
+++ b/suseconnect-ng.spec
@@ -30,6 +30,7 @@ Summary:        Utility to register a system with the SUSE Customer Center
 Group:          System/Management
 Source:         connect-ng-%{version}.tar.xz
 Source1:        %name-rpmlintrc
+BuildRequires:  git
 BuildRequires:  golang-packaging
 BuildRequires:  go >= 1.16
 BuildRequires:  zypper


### PR DESCRIPTION
PR to RPM spec file for go1.18 compatibility: export GOFLAGS="-buildvcs=false" in sections %build and %check.

Closes #128.

After go1.18.1 a follow-up PR to #128 will remove the export in %check (go test).
