### PR TITLE
Add deactivate API to ruby bindings (bsc#1202705)

### DIFF
--- a/internal/connect/client.go
+++ b/internal/connect/client.go
@@ -338,6 +338,17 @@ func SystemActivations() (map[string]Activation, error) {
 	return systemActivations()
 }
 
+// DeactivateProduct deactivates given product in SMT/SCC
+// returns Service to be removed from zypper
+func DeactivateProduct(product Product) (Service, error) {
+	return deactivateProduct(product)
+}
+
+// DeregisterSystem deletes current system in SMT/SCC
+func DeregisterSystem() error {
+	return deregisterSystem()
+}
+
 // InstallerUpdates returns an array of Installer-Updates repositories for the given product
 func InstallerUpdates(product Product) ([]Repo, error) {
 	return installerUpdates(product)

--- a/libsuseconnect/libsuseconnect.go
+++ b/libsuseconnect/libsuseconnect.go
@@ -84,6 +84,18 @@ func update_system(clientParams, distroTarget *C.char) *C.char {
 	return C.CString("{}")
 }
 
+//export deactivate_system
+func deactivate_system(clientParams *C.char) *C.char {
+	loadConfig(C.GoString(clientParams))
+
+	err := connect.DeregisterSystem()
+	if err != nil {
+		return C.CString(errorToJSON(err))
+	}
+
+	return C.CString("{}")
+}
+
 //export credentials
 func credentials(path *C.char) *C.char {
 	creds, err := connect.ReadCredentials(C.GoString(path))
@@ -161,6 +173,26 @@ func activated_products(clientParams *C.char) *C.char {
 		return C.CString(errorToJSON(err))
 	}
 	jsn, err := json.Marshal(products)
+	if err != nil {
+		return C.CString(errorToJSON(err))
+	}
+	return C.CString(string(jsn))
+}
+
+//export deactivate_product
+func deactivate_product(clientParams, product *C.char) *C.char {
+	loadConfig(C.GoString(clientParams))
+
+	var p connect.Product
+	err := json.Unmarshal([]byte(C.GoString(product)), &p)
+	if err != nil {
+		return C.CString(errorToJSON(connect.JSONError{Err: err}))
+	}
+	service, err := connect.DeactivateProduct(p)
+	if err != nil {
+		return C.CString(errorToJSON(err))
+	}
+	jsn, err := json.Marshal(service)
 	if err != nil {
 		return C.CString(errorToJSON(err))
 	}

--- a/yast/lib/suse/connect/yast.rb
+++ b/yast/lib/suse/connect/yast.rb
@@ -12,12 +12,14 @@ module GoConnect
   extern 'void free_string(string)'
   extern 'string announce_system(string, string)'
   extern 'string update_system(string, string)'
+  extern 'string deactivate_system(string)'
   extern 'string credentials(string)'
   extern 'string create_credentials_file(string, string, string, string)'
   extern 'string curlrc_credentials()'
   extern 'string show_product(string, string)'
   extern 'string activated_products(string)'
   extern 'string activate_product(string, string, string)'
+  extern 'string deactivate_product(string, string)'
   extern 'string get_config(string)'
   extern 'string write_config(string)'
   extern 'string update_certificates()'
@@ -68,6 +70,14 @@ module SUSE
           _process_result(GoConnect.update_system(jsn_params, distro_target))
         end
 
+        # Deactivates the system in SCC / the registration server.
+        # @param [Hash] client_params parameters to override SUSEConnect config
+        def deactivate_system(client_params = {})
+          _set_verify_callback(client_params[:verify_callback])
+          jsn_params = JSON.generate(client_params)
+          _process_result(GoConnect.deactivate_system(jsn_params))
+        end
+
         # Activates a product on SCC / the registration server.
         # Expects product parameter to identify the product.
         # Requires a token / regcode except for free products/extensions.
@@ -83,6 +93,21 @@ module SUSE
           jsn_params = JSON.generate(client_params)
           jsn_product = JSON.generate(product.to_h)
           _process_result(GoConnect.activate_product(jsn_params, jsn_product, email))
+        end
+
+        # Deactivates a product on SCC / the registration server.
+        # Expects product parameter to identify the product.
+        # Returns a service object for the deactivated product.
+        #
+        # @param [OpenStruct] product with identifier, arch and version defined
+        # @param [Hash] client_params parameters to override SUSEConnect config
+        #
+        # @return [OpenStruct] Service object as openstruct
+        def deactivate_product(product, client_params = {})
+          _set_verify_callback(client_params[:verify_callback])
+          jsn_params = JSON.generate(client_params)
+          jsn_product = JSON.generate(product.to_h)
+          _process_result(GoConnect.deactivate_product(jsn_params, jsn_product))
         end
 
         # Upgrades a product on SCC / the registration server.


### PR DESCRIPTION
Existing functionalities used by CLI were exposed and can be called from ruby clients.

Closes #148