### PR TITLE
Fix keepalive feature notice during installation

### DIFF
--- a/suseconnect-ng.spec
+++ b/suseconnect-ng.spec
@@ -145,7 +145,7 @@ rm -rf %buildroot/usr/share/go
 # in pre blocks the old version is still installed. This way we can detect
 # if --keepalive was already present before
 kainfo=0
-helptext=$(SUSEConnect --help)
+helptext=$(test -x "$(type -p SUSEConnect)" && SUSEConnect --help)
 if [ $? -eq 0 ]; then
     echo "$helptext" | grep -q keepalive
     kainfo=$?


### PR DESCRIPTION
Previous condition worked fine but printed "command not found" for new installations. Added pre-test prevents this.

Closes #149