### PR TITLE
Switch to jenkins-hosted credentials

### DIFF
--- a/integration/Dockerfile.ng-sle15sp3
+++ b/integration/Dockerfile.ng-sle15sp3
@@ -20,8 +20,8 @@ RUN zypper ar http://download.suse.de/ibs/SUSE/Products/SLE-Module-Basesystem/15
       vim osc hwinfo libx86emu3 zypper-migration-plugin sudo awk curl \
       obs-service-tar_scm obs-service-recompress obs-service-extract_file obs-service-set_version obs-service-format_spec_file
 
-RUN wget http://username:password@gaffer.suse.de:9999/files/.regcode -O ~/.regcode
-RUN wget http://username:password@gaffer.suse.de:9999/files/.oscrc -O ~/.oscrc
+RUN wget --no-check-certificate https://ci.suse.de/job/scc-connect-ng-config/lastBuild/artifact/.regcodes -O ~/.regcodes
+RUN wget --no-check-certificate https://ci.suse.de/job/scc-connect-ng-config/lastBuild/artifact/.oscrc -O ~/.oscrc
 
 RUN echo 'gem: --no-ri --no-rdoc' > /etc/gemrc && \
     gem install bundler --no-document

--- a/integration/run.sh
+++ b/integration/run.sh
@@ -13,7 +13,7 @@ remote=$(pwd)
 head=$(git rev-list -n1 HEAD)
 mkdir osc-package
 cd osc-package
-osc co -o . 'systemsmanagement:SCC/suseconnect-ng'
+osc -A https://api.opensuse.org co -o . 'systemsmanagement:SCC/suseconnect-ng'
 cp ../_service ./
 sed -i "s|https://github.com/SUSE/connect-ng.git|file://$remote|g" _service
 sed -i "s|main|$head|g" _service
@@ -37,4 +37,8 @@ cd /tmp/connect
 rm bin/SUSEConnect
 # the tests match the exact version defined in the ruby code, replace it with ours
 sed -i "s|VERSION = '[^']*'|VERSION = '$shortversion'|g" lib/suse/connect/version.rb
+# load test regcodes into env vars
+set -a
+. ~/.regcodes
+set +a
 cucumber


### PR DESCRIPTION
Update CI setup to match changes from ruby version:
https://github.com/SUSE/connect/pull/481.

The config files with credentials and test regcodes are served from
Jenkins as archived artifacts of a special job created for this.
This job can be re-built with different parameters to update contents of
those config files.

The .regcodes file replaces .regcode and contains list of env variables
with values which can be sourced or e.g. passed to docker via --env-file.