### PR TITLE
migration: fixed handling of the `--auto-agree-license` flags from zypper

### DIFF
--- a/internal/connect/zypper.go
+++ b/internal/connect/zypper.go
@@ -288,9 +288,12 @@ func RefreshRepos(version string, force, quiet, verbose, nonInteractive bool) er
 }
 
 // DistUpgrade runs zypper dist-upgrade with given flags and extra args
-func DistUpgrade(version string, quiet, verbose, nonInteractive bool, extraArgs []string) error {
+func DistUpgrade(version string, quiet, verbose, AutoAgreeLicenses, nonInteractive bool, extraArgs []string) error {
 	flags := zypperFlags(version, quiet, verbose, nonInteractive, true)
 	args := append(flags, "dist-upgrade")
+	if AutoAgreeLicenses {
+		args = append(args, "--auto-agree-with-licenses")
+	}
 	args = append(args, extraArgs...)
 	_, err := zypperRun(args, []int{zypperOK})
 	return err


### PR DESCRIPTION
Fixes bsc#1214781

I have also taken the opportunity to do some cleaning around the arguments being passed which are basically zypper global flags.

## How to test

I have tested SLES15SP4 -> SLES15SP5, but other routes should be similar.

Before anything:

- Install SLES15SP4 so we can migrate to SP5. Activate it with a regcode.
- Now you can build this patch in two ways:
  - Just compile the binary: ready the VM with the prerequisites to build suseconnect-ng, checkout this branch and run `make`. 
  - Build the package. Checkout the suseconnect-ng project from OBS. In the `_service` file, change the `revision` parameter to the commit sha from this PR. Then call `osc service manualrun`. And then build the package with `osc build ...` as usual.
- Don't install it just yet, since you need to test the "before this patch was applied" situation 😉 

After all this, you can proceed to test this. So, *without* using this patch:

1. Make sure that the system is updated.
2. Run `zypper-migration -l` and note that at some point it fails with the following message (notice the `--l` flag, that's the actual bug)

```
Executing '/usr/bin/zypper --releasever 15.5 --no-refresh dist-upgrade --l --no-allow-vendor-change'

Warning: Enforced setting: $releasever=15.5
The flag --l is not known.
command '/usr/bin/zypper --releasever 15.5 --no-refresh dist-upgrade --l --no-allow-vendor-change' failed
Error: zypper returned 2 with 'The flag --l is not known.' (exit status 2)

Migration failed.
```

Now install the patch. That is, if you built a package, install it with zypper, otherwise, if you built it manually, just place the file in `out/suseconnect` into `/usr/lib/zypper/commands/zypper-migration`. In any case, now:

1. Run `zypper-migration -l` again.
2. Migration should just work.