### PR TITLE
WIP: fix migration against SMT (bsc#1198625)

### DIFF
--- a/internal/connect/api_test.go
+++ b/internal/connect/api_test.go
@@ -267,3 +267,25 @@ func TestProductMigrations(t *testing.T) {
 		t.Fatalf("len(migrations) == %d, expected 2", len(migrations))
 	}
 }
+
+func TestProductMigrationsSMT(t *testing.T) {
+	createTestCredentials("", "", t)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write(readTestFile("migrations-smt.json", t))
+	}))
+	defer ts.Close()
+	CFG.BaseURL = ts.URL
+
+	migrations, err := productMigrations(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(migrations) != 1 {
+		t.Fatalf("len(migrations) == %d, expected 1", len(migrations))
+	}
+	gotID := migrations[0][0].ID
+	expectedID := 101361
+	if gotID != expectedID {
+		t.Fatalf("Got ID: %d, expected: %d", gotID, expectedID)
+	}
+}

--- a/internal/connect/product_test.go
+++ b/internal/connect/product_test.go
@@ -129,3 +129,45 @@ func TestSplitTriplet(t *testing.T) {
 		t.Fatal("Expected error, got nil")
 	}
 }
+
+func TestFindIDInt(t *testing.T) {
+	jsn := `{"id": 101361}`
+	var p Product
+	err := json.Unmarshal([]byte(jsn), &p)
+	if err != nil {
+		t.Fatalf("Error: %v", err)
+	}
+	if p.ID != 101361 {
+		t.Errorf("Expected: %d, got: %d", 101361, p.ID)
+	}
+}
+
+func TestFindIDString(t *testing.T) {
+	jsn := `{"id": "101361"}`
+	var p Product
+	err := json.Unmarshal([]byte(jsn), &p)
+	if err != nil {
+		t.Fatalf("Error: %v", err)
+	}
+	if p.ID != 101361 {
+		t.Errorf("Expected: %d, got: %d", 101361, p.ID)
+	}
+}
+
+func TestMarshallProductIntID(t *testing.T) {
+	p1 := Product{ID: 42}
+	jsn, err := json.Marshal(&p1)
+	if err != nil {
+		t.Fatalf("Error: %v", err)
+	}
+
+	p2 := Product{}
+	err = json.Unmarshal([]byte(jsn), &p2)
+	if err != nil {
+		t.Fatalf("Error: %v", err)
+	}
+
+	if p1.ID != p2.ID {
+		t.Errorf("Expected: %d, got: %d", p1.ID, p2.ID)
+	}
+}

--- a/testdata/migrations-smt.json
+++ b/testdata/migrations-smt.json
@@ -1,0 +1,23 @@
+[
+  [
+    {
+      "product_type": "base",
+      "identifier": "suse-microos",
+      "release_stage": "released",
+      "free": true,
+      "productdataid": "2401",
+      "available": true,
+      "friendly_name": "SUSE Linux Enterprise Micro 5.2 x86_64",
+      "product_class": "MICROOS-X86",
+      "base": true,
+      "description": "SUSE Linux Enterprise Micro 5.2",
+      "shortname": "SUSE Linux Enterprise Micro",
+      "id": "101361",
+      "product_orig": "SUSE-MicroOS",
+      "release_type": null,
+      "cpe": "cpe:/o:suse:suse-microos:5.2",
+      "arch": "x86_64",
+      "version": "5.2"
+    }
+  ]
+]


### PR DESCRIPTION
We are using the Product struct to unmarshall in the
POST /connect/systems/products/migrations call.

SMT add an "id" field with type string. SCC and RMT don't
return this field in the same call. But other places (yast?)
needs this field, but as type int.

This fixes it in the custom unmarshaller, but then a custom
marshaller was needed also.

Maybe better to create a Migration struct with just the fields we
need, then the migrations code can create []Product from that.