### PR TITLE
Update Dockerfile.yast

### DIFF
--- a/Dockerfile.yast
+++ b/Dockerfile.yast
@@ -1,6 +1,6 @@
 FROM registry.opensuse.org/yast/head/containers/yast-ruby:latest
 
-RUN rm -r /usr/lib64/ruby/gems/*/gems/suse-connect-*
+RUN zypper rm -y suseconnect-ng libsuseconnect suseconnect-ruby-bindings
 
 # invalidate github cache
 ADD https://api.github.com/repos/yast/yast-registration/git/refs/heads/master version.json
@@ -10,6 +10,6 @@ WORKDIR /yast-registration
 RUN git clone --depth 1 https://github.com/yast/yast-registration.git /yast-registration
 
 COPY out/libsuseconnect.so /usr/lib64
-COPY yast/lib /usr/lib64/ruby/vendor_ruby/2.7.0
+COPY yast/lib /usr/lib64/ruby/vendor_ruby/3.1.0
 CMD ["rake", "test:unit"]
 


### PR DESCRIPTION
The test-yast make target was failing with:
STEP 2/8: RUN rm -r /usr/lib64/ruby/gems/*/gems/suse-connect-* rm: cannot remove '/usr/lib64/ruby/gems/*/gems/suse-connect-*': No such file or directory

The suseconnect-ng, libsuseconnect and suseconnect-ruby-bindings packages are now in the latest yast-ruby container image. This patch removes them, and the locally checked out code will be tested instead.