### PR TITLE
Allow reloading CA certs pool (bsc#1195220)

### DIFF
--- a/internal/connect/connection.go
+++ b/internal/connect/connection.go
@@ -148,7 +148,7 @@ func callHTTP(verb, path string, body []byte, query map[string]string, auth auth
 	return resBody, nil
 }
 
-func reloadCertPool() error {
+func ReloadCertPool() error {
 	// TODO: update when https://github.com/golang/go/issues/41888 is fixed
 	httpclient = nil
 	setupHTTPClient()

--- a/internal/connect/system.go
+++ b/internal/connect/system.go
@@ -122,5 +122,5 @@ func UpdateCertificates() error {
 		return err
 	}
 	// reload CA certs in Go
-	return reloadCertPool()
+	return ReloadCertPool()
 }

--- a/libsuseconnect/libsuseconnect.go
+++ b/libsuseconnect/libsuseconnect.go
@@ -296,6 +296,15 @@ func update_certificates() *C.char {
 	return C.CString("{}")
 }
 
+//export reload_certificates
+func reload_certificates() *C.char {
+	err := connect.ReloadCertPool()
+	if err != nil {
+		return C.CString(errorToJSON(err))
+	}
+	return C.CString("{}")
+}
+
 //export list_installer_updates
 func list_installer_updates(clientParams, product *C.char) *C.char {
 	loadConfig(C.GoString(clientParams))

--- a/yast/lib/suse/connect/ssl_certificate.rb
+++ b/yast/lib/suse/connect/ssl_certificate.rb
@@ -33,6 +33,12 @@ module SUSE
         _process_result(GoConnect.update_certificates())
       end
 
+      # reload internal CA cert pool
+      def self.reload
+        log.debug "Reloading Golang CA cert pool..."
+        _process_result(GoConnect.reload_certificates())
+      end
+
       # @param digest_class [Class] target digest class (e.g. OpenSSL::Digest::SHA1)
       # @param cert [OpenSSL::X509::Certificate] the certificate
       # @return [String] digest in "AB:CD:EF:..." format

--- a/yast/lib/suse/connect/yast.rb
+++ b/yast/lib/suse/connect/yast.rb
@@ -21,6 +21,7 @@ module GoConnect
   extern 'string get_config(string)'
   extern 'string write_config(string)'
   extern 'string update_certificates()'
+  extern 'string reload_certificates()'
   extern 'string list_installer_updates(string, string)'
   extern 'string system_migrations(string, string)'
   extern 'string offline_system_migrations(string, string, string)'


### PR DESCRIPTION
Export function to allow explicit reloading of certs after chaning them on disk outside of SUSEConnect.