### PR TITLE
Drop .git from tar

### DIFF
--- a/_service
+++ b/_service
@@ -11,7 +11,7 @@
     <param name="versionrewrite-pattern">v(\d+\.\d+\.\d+)</param>
     <param name="versionrewrite-replacement">\1</param>
     <param name="changesgenerate">enable</param>
-    <param name="package-meta">yes</param>
+    <param name="package-meta">no</param>
     <param name="exclude">vendor</param>
   </service>
   <service name="recompress" mode="manual">

--- a/suseconnect-ng.spec
+++ b/suseconnect-ng.spec
@@ -101,8 +101,6 @@ This package provides bindings needed to use libsuseconnect from Ruby scripts.
 
 %prep
 %setup -q -n connect-ng-%{version}
-# keep git metadata but don't use it for "VCS stamping"
-mv .git .git.bak
 
 %build
 find %_builddir/..


### PR DESCRIPTION
The .git directory in tarball caused one of the package updates to be declined by reviewers. Removing as requested.