### PR TITLE
suseconnect: added the `--list-ext` flag

### DIFF
--- a/suseconnect/suseconnect.go
+++ b/suseconnect/suseconnect.go
@@ -69,6 +69,7 @@ func connectMain() {
 	flag.BoolVar(&cleanup, "cleanup", false, "")
 	flag.BoolVar(&cleanup, "clean", false, "")
 	flag.BoolVar(&listExtensions, "list-extensions", false, "")
+	flag.BoolVar(&listExtensions, "list-ext", false, "")
 	flag.BoolVar(&listExtensions, "l", false, "")
 	flag.BoolVar(&rollback, "rollback", false, "")
 	flag.BoolVar(&version, "version", false, "")


### PR DESCRIPTION
This is an alias for `-l` and `--list-extensions` which is supported in the Ruby SUSEConnect but not on this project.

Fixes bsc#1203574