### PR TITLE
Add keepalive cmd

### DIFF
--- a/internal/connect/client.go
+++ b/internal/connect/client.go
@@ -200,6 +200,18 @@ func UpdateSystem(distroTarget, instanceDataFile string) error {
 	return updateSystem(sysInfoBody)
 }
 
+// SendKeepAlivePing updates the system information on the server
+func SendKeepAlivePing() error {
+	if !IsRegistered() {
+		return ErrPingFromUnregistered
+	}
+	err := UpdateSystem("", "")
+	if err == nil {
+		Info.Print(bold(greenText("\nSuccessfully updated system")))
+	}
+	return err
+}
+
 // announceOrUpdate Announces the system to the server, receiving and storing its
 // credentials. When already announced, sends the current hardware details to the server
 func announceOrUpdate() error {

--- a/internal/connect/errors.go
+++ b/internal/connect/errors.go
@@ -11,6 +11,7 @@ var (
 	ErrMalformedSccCredFile       = errors.New("Cannot parse credentials file")
 	ErrMissingCredentialsFile     = errors.New("Credentials file is missing")
 	ErrSystemNotRegistered        = errors.New("System not registered")
+	ErrPingFromUnregistered       = errors.New("Keepalive ping not allowed from unregistered system.")
 	ErrBaseProductDeactivation    = errors.New("Unable to deactivate base product")
 	ErrCannotDetectBaseProduct    = errors.New("Unable to detect base product")
 	ErrListExtensionsUnregistered = errors.New("System not registered")

--- a/suseconnect/connectUsage.txt
+++ b/suseconnect/connectUsage.txt
@@ -35,6 +35,7 @@ Manage subscriptions at https://scc.suse.com
                              format.
         --status-text        Get current system registration status in text
                              format.
+        --keepalive          Sends data to SCC to update the system information.
     -l, --list-extensions    List all extensions and modules available for
                              installation on this system.
         --write-config       Write options to config file at /etc/SUSEConnect.

--- a/suseconnect/suseconnect.go
+++ b/suseconnect/suseconnect.go
@@ -35,6 +35,7 @@ func main() {
 func connectMain() {
 	var (
 		status           bool
+		keepAlive        bool
 		statusText       bool
 		debug            bool
 		writeConfig      bool
@@ -60,6 +61,7 @@ func connectMain() {
 	flag.BoolVar(&status, "status", false, "")
 	flag.BoolVar(&status, "s", false, "")
 	flag.BoolVar(&statusText, "status-text", false, "")
+	flag.BoolVar(&keepAlive, "keepalive", false, "")
 	flag.BoolVar(&debug, "debug", false, "")
 	flag.BoolVar(&writeConfig, "write-config", false, "")
 	flag.BoolVar(&deRegister, "de-register", false, "")
@@ -140,6 +142,9 @@ func connectMain() {
 		output, err := connect.GetProductStatuses("json")
 		exitOnError(err)
 		fmt.Println(output)
+	} else if keepAlive {
+		err := connect.SendKeepAlivePing()
+		exitOnError(err)
 	} else if statusText {
 		output, err := connect.GetProductStatuses("text")
 		exitOnError(err)
@@ -240,6 +245,10 @@ func exitOnError(err error) {
 		fmt.Print("Can not deregister base product. Use SUSEConnect -d to deactivate ")
 		fmt.Print("the whole system.\n")
 		os.Exit(70)
+	case connect.ErrPingFromUnregistered:
+		fmt.Print("Error sending keepalive: ")
+		fmt.Print("System is not registered. Use the --regcode parameter to register it.\n")
+		os.Exit(71)
 	default:
 		fmt.Printf("SUSEConnect error: %s\n", err)
 		os.Exit(1)


### PR DESCRIPTION
## How to test

We need to run a golang suse container to test the keepalive cmd

```bash
> docker pull registry.suse.com/bci/golang:1.18
> docker run -it --rm -v "$PWD":/usr/src/myapp -w /usr/src/myapp registry.suse.com/bci/golang:1.18
# inside container
> git config --global --add safe.directory /usr/src/myapp && make

# First case, unregisted system 
> ./out/suseconnect --keepalive
# Should print out an error

# Second case
> ./out/suseconnect -r C6B55B64D68F9997 && ./out/suseconnect --keepalive
# should print a success message

```