### PR TITLE
Don't write system_token to service credentials files

### DIFF
--- a/internal/connect/credentials.go
+++ b/internal/connect/credentials.go
@@ -111,7 +111,10 @@ func (c Credentials) write() error {
 		}
 	}
 	buf := bytes.Buffer{}
-	fmt.Fprintf(&buf, "username=%s\npassword=%s\nsystem_token=%s\n", c.Username, c.Password, c.SystemToken)
+	fmt.Fprintf(&buf, "username=%s\npassword=%s\n", c.Username, c.Password)
+	if c.SystemToken != "" {
+		fmt.Fprintf(&buf, "system_token=%s\n", c.SystemToken)
+	}
 	return os.WriteFile(path, buf.Bytes(), 0600)
 }
 
@@ -137,7 +140,8 @@ func writeServiceCredentials(serviceName string) error {
 		return err
 	}
 	path := serviceCredentialsFile(serviceName)
-	return CreateCredentials(c.Username, c.Password, c.SystemToken, path)
+	// the SystemToken is not written to service credential files
+	return CreateCredentials(c.Username, c.Password, "", path)
 }
 
 func removeSystemCredentials() error {

--- a/internal/connect/credentials_test.go
+++ b/internal/connect/credentials_test.go
@@ -66,6 +66,19 @@ func TestWriteCredentials(t *testing.T) {
 	}
 }
 
+func TestWriteCredentialsEmptyToken(t *testing.T) {
+	CFG.FsRoot = t.TempDir()
+	if err := writeSystemCredentials("user1", "pass1", ""); err != nil {
+		t.Fatalf("Unexpected error: %s", err)
+	}
+	expected := "username=user1\npassword=pass1\n"
+	contents, _ := os.ReadFile(systemCredentialsFile())
+	got := string(contents)
+	if got != expected {
+		t.Errorf("Expected %#v, got %#v", expected, got)
+	}
+}
+
 func TestWriteReadDeleteService(t *testing.T) {
 	CFG.FsRoot = t.TempDir()
 	if err := writeSystemCredentials("user1", "pass1", "1234"); err != nil {
@@ -79,8 +92,8 @@ func TestWriteReadDeleteService(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected error: %s", err)
 	}
-	if rc.Username != "user1" || rc.Password != "pass1" || rc.SystemToken != "1234" {
-		t.Errorf("Got: %s and %s, expected user1 and pass1", rc.Username, rc.Password)
+	if rc.Username != "user1" || rc.Password != "pass1" || rc.SystemToken != "" {
+		t.Errorf("Got: %s, %s, %s. Expected user1, pass1, \"\"", rc.Username, rc.Password, rc.SystemToken)
 	}
 	if err := removeServiceCredentials("service1"); err != nil {
 		t.Errorf("Unexpected error: %s", err)


### PR DESCRIPTION
Zypper only reads the username and password from service credential files under /etc/zypp/credentials.d. The system_token line causes a problem with registercloudguest (bsc#1205089). Fixes #158