### PR TITLE
Bump to v1.1.0

### DIFF
--- a/suseconnect-ng.spec
+++ b/suseconnect-ng.spec
@@ -56,8 +56,8 @@ BuildRequires:  systemd
 %endif
 
 
-Obsoletes:      SUSEConnect < 1.0.0
-Provides:       SUSEConnect = 1.0.0
+Obsoletes:      SUSEConnect < 1.1.0
+Provides:       SUSEConnect = 1.1.0
 Obsoletes:      zypper-migration-plugin < 0.99
 Provides:       zypper-migration-plugin = 0.99
 Obsoletes:      zypper-search-packages-plugin < 0.99


### PR DESCRIPTION
After this, I will tag the `v1.1.0` release, push the tag and start with the releasing process from our side.