### PR TITLE
Add option to run local scc tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 out
 internal/connect/version.txt
+connect-ruby

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,13 @@ test: internal/connect/version.txt
 test-yast: build-so
 	docker build -t go-connect-test-yast -f Dockerfile.yast . && docker run -t go-connect-test-yast
 
+test-scc: connect-ruby
+	docker build -t connect.ng-sle15sp3 -f integration/Dockerfile.ng-sle15sp3 .
+	docker run --privileged --rm -t connect.ng-sle15sp3 ./integration/run.sh
+
+connect-ruby:
+	git clone https://github.com/SUSE/connect connect-ruby
+
 gofmt:
 	@if [ ! -z "$$(gofmt -l ./)" ]; then echo "Formatting errors..."; gofmt -d ./; exit 1; fi
 

--- a/integration/Dockerfile.ng-sle15sp3
+++ b/integration/Dockerfile.ng-sle15sp3
@@ -3,8 +3,6 @@ FROM registry.suse.de/suse/sle-15-sp3/update/standard/suse/sle15:15.3
 ENV PRODUCT SLE_15_SP3
 ENV BUILT_AT "Tue Jul 13 15:32 CET 2021"
 
-RUN useradd --no-log-init --create-home scc
-
 # Remember to drop docker caches if any of these change
 RUN zypper ar http://download.suse.de/ibs/SUSE/Products/SLE-Module-Basesystem/15-SP3/x86_64/product base &&\
     zypper ar http://download.suse.de/ibs/SUSE/Updates/SLE-Module-Basesystem/15-SP3/x86_64/update base-updates &&\
@@ -35,10 +33,8 @@ ADD connect-ruby/lib/suse/connect/version.rb ./lib/suse/connect/
 RUN bundle config jobs $(nproc) && \
     bundle install
 ADD connect-ruby/. /tmp/connect
-RUN chown -R scc /tmp/connect
 
 
 RUN mkdir /tmp/connect-ng
 WORKDIR /tmp/connect-ng
 ADD . /tmp/connect-ng
-RUN chown -R scc /tmp/connect-ng


### PR DESCRIPTION
This will run cross-tests from ruby-connect using suseconnect-ng
replacement parts similar to what is done in the CI.