### PR TITLE
Added support for the System-Token header

### DIFF
--- a/internal/connect/api.go
+++ b/internal/connect/api.go
@@ -14,13 +14,13 @@ func announceSystem(body []byte) (string, string, error) {
 		return "", "", err
 	}
 	var creds struct {
-		Login     string `json:"login"`
-		Passoword string `json:"password"`
+		Login    string `json:"login"`
+		Password string `json:"password"`
 	}
 	if err = json.Unmarshal(resp, &creds); err != nil {
 		return "", "", JSONError{err}
 	}
-	return creds.Login, creds.Passoword, nil
+	return creds.Login, creds.Password, nil
 }
 
 func upToDate() bool {

--- a/internal/connect/api_test.go
+++ b/internal/connect/api_test.go
@@ -8,8 +8,11 @@ import (
 )
 
 func TestAnnounceSystem(t *testing.T) {
+	createTestCredentials("", "", t)
+
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("System-Token", "token")
 		io.WriteString(w, `{"login":"test-user","password":"test-password"}`)
 	}))
 	defer ts.Close()
@@ -24,6 +27,15 @@ func TestAnnounceSystem(t *testing.T) {
 	}
 	if password != "test-password" {
 		t.Errorf("Expected password: \"test-password\", got: \"%s\"", password)
+	}
+
+	// System token should have been updated.
+	creds, err := getCredentials()
+	if err != nil {
+		t.Fatalf("Unexpected error: %s", err)
+	}
+	if creds.SystemToken != "token" {
+		t.Fatalf("Unexpected token '%v', should have been 'token'", creds.SystemToken)
 	}
 }
 

--- a/internal/connect/client.go
+++ b/internal/connect/client.go
@@ -227,7 +227,7 @@ func announceOrUpdate() error {
 	if err != nil {
 		return err
 	}
-	return writeSystemCredentials(login, password)
+	return writeSystemCredentials(login, password, "")
 }
 
 // IsRegistered returns true if there is a valid credentials file

--- a/internal/connect/credentials_test.go
+++ b/internal/connect/credentials_test.go
@@ -12,9 +12,9 @@ func TestParseCredentials(t *testing.T) {
 		expectCreds Credentials
 		expectErr   error
 	}{
-		{"username=user1\npassword=pass1", Credentials{"", "user1", "pass1"}, nil},
-		{" \n username = user1 \n password = pass1 \n", Credentials{"", "user1", "pass1"}, nil},
-		{"username = user1 \n junk \n password = pass1 \n", Credentials{"", "user1", "pass1"}, nil},
+		{"username=user1\npassword=pass1", Credentials{"", "user1", "pass1", ""}, nil},
+		{" \n username = user1 \n password = pass1 \nsystem_token=\n", Credentials{"", "user1", "pass1", ""}, nil},
+		{"username = user1 \n junk \n password = pass1 \nsystem_token=1234", Credentials{"", "user1", "pass1", "1234"}, nil},
 		{"USERNAME = user1 \n passed = pass1", Credentials{}, ErrMalformedSccCredFile},
 		{"username= \n password = \n", Credentials{}, ErrMalformedSccCredFile},
 	}
