### PR TITLE
Keep keepalive timer states when replacing SUSEConnect (bsc#1211588)

### DIFF
--- a/suseconnect-ng.spec
+++ b/suseconnect-ng.spec
@@ -185,6 +185,13 @@ about these improvements and any ideas you might have.
 EOF
 fi
 
+# If the keepalive timer exists on package install (not upgrade), then we are replacing SUSEConnect.
+# Record the enabled and active statuses so they can be restored in %posttrans.
+if [ "$1" -eq 1 ]; then
+  /usr/bin/systemctl is-enabled suseconnect-keepalive.timer >/dev/null 2>&1 && touch /run/suseconnect-keepalive.timer.is-enabled || :
+  /usr/bin/systemctl is-active suseconnect-keepalive.timer >/dev/null 2>&1 && touch /run/suseconnect-keepalive.timer.is-active || :
+fi
+
 %post
 %service_add_post suseconnect-keepalive.service suseconnect-keepalive.timer
 
@@ -193,6 +200,16 @@ fi
 
 %postun
 %service_del_postun suseconnect-keepalive.service suseconnect-keepalive.timer
+
+%posttrans
+if [ -e /run/suseconnect-keepalive.timer.is-enabled ]; then
+   /usr/bin/systemctl enable suseconnect-keepalive.timer >/dev/null 2>&1 || :
+   rm /run/suseconnect-keepalive.timer.is-enabled ||:
+fi
+if [ -e /run/suseconnect-keepalive.timer.is-active ]; then
+  /usr/bin/systemctl start suseconnect-keepalive.timer >/dev/null 2>&1 || :
+  rm /run/suseconnect-keepalive.timer.is-active ||:
+fi
 
 %check
 %gotest -v %import_path/internal/connect %{?test_hwinfo_args}


### PR DESCRIPTION
When replacing the Ruby SUSEConnect with suseconnect-ng, the keepalive systemd timer was disabled and inactive aferwards, even though it was enabled and running beforehand. This is because we are using the same name for timer in both packages, and the run order of the pre/post/preun/postun blocks. This patches fixes that by recording the enabled/active states in pre, and restoring them in posttrans.