### PR TITLE
Added EULA display for addons

### DIFF
--- a/SUSEConnect.example
+++ b/SUSEConnect.example
@@ -1,0 +1,17 @@
+---
+## SUSEConnect configuration file example
+
+## URL of the registration server. (default: https://scc.suse.com)
+# url: https://scc.suse.com
+
+## Language code to use for error messages (default: $LANG)
+# language:
+
+## Do not verify SSL certificates when using https (default: false)
+# insecure: false
+
+## Do not refresh zypper service when registering (default: false)
+# no_zypper_refs: false
+
+## Automatically agree to extension and module license confirmation prompts (default: false)
+# auto_agree_with_licenses: false

--- a/internal/connect/config.go
+++ b/internal/connect/config.go
@@ -34,6 +34,7 @@ type Config struct {
 	Product          Product
 	InstanceDataFile string
 	Email            string `json:"email"`
+	AutoAgreeEULA    bool
 
 	NoZypperRefresh    bool
 	AutoImportRepoKeys bool
@@ -59,6 +60,7 @@ func (c Config) toYAML() []byte {
 	if c.Namespace != "" {
 		fmt.Fprintf(&buf, "namespace: %s\n", c.Namespace)
 	}
+	fmt.Fprintf(&buf, "auto_agree_with_licenses: %v\n", c.AutoAgreeEULA)
 	return buf.Bytes()
 }
 
@@ -104,6 +106,8 @@ func parseConfig(r io.Reader, c *Config) {
 			c.Insecure, _ = strconv.ParseBool(val)
 		case "no_zypper_refs":
 			c.NoZypperRefresh, _ = strconv.ParseBool(val)
+		case "auto_agree_with_licenses":
+			c.AutoAgreeEULA, _ = strconv.ParseBool(val)
 		default:
 			Debug.Printf("Cannot parse line \"%s\" from %s", line, c.Path)
 		}

--- a/internal/connect/config_test.go
+++ b/internal/connect/config_test.go
@@ -11,7 +11,8 @@ var cfg1 = `---
 insecure: false
 url: https://smt-azure.susecloud.net
 language: en_US.UTF-8
-no_zypper_refs: true`
+no_zypper_refs: true
+auto_agree_with_licenses: true`
 
 var cfg2 = `---
  insecure: true
@@ -27,7 +28,12 @@ badkey: badval
 
 func TestParseConfig(t *testing.T) {
 	r := strings.NewReader(cfg1)
-	expect := Config{BaseURL: "https://smt-azure.susecloud.net", Language: "en_US.UTF-8", NoZypperRefresh: true}
+	expect := Config{
+		BaseURL:         "https://smt-azure.susecloud.net",
+		Language:        "en_US.UTF-8",
+		NoZypperRefresh: true,
+		AutoAgreeEULA:   true,
+	}
 	c := Config{}
 	parseConfig(r, &c)
 	if !reflect.DeepEqual(c, expect) {
@@ -49,6 +55,7 @@ func TestSaveLoad(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "SUSEConnect.test")
 	c1 := NewConfig()
 	c1.Path = path
+	c1.AutoAgreeEULA = true
 	if err := c1.Save(); err != nil {
 		t.Fatalf("Unable to write config: %s", err)
 	}

--- a/internal/connect/connection.go
+++ b/internal/connect/connection.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"crypto/tls"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httputil"
@@ -197,4 +198,23 @@ func ReloadCertPool() error {
 	httpclient = nil
 	setupHTTPClient()
 	return nil
+}
+
+func downloadFile(url string) ([]byte, error) {
+	setupHTTPClient()
+
+	resp, err := httpclient.Get(url)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	resBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	if !successCode(resp.StatusCode) {
+		return nil, fmt.Errorf("Downloading %s failed (code: %d): %s", url, resp.StatusCode, resBody)
+	}
+	return resBody, nil
 }

--- a/internal/connect/eula.go
+++ b/internal/connect/eula.go
@@ -1,0 +1,226 @@
+package connect
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"net/url"
+	"os"
+	"os/exec"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+const eulaIndex = "directory.yast"
+
+var (
+	eulaMatch = regexp.MustCompile(`^license\.(.*)\.txt$`)
+)
+
+func selectEULALanguage(index map[string]string) string {
+	if len(index) == 0 {
+		return ""
+	}
+
+	// Remove the encoding (e.g. ".UTF-8") and default to en_US.
+	lang := CFG.Language
+	lang = strings.Split(lang, ".")[0]
+	if lang == "" || lang == "C" || lang == "POSIX" {
+		lang = "en_US"
+	}
+
+	// Language priorities (xx_YY, xx, en_US, en, ...)
+	prios := []string{lang, strings.Split(lang, "_")[0], "en_US", "en"}
+	for _, l := range prios {
+		if _, ok := index[l]; ok {
+			return l
+		}
+	}
+
+	// Last option: return first available language (sorted to make things consistent)
+	langs := make([]string, 0)
+	for l := range index {
+		langs = append(langs, l)
+	}
+	sort.Strings(langs)
+	return langs[0]
+}
+
+func parseEULAIndex(data []byte, baseURL string) (map[string]string, error) {
+	ret := make(map[string]string, 0)
+	base, err := url.Parse(baseURL)
+	if err != nil {
+		return ret, err
+	}
+	scanner := bufio.NewScanner(bytes.NewReader(data))
+	for scanner.Scan() {
+		name := scanner.Text()
+		if name == eulaIndex {
+			continue
+		}
+		url, _ := base.Parse(name)
+		if name == "license.txt" {
+			ret["en_US"] = url.String()
+			continue
+		}
+		match := eulaMatch.FindStringSubmatch(name)
+		if len(match) == 2 {
+			ret[match[1]] = url.String()
+			continue
+		}
+		Debug.Printf("Ignoring unknown index entry: %s", name)
+	}
+	return ret, nil
+}
+
+func downloadEULAIndex(baseURL string) (map[string]string, error) {
+	base, err := url.Parse(baseURL)
+	if err != nil {
+		return map[string]string{}, err
+	}
+	url, err := base.Parse(eulaIndex)
+	if err != nil {
+		return map[string]string{}, err
+	}
+	Debug.Printf("Downloading license index from %s...", url)
+	index, err := downloadFile(url.String())
+	if err != nil {
+		return map[string]string{}, err
+	}
+	ret, err := parseEULAIndex(index, baseURL)
+	if err != nil {
+		return map[string]string{}, err
+	}
+	Debug.Printf("Downloaded license index %+v", ret)
+	return ret, nil
+}
+
+func showTextInPager(text []byte) error {
+	// POSIX default
+	pager := "more"
+	if p, ok := os.LookupEnv("PAGER"); ok && p != "" {
+		pager = p
+	}
+	Debug.Printf("Using %s as pager.", pager)
+
+	// Run interactive pager (`sh` is needed to allow custom pagers e.g. `less
+	// -N`)
+	comm := exec.Command("sh", "-c", pager)
+	comm.Stdin = bytes.NewReader(text)
+	comm.Stdout = os.Stdout
+	comm.Stderr = os.Stderr
+	return comm.Run()
+}
+
+// Prints the text of the EULA without some padding at the end which doesn't
+// make much sense outside of the pager.
+func printEULA(text []byte) {
+	Info.Println(string(bytes.TrimSpace(text)))
+}
+
+// Returns the text of the EULA to be shown to the user, or nothing if there was
+// an error.
+func fetchEULAFrom(extension Product) ([]byte, error) {
+	eulas, err := downloadEULAIndex(extension.EULAURL)
+	if err != nil {
+		return nil, err
+	}
+	lang := selectEULALanguage(eulas)
+
+	// This should happen only if there are no license files in index
+	if lang == "" {
+		return nil, fmt.Errorf("No EULAs found at: %s", extension.EULAURL)
+	}
+
+	// Download EULA text
+	eula, err := downloadFile(eulas[lang])
+	if err != nil {
+		return nil, err
+	}
+
+	// Trim BOM (some pagers display it as hex codes)
+	eula = bytes.TrimLeft(eula, "\xef\xbb\xbf")
+
+	// Add header
+	header := fmt.Sprintf(
+		"In order to install '%s', you must agree to terms of the following license agreement:\n\n",
+		extension.FriendlyName)
+
+	return append([]byte(header), eula...), nil
+}
+
+// Prompts the user to accept or not the EULA. If there was an error or the user
+// did not accept the EULA an error will be returned, otherwise this function
+// returns nil.
+func promptUser(text []byte, extensionName string) error {
+	// Show the text itself into the pager. If the pager is not available, then
+	// just print it.
+	if err := showTextInPager(text); err != nil {
+		printEULA(text)
+	}
+
+	for {
+		// Using `fmt` instead of `Info` to avoid an unexpected (and ugly)
+		// newline after printing this line.
+		fmt.Print("Do you agree with the terms of the license? [y/yes n/no] (n): ")
+
+		reader := bufio.NewReader(os.Stdin)
+		answer, err := reader.ReadString('\n')
+		if err != nil {
+			return fmt.Errorf("\nStandard input seems to be closed, please restart " +
+				"the operation in interactive mode or use '--auto-agree-with-licenses' option.")
+		}
+
+		answer = strings.ToLower(strings.TrimSpace(answer))
+
+		if answer == "y" || answer == "yes" {
+			return nil
+		} else if answer == "" || answer == "n" || answer == "no" {
+			return fmt.Errorf("aborting installation due to user disagreement with %s license", extensionName)
+		}
+	}
+}
+
+// AcceptEULA handles EULA interactions from the given base product/extensions.
+// If there are no EULAs to be handled, then this function does nothing and
+// returns nil. If the global configuration is set to auto-accept EULAs, then
+// they are accepted without further action. Otherwise, we prompt to users to
+// confirm it and then we proceed accordingly.
+func AcceptEULA() error {
+	// Separate EULAs are only for addon products
+	if CFG.Product.isEmpty() {
+		return nil
+	}
+
+	// Fetch list of extensions and search for requested product
+	base, err := baseProduct()
+	if err != nil {
+		return err
+	}
+	prod, err := showProduct(base)
+	if err != nil {
+		return err
+	}
+	extension, _ := prod.findExtension(CFG.Product)
+
+	// No EULA or product not found (handle in registration code)
+	if strings.TrimSpace(extension.EULAURL) == "" {
+		return nil
+	}
+
+	// Fetch the text from the EULA if possible.
+	eula, err := fetchEULAFrom(extension)
+	if err != nil {
+		return err
+	}
+
+	if CFG.AutoAgreeEULA {
+		printEULA(eula)
+		fmt.Println("")
+		Info.Printf("-> License auto-accepted through user configuration ...\n\n")
+		return nil
+	}
+
+	return promptUser(eula, extension.FriendlyName)
+}

--- a/internal/connect/eula_test.go
+++ b/internal/connect/eula_test.go
@@ -1,0 +1,98 @@
+package connect
+
+import (
+	"strings"
+	"testing"
+)
+
+var index1 = `directory.yast
+license.de.txt
+license.es.txt
+license.fr.txt
+license.it.txt
+license.ja.txt
+license.ko.txt
+license.pt_BR.txt
+license.ru.txt
+license.txt
+license.zh_CN.txt
+license.zh_TW.txt
+`
+
+func TestParseEULAIndex(t *testing.T) {
+	expectedLangs := []string{
+		"de", "es", "fr", "it", "ja", "ko",
+		"pt_BR", "ru", "en_US", "zh_CN", "zh_TW",
+	}
+	baseURL := "http://license.server/product1/"
+	eulas, err := parseEULAIndex([]byte(index1), baseURL)
+	if err != nil {
+		t.Fatalf("Parsing error: %+v", err)
+
+	}
+	if len(eulas) != len(expectedLangs) {
+		t.Fatalf("Unexpected number of items: %v", len(eulas))
+	}
+	for _, l := range expectedLangs {
+		if url, ok := eulas[l]; ok {
+			if !strings.HasPrefix(url, baseURL) {
+				t.Errorf("Malformed URL found: %v", url)
+			}
+		} else {
+			t.Errorf("Expected language %v not found in index", l)
+		}
+	}
+}
+
+func TestSelectEULALang(t *testing.T) {
+	eulas := map[string]string{
+		"de":    "de-url",
+		"fr":    "fr-url",
+		"en":    "en-url",
+		"en_US": "en-us-url",
+		"pl":    "pl-url",
+		"es":    "es-url",
+	}
+	var tests = []struct {
+		input    string
+		expected string
+	}{
+		{"", "en_US"},
+		{"C", "en_US"},
+		{"POSIX", "en_US"},
+		{"de", "de"},
+		{"fr.UTF-8", "fr"},
+		{"es_BR", "es"},
+		{"pl_PL.UTF-8", "pl"},
+		{"zh_TW", "en_US"},
+	}
+	for _, test := range tests {
+		CFG.Language = test.input
+		out := selectEULALanguage(eulas)
+		if out != test.expected {
+			t.Errorf("For lang '%v' expected '%v', got '%v'", test.input, test.expected, out)
+		}
+	}
+}
+
+func TestSelectEULALangFallback(t *testing.T) {
+	eulas := map[string]string{
+		"pl":    "pl-url",
+		"zh_TW": "zh-url",
+	}
+	CFG.Language = "fr_FR.UTF-8"
+	out := selectEULALanguage(eulas)
+	// first from available ones even if it doesn't make sense for given config
+	if out != "pl" {
+		t.Errorf("Expected 'pl', got '%v'", out)
+	}
+}
+
+func TestSelectEULALangEmpty(t *testing.T) {
+	eulas := map[string]string{}
+	CFG.Language = "pl_PL.UTF-8"
+	out := selectEULALanguage(eulas)
+	if out != "" {
+		t.Errorf("Expected empty, got '%v'", out)
+	}
+}

--- a/internal/connect/product.go
+++ b/internal/connect/product.go
@@ -157,3 +157,17 @@ func (p Product) distroTarget() string {
 	version := strings.Split(p.Version, ".")[0]
 	return identifier + "-" + version + "-" + p.Arch
 }
+
+func (p Product) findExtension(query Product) (Product, error) {
+	for _, e := range p.Extensions {
+		if e.ToTriplet() == query.ToTriplet() {
+			return e, nil
+		}
+		if len(e.Extensions) > 0 {
+			if child, err := e.findExtension(query); err == nil {
+				return child, nil
+			}
+		}
+	}
+	return Product{}, fmt.Errorf("Extension not found")
+}

--- a/suseconnect-ng.spec
+++ b/suseconnect-ng.spec
@@ -144,6 +144,7 @@ install -D -m 644 %_builddir/go/src/%import_path/man/SUSEConnect.5 %buildroot/%_
 install -D -m 644 %_builddir/go/src/%import_path/man/SUSEConnect.8 %buildroot/%_mandir/man8/SUSEConnect.8
 install -D -m 644 %_builddir/go/src/%import_path/man/zypper-migration.8 %buildroot/%_mandir/man8/zypper-migration.8
 install -D -m 644 %_builddir/go/src/%import_path/man/zypper-search-packages.8 %buildroot/%_mandir/man8/zypper-search-packages.8
+install -D -m 644 %_builddir/go/src/%import_path/SUSEConnect.example %{buildroot}%_sysconfdir/SUSEConnect.example
 
 # Install the SUSEConnect --keepalive timer and service.
 install -D -m 644 %_builddir/go/src/%import_path/suseconnect-keepalive.timer %buildroot/%_unitdir/suseconnect-keepalive.timer
@@ -242,6 +243,7 @@ make -C %_builddir/go/src/%import_path gofmt
 %_mandir/man5/*
 %_unitdir/suseconnect-keepalive.service
 %_unitdir/suseconnect-keepalive.timer
+%config %{_sysconfdir}/SUSEConnect.example
 
 %files -n libsuseconnect
 %license LICENSE LICENSE.LGPL

--- a/suseconnect/connectUsage.txt
+++ b/suseconnect/connectUsage.txt
@@ -20,6 +20,9 @@ Manage subscriptions at https://scc.suse.com
                              removes all its services installed by SUSEConnect.
                              After de-registration the system no longer consumes
                              a subscription slot in SCC.
+        --auto-agree-with-licenses
+                             Automatically say 'yes' to extension and module
+                             license confirmation prompts.
         --instance-data  [path to file]
                              Path to the XML file holding the public key and
                              instance data for cloud registration with SMT.


### PR DESCRIPTION
Display the license text before registering an addon product whenever that is available. SUSEConnect will then prompt with a message to accept or not said EULA.

This commit also adds a new configuration option (and flag) with which you can instruct SUSEConnect to auto-accept the license without any prompting.

Fixes bsc#1170267
Supersedes SUSE/connect-ng#114

## How to test

Before this patch:

1. Register a system.
2. Try to run a command such as: `# ./out/suseconnect -p sle-module-NVIDIA-compute/15/x86_64`
3. It should *fail*.

After this is merged, you should be able to re-run the same command and you will be given a license text to accept. If you accept, then you will proceed to register the addon as expected, otherwise it will exit with an error message.

Moreover, if you add the `--auto--auto-agree-with-licenses` flag, then there will be no user interaction needed and the license will be accepted automatically. The same happens if you toggle the configuration on `/etc/SUSEConnect` (see example file)