### PR TITLE
Print nested zypper errors (bsc#1200803)

### DIFF
--- a/internal/connect/errors.go
+++ b/internal/connect/errors.go
@@ -36,11 +36,12 @@ type ZypperError struct {
 	Commmand []string
 	ExitCode int
 	Output   []byte
+	Err      error
 }
 
 func (ze ZypperError) Error() string {
-	return fmt.Sprintf("command '%s' failed\nError: zypper returned %d with '%s'",
-		strings.Join(ze.Commmand, " "), ze.ExitCode, ze.Output)
+	return fmt.Sprintf("command '%s' failed\nError: zypper returned %d with '%s' (%s)",
+		strings.Join(ze.Commmand, " "), ze.ExitCode, ze.Output, ze.Err)
 }
 
 // APIError is returned on failed HTTP requests

--- a/internal/connect/zypper.go
+++ b/internal/connect/zypper.go
@@ -47,7 +47,7 @@ func zypperRun(args []string, validExitCodes []int) ([]byte, error) {
 	output, err := execute(cmd, validExitCodes)
 	if err != nil {
 		if ee, ok := err.(ExecuteError); ok {
-			return nil, ZypperError{Commmand: ee.Commmand, ExitCode: ee.ExitCode, Output: ee.Output}
+			return nil, ZypperError(ee)
 		}
 	}
 	return output, nil


### PR DESCRIPTION
If zypper fails with no output and no meaningful exit code, sometimes the nested error has some important details.

Example: '/usr/bin/zypper: no such file or directory' was returned as `Error: zypper returned -1 with ''` now it will be `Error: zypper returned -1 with '' (fork/exec /usr/bin/zypper: no such file or directory)`