### PR TITLE
Disallow the usage on transactional servers

### DIFF
--- a/internal/connect/system.go
+++ b/internal/connect/system.go
@@ -2,10 +2,21 @@ package connect
 
 import (
 	"bytes"
+	"errors"
+	"fmt"
 	"io"
 	"os"
 	"os/exec"
 	"strings"
+	"syscall"
+)
+
+const (
+	// From <linux/mount.h>, <bits/statvfs.h>, etc.
+	ST_RDONLY = 0x1
+
+	// From <linux/magic.h>
+	BTRFS_SUPER_MAGIC = 0x9123683E
 )
 
 var systemEcho bool
@@ -123,4 +134,38 @@ func UpdateCertificates() error {
 	}
 	// reload CA certs in Go
 	return ReloadCertPool()
+}
+
+// ReadOnlyFilesystem returns an error if the given root path contains a
+// read-only mount point or if the system should actually be managed through
+// `transactional-update`. Otherwise it just returns nil. Note that if the given
+// root path is empty, then "/" is assumed.
+func ReadOnlyFilesystem(root string) error {
+	path := root
+	if path == "" {
+		path = "/"
+	}
+	statfs := &syscall.Statfs_t{}
+	if err := syscall.Statfs(path, statfs); err != nil {
+		return fmt.Errorf("Checking whether %v is mounted read-only failed: %v", path, err)
+	}
+
+	// Just like zypper, we will assume that a BTRFS file system with the
+	// `transactional-update` binary installed is a transactional server.
+	_, err := os.Stat("/usr/sbin/transactional-update")
+	if statfs.Type == BTRFS_SUPER_MAGIC && err == nil {
+		// The user did not use the 'root' flag from the CLI: this is not
+		// `transactional-update` calling SUSEConnect but rather a user
+		// directly. This is not allowed.
+		if root == "" {
+			return errors.New("This is a transactional-server, please use `transactional-update register` to manage your product activations")
+		}
+	}
+
+	// The root is read only, we cannot write in there.
+	if (statfs.Flags & ST_RDONLY) == ST_RDONLY {
+		return fmt.Errorf("`%v` is mounted as `read-only`. Aborting", path)
+	}
+
+	return nil
 }

--- a/suseconnect/suseconnect.go
+++ b/suseconnect/suseconnect.go
@@ -175,6 +175,13 @@ func connectMain() {
 			}
 		})
 	}
+
+	// Reading the configuration/flags is done, now let's check if the
+	// filesystem can handle operations from SUSEConnect.
+	if err := connect.ReadOnlyFilesystem(connect.CFG.FsRoot); err != nil {
+		exitOnError(err)
+	}
+
 	if status {
 		output, err := connect.GetProductStatuses("json")
 		exitOnError(err)


### PR DESCRIPTION
## Description

If SUSEConnect is being used from a transactional server, it should be disallowed since the recommended way on this situation is to use `transactional-update`. Otherwise, we will also disallow using SUSEConnect if the given root is mounted read-only.

## How to test

There are three sides for testing this PR.

### Still works

Check that using SUSEConnect on a regular system continues to work. Bonus points if this system is using BTRFS as the file system.

### Transactional server

1. Install the built binary into a recent MicroOS image (or a system with BTRFS and `transactional-update` installed).
2. Run the program and check that an error is given instructing the user to use `transactional-update` instead.
3. `transactional-update` works.

### Read only mount point

1. Mount a device in read only mode. One thing I did was to create a dummy loopback device and then mount that (check [this tutorial](https://linuxhandbook.com/create-virtual-block-device/) on how to do it).
2. Call SUSEConnect with `--root` pointing to this read only mount point.
3. You should get an error about trying to use a read only root.