### PR TITLE
@wip use more linux tools output & container detection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,9 @@ build-so: out internal/connect/version.txt
 build-arm: out internal/connect/version.txt
 	GOOS=linux GOARCH=arm64 GOARM=7 go build -v -o out/ github.com/SUSE/connect-ng/suseconnect
 
+build-ppc: out internal/connect/version.txt
+	GOOS=linux GOARCH=ppc64le go build -v -o out/ github.com/SUSE/connect-ng/suseconnect
+
 build-s390: out internal/connect/version.txt
 	GOOS=linux GOARCH=s390x go build -v -o out/ github.com/SUSE/connect-ng/suseconnect
 


### PR DESCRIPTION
- Refactored getHwinfo to use "lscpu -J", it provides JSON output for CPU information.

  Tested in x86_64, ppc64le & s390x and it works consistently.

- De-branched optional writes to the hwinfo struct. At the end it will be sent as an empty value anyways, SCC must be able to handle those and only write when they are not-empty.

- Re-Implemented UUID for s390x: "read_values -u" is not yet implemented, to make up for it, the same values used in the implementation are polyfilled here.

- Added extra support for container runtime detection: Container runtime information will be appended into the hypervisor field. The detection is based on matching container runtime tool names in the /proc/self/cgroup file.

- S390x exclusive: capture only the version of z/VM running.

- Memory detection using "lsmem -J": still a @wip, there's some behavior not quite certain yet...

Tests are pending.

Outputs that I've tested:

```
x86_64 Host (virtualized)
Proxmox
cpus: 8 (8 vCPUs)
sockets: 1
ram: 32G

{"hostname":"bibo","distro_target":"sle-15-x86_64","hwinfo":{"hostname":"bibo","cpus":8,"sockets":1,"hypervisor":"kvm/KVM","arch":"x86_64","uuid":"030d1157-2db2-45d3-9996-fe5e9a501198","cloud_provider":"","mem_total":32768}}

---

x86_64 Host
Intel(R) Xeon(R) W-2123 
cpus: 8 (4 cores, 8 threads)
sockets: 1
ram: 32G

{"hostname":"cuatro","distro_target":"","hwinfo":{"hostname":"cuatro","cpus":8,"sockets":1,"hypervisor":"","arch":"x86_64","uuid":"4c4c4544-0039-4a10-8042-c6c04f305332","cloud_provider":"","mem_total":32512}}

---

x86_64 docker container (no-systemd)
Intel(R) Xeon(R) W-2123 
cpus: 8 (4 cores, 8 threads)
sockets: 1
ram: 32G

{"hostname":"20f07c167028","distro_target":"sle-15-x86_64","hwinfo":{"hostname":"20f07c167028","cpus":8,"sockets":1,"hypervisor":"docker","arch":"x86_64","uuid":"","cloud_provider":"","mem_total":32512}}

---

x86_64 docker container (with-systemd)
Intel(R) Xeon(R) W-2123 
cpus: 8 (4 cores, 8 threads)
sockets: 1
ram: 32G

{"hostname":"74fbe9549042","distro_target":"sle-15-x86_64","hwinfo":{"hostname":"74fbe9549042","cpus":8,"sockets":1,"hypervisor":"docker","arch":"x86_64","uuid":"","cloud_provider":"","mem_total":32512}}

---

x86_64 podman container (no-systemd)
Intel(R) Xeon(R) W-2123 
cpus: 8 (4 cores, 8 threads)
sockets: 1
ram: 32G

{"hostname":"73579c758d57","distro_target":"sle-15-x86_64","hwinfo":{"hostname":"73579c758d57","cpus":8,"sockets":1,"hypervisor":"libpod","arch":"x86_64","uuid":"","cloud_provider":"","mem_total":32512}}

---

x86_64 podman container (with-systemd)
Intel(R) Xeon(R) W-2123 
cpus: 8 (4 cores, 8 threads)
sockets: 1
ram: 32G

{"hostname":"b9c2ae8d276f","distro_target":"sle-15-x86_64","hwinfo":{"hostname":"b9c2ae8d276f","cpus":8,"sockets":1,"hypervisor":"libpod","arch":"x86_64","uuid":"","cloud_provider":"","mem_total":32512}}

---

S390x VM
cpus: 2 (2 cores)
sockets: 2
ram: 2G

{"hostname":"s390vsl120","distro_target":"sle-15-s390x","hwinfo":{"hostname":"s390vsl120","cpus":2,"sockets":2,"hypervisor":"zvm/IBM/6.4.0","arch":"s390x","uuid":"0000000000090A97-ZLP2-LINUX120","cloud_provider":"","mem_total":2048}}

---

PPC64 LPAR 
cpus: 16 (16 cores)
socket: 1

{"hostname":"nessberry-1","distro_target":"sle-15-ppc64le","hwinfo":{"hostname":"nessberry-1","cpus":16,"sockets":1,"hypervisor":"powervm/pHyp","arch":"ppc64le","uuid":"","cloud_provider":"","mem_total":81920}}

---

EC2 Machine
cpus: 2 (2 vCPU's)
sockets: 2

{"hostname":"ip-10-156-10-46","distro_target":"sle-15-x86_64","hwinfo":{"hostname":"ip-10-156-10-46","cpus":2,"sockets":1,"hypervisor":"amazon/KVM","arch":"x86_64","uuid":"ec25ae84-675d-9128-a024-42994bb6006a","cloud_provider":"Amazon","mem_total":4096}}

---

EC2 Machine -- Docker container / (without systemd)
cpus: 2 (2 vCPU's)
sockets: 2

{"hostname":"0648eee565d6","distro_target":"sle-15-x86_64","hwinfo":{"hostname":"0648eee565d6","cpus":2,"sockets":1,"hypervisor":"docker/KVM","arch":"x86_64","uuid":"","cloud_provider":"","mem_total":4096}}

---

EC2 Machine -- Docker container / (with systemd)
cpus: 2 (2 vCPU's)
sockets: 2

{"hostname":"2836cb63c8ba","distro_target":"sle-15-x86_64","hwinfo":{"hostname":"2836cb63c8ba","cpus":2,"sockets":1,"hypervisor":"amazon/docker/KVM","arch":"x86_64","uuid":"","cloud_provider":"","mem_total":4096}}

---

EC2 Machine -- podman container / (without systemd)
cpus: 2 (2 vCPU's)
sockets: 2

{"hostname":"b4a7a3e476d3","distro_target":"sle-15-x86_64","hwinfo":{"hostname":"b4a7a3e476d3","cpus":2,"sockets":1,"hypervisor":"libpod/KVM","arch":"x86_64","uuid":"","cloud_provider":"","mem_total":4096}}

---

EC2 Machine -- podman container / (with systemd)
cpus: 2 (2 vCPU's)
sockets: 2

{"hostname":"31f30104745f","distro_target":"sle-15-x86_64","hwinfo":{"hostname":"31f30104745f","cpus":2,"sockets":1,"hypervisor":"amazon/libpod/KVM","arch":"x86_64","uuid":"","cloud_provider":"","mem_total":4096}}
```