### PR TITLE
ci: fixed integration image

### DIFF
--- a/integration/Dockerfile.ng-sle15sp3
+++ b/integration/Dockerfile.ng-sle15sp3
@@ -16,13 +16,13 @@ RUN zypper ar http://download.suse.de/ibs/SUSE/Products/SLE-Module-Basesystem/15
     zypper --non-interactive up &&\
     zypper --non-interactive install git-core ruby-devel make gcc gcc-c++ build wget dmidecode \
       vim osc hwinfo libx86emu3 zypper-migration-plugin sudo awk curl \
-      obs-service-tar_scm obs-service-recompress obs-service-extract_file obs-service-set_version obs-service-format_spec_file
+      obs-service-tar_scm obs-service-recompress obs-service-extract_file obs-service-set_version obs-service-format_spec_file obs-service-download_files
 
 RUN wget --no-check-certificate https://ci.suse.de/job/scc-connect-ng-config/lastBuild/artifact/.regcodes -O ~/.regcodes
 RUN wget --no-check-certificate https://ci.suse.de/job/scc-connect-ng-config/lastBuild/artifact/.oscrc -O ~/.oscrc
 
 RUN echo 'gem: --no-ri --no-rdoc' > /etc/gemrc && \
-    gem install bundler --no-document
+    gem install bundler --no-document -v 2.3.26
 
 RUN mkdir /tmp/connect && mkdir -p /tmp/connect/lib/suse/connect
 WORKDIR /tmp/connect


### PR DESCRIPTION
It was missing a service for `osc` and bundler needed to be told the exact version since it's all quite old.