@@ -33,14 +33,14 @@ func TestWriteReadDeleteSystem(t *testing.T) {
 	if err != ErrMissingCredentialsFile {
 		t.Fatalf("Expected [%s], got [%s]", ErrMissingCredentialsFile, err)
 	}
-	if err := writeSystemCredentials("user1", "pass1"); err != nil {
+	if err := writeSystemCredentials("user1", "pass1", "1234"); err != nil {
 		t.Fatalf("Unexpected error: %s", err)
 	}
 	c, err := getCredentials()
 	if err != nil {
 		t.Fatalf("Unexpected error: %s", err)
 	}
-	if c.Username != "user1" || c.Password != "pass1" {
+	if c.Username != "user1" || c.Password != "pass1" || c.SystemToken != "1234" {
 		t.Errorf("Unexpected user1 and pass1. Got: %s and %s",
 			c.Username, c.Password)
 	}
@@ -55,10 +55,10 @@ func TestWriteReadDeleteSystem(t *testing.T) {
 
 func TestWriteCredentials(t *testing.T) {
 	CFG.FsRoot = t.TempDir()
-	if err := writeSystemCredentials("user1", "pass1"); err != nil {
+	if err := writeSystemCredentials("user1", "pass1", "1234"); err != nil {
 		t.Fatalf("Unexpected error: %s", err)
 	}
-	expected := "username=user1\npassword=pass1\n"
+	expected := "username=user1\npassword=pass1\nsystem_token=1234\n"
 	contents, _ := os.ReadFile(systemCredentialsFile())
 	got := string(contents)
 	if got != expected {
@@ -68,7 +68,7 @@ func TestWriteCredentials(t *testing.T) {
 
 func TestWriteReadDeleteService(t *testing.T) {
 	CFG.FsRoot = t.TempDir()
-	if err := writeSystemCredentials("user1", "pass1"); err != nil {
+	if err := writeSystemCredentials("user1", "pass1", "1234"); err != nil {
 		t.Fatalf("Unexpected error: %s", err)
 	}
 	if err := writeServiceCredentials("service1"); err != nil {
@@ -79,7 +79,7 @@ func TestWriteReadDeleteService(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected error: %s", err)
 	}
-	if rc.Username != "user1" || rc.Password != "pass1" {
+	if rc.Username != "user1" || rc.Password != "pass1" || rc.SystemToken != "1234" {
 		t.Errorf("Got: %s and %s, expected user1 and pass1", rc.Username, rc.Password)
 	}
 	if err := removeServiceCredentials("service1"); err != nil {
@@ -96,10 +96,10 @@ func TestParseCurlrcCredentials(t *testing.T) {
 		expectCreds Credentials
 		expectErr   error
 	}{
-		{"--proxy-user \"meuser1$:mepassord2%\"", Credentials{"", "meuser1$", "mepassord2%"}, nil},
-		{"--proxy-user = \"meuser1$:mepassord2%\"", Credentials{"", "meuser1$", "mepassord2%"}, nil},
-		{"proxy-user = \"meuser1$:mepassord2%\"", Credentials{"", "meuser1$", "mepassord2%"}, nil},
-		{"proxy-user=\"meuser1$:mepassord2%\"", Credentials{"", "meuser1$", "mepassord2%"}, nil},
+		{"--proxy-user \"meuser1$:mepassord2%\"", Credentials{"", "meuser1$", "mepassord2%", ""}, nil},
+		{"--proxy-user = \"meuser1$:mepassord2%\"", Credentials{"", "meuser1$", "mepassord2%", ""}, nil},
+		{"proxy-user = \"meuser1$:mepassord2%\"", Credentials{"", "meuser1$", "mepassord2%", ""}, nil},
+		{"proxy-user=\"meuser1$:mepassord2%\"", Credentials{"", "meuser1$", "mepassord2%", ""}, nil},
 		{"", Credentials{}, ErrNoProxyCredentials},
 	}
 

--- a/internal/connect/helpers_test.go
+++ b/internal/connect/helpers_test.go
@@ -24,7 +24,7 @@ func createTestCredentials(username, password string, t *testing.T) {
 		password = "test"
 	}
 	CFG.FsRoot = t.TempDir()
-	err := writeSystemCredentials(username, password)
+	err := writeSystemCredentials(username, password, "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/libsuseconnect/libsuseconnect.go
+++ b/libsuseconnect/libsuseconnect.go
@@ -68,7 +68,7 @@ func announce_system(clientParams, distroTarget *C.char) *C.char {
 	var res struct {
 		Credentials []string `json:"credentials"`
 	}
-	res.Credentials = []string{login, password}
+	res.Credentials = []string{login, password, ""}
 	jsn, _ := json.Marshal(&res)
 	return C.CString(string(jsn))
 }
@@ -95,9 +95,9 @@ func credentials(path *C.char) *C.char {
 }
 
 //export create_credentials_file
-func create_credentials_file(login, password, path *C.char) *C.char {
+func create_credentials_file(login, password, token, path *C.char) *C.char {
 	err := connect.CreateCredentials(
-		C.GoString(login), C.GoString(password), C.GoString(path))
+		C.GoString(login), C.GoString(password), C.GoString(token), C.GoString(path))
 	if err != nil {
 		return C.CString(errorToJSON(err))
 	}


### PR DESCRIPTION
## Description

In order to detect system duplicates, SCC implemented a `System-Token` mechanism in which systems are to report a token that is generated for every request from systems.

The Ruby implementation of SUSEConnect stores this into the credentials file for every request. If the response did not contain any token (e.g. first time that a system contacts SCC or upgrading from and older SUSEConnect) then an empty token is stored into the credentials file. All in all, this commit brings this Go implementation on par with the Ruby one when it comes to detecting system duplicates.

## How to test this

1. Build with the latest changes.
2. Run any request (e.g. the recently added `--keepalive` command)
3. Check that the system credentials have changed by adding a new `system_token` value.
4. Check that the system from Glue's database has updated its `system_token` column.

Retry steps 2, 3 and 4 multiple times and check that the `system_token` field keeps being in sync.

## Related issues

Fixes #125 