### PR TITLE
Fix invalid User-Agent field

### DIFF
--- a/internal/connect/version.go
+++ b/internal/connect/version.go
@@ -12,5 +12,5 @@ var (
 
 // GetShortenedVersion returns the short program version
 func GetShortenedVersion() string {
-	return strings.Split(version, "~")[0]
+	return strings.Split(strings.TrimSpace(version), "~")[0]
 }


### PR DESCRIPTION
When the string in version.txt did not have a "~" GetShortenedVersion() was returning the string but adding a newline.

Fixes https://github.com/SUSE/connect-ng/issues/188