### PR TITLE
Prepare for building on SLE12 SP5

### DIFF
--- a/suseconnect-ng.spec
+++ b/suseconnect-ng.spec
@@ -33,13 +33,7 @@ Group:          System/Management
 Source:         connect-ng-%{version}.tar.xz
 Source1:        %name-rpmlintrc
 BuildRequires:  golang-packaging
-# use FIPS compliant go version for SLE targets and Leap 15.5+ targets
-%if ( 0%{?is_opensuse} == 0 && 0%{?sle_version} ) || ( 0%{?is_opensuse} == 1 && 0%{?sle_version} >= 150500 )
-# temporary until BuildRequires: go-openssl >= 1.16 works
 BuildRequires:  go1.18-openssl
-%else
-BuildRequires:  go >= 1.16
-%endif
 BuildRequires:  ruby-devel
 BuildRequires:  zypper
 


### PR DESCRIPTION
This removed the restrictions in the spec file to build with the old go compiler on SLE12. SLE12 now has `go1.18-openssl` which is required to build connect-ng.


**How to test this changes:**
Make sure you have `osc` setup and ibs working:

```
osc -A https://api.suse.de co Devel:SCC:suseconnect/suseconnect-ng
cd Devel:SCC:suseconnect/suseconnect-ng/
osc service manualrun

cd connect-ng && git checkout build-sle12-sp5
cd ..

# Note: go1.18-openssl is only available in SLE12_SP5_Update which is only released in ibs and not in obs!
osc build SLE_12_SP5_Update x86_64 --no-verify
```

Run SLE12 SP5 in any way (your choice) and check registration/activation etc. is working.

**As always, if you need help with testing this, please reach out to me!**:rocket: