### PR TITLE
Bump to 1.0.0

### DIFF
--- a/suseconnect-ng.spec
+++ b/suseconnect-ng.spec
@@ -46,8 +46,8 @@ BuildRequires:  s390-tools
 BuildRequires:  systemd
 %endif
 
-Obsoletes:      SUSEConnect < 0.3.99
-Provides:       SUSEConnect = 0.3.99
+Obsoletes:      SUSEConnect < 1.0.0
+Provides:       SUSEConnect = 1.0.0
 Obsoletes:      zypper-migration-plugin < 0.99
 Provides:       zypper-migration-plugin = 0.99
 Obsoletes:      zypper-search-packages-plugin < 0.99

--- a/suseconnect-ng.spec
+++ b/suseconnect-ng.spec
@@ -84,7 +84,7 @@ replaced SUSEConnect.
 %{go_provides}
 
 %package -n libsuseconnect
-Summary:        C interface to suseconnect-ng.
+Summary:        C interface to suseconnect-ng
 Group:          System/Management
 # the CLI is not used by libsuseconnect but it has the same dependencies and it's easier to keep one list above
 Requires:       suseconnect-ng
@@ -93,7 +93,7 @@ This package contains library which provides C interface to selected
 suseconnect-ng functions.
 
 %package -n suseconnect-ruby-bindings
-Summary:        Ruby bindings for libsuseconnect library.
+Summary:        Ruby bindings for libsuseconnect library
 Group:          System/Management
 Requires:       libsuseconnect
 %description -n suseconnect-ruby-bindings


### PR DESCRIPTION
As part of the new release schema of SUSEConnect Ruby to only contain minor releases (thus, no major nor patch-level releases), it's safer to simply increase the version of SUSEConnect-ng to 1.0.0 and obsolete anything behind this major release.

Moreover, I have also removed the dots at the end of the summary of two packages because rpmlint was throwing an error on it.

I have tested this change by also adding a new `v1.0.0` tag, building it locally and then trying it out on a SLES15 SP3 with SUSEConnect 0.3.36 (the latest version from SUSEConnect ruby). The package was properly upgraded with no problems.

**Important**: whenever this PR is merged, I will push the v1.0.0 tag for this repo and start the release process of SUSEConnect-ng myself.