### PR TITLE
Some cleanups

### DIFF
--- a/internal/connect/connection.go
+++ b/internal/connect/connection.go
@@ -97,13 +97,6 @@ func setupHTTPClient() {
 
 func callHTTP(verb, path string, body []byte, query map[string]string, auth authType) ([]byte, error) {
 	setupHTTPClient()
-	if httpclient == nil {
-		// use defaults from DefaultTransport
-		tr := http.DefaultTransport.(*http.Transport).Clone()
-		tr.TLSClientConfig = &tls.Config{InsecureSkipVerify: CFG.Insecure}
-		tr.Proxy = proxyWithAuth
-		httpclient = &http.Client{Transport: tr, Timeout: 60 * time.Second}
-	}
 	req, err := http.NewRequest(verb, CFG.BaseURL, bytes.NewReader(body))
 	if err != nil {
 		return nil, err
@@ -148,6 +141,7 @@ func callHTTP(verb, path string, body []byte, query map[string]string, auth auth
 	return resBody, nil
 }
 
+// ReloadCertPool triggers reload of internals CA cert pool
 func ReloadCertPool() error {
 	// TODO: update when https://github.com/golang/go/issues/41888 is fixed
 	httpclient = nil

--- a/suseconnect-ng.spec
+++ b/suseconnect-ng.spec
@@ -30,7 +30,6 @@ Summary:        Utility to register a system with the SUSE Customer Center
 Group:          System/Management
 Source:         connect-ng-%{version}.tar.xz
 Source1:        %name-rpmlintrc
-BuildRequires:  git
 BuildRequires:  golang-packaging
 BuildRequires:  go >= 1.16
 BuildRequires:  zypper
@@ -103,6 +102,8 @@ This package provides bindings needed to use libsuseconnect from Ruby scripts.
 
 %prep
 %setup -q -n connect-ng-%{version}
+# keep git metadata but don't use it for "VCS stamping"
+mv .git .git.bak
 
 %build
 find %_builddir/..

--- a/yast/lib/suse/toolkit/shim_utils.rb
+++ b/yast/lib/suse/toolkit/shim_utils.rb
@@ -1,3 +1,5 @@
+require 'openssl'
+
 module SUSE
   module Toolkit
     # This module implements common boilerplate for wrapping libsuseconnect


### PR DESCRIPTION
* Remove redundant code + add comment
This was moved to setupHTTPClient().
Add missing comment for exported function.
* Add missing import
This is needed for _check_error().
*  Fix "VCS stamping" problem
Go1.18+ embeds some additional info if it finds VCS directories in sources (e.g. .git). If git metadata is broken or incomplete, the build can fail. Renaming .git to .git.bak keeps the metadata in tarball but "hides" it from the go commands.
Also remove "BuildRequires: git" which was supposed to solve above problem.
