### PR TITLE
Set docker and podman auth credentials if possible

### DIFF
--- a/internal/connect/client.go
+++ b/internal/connect/client.go
@@ -124,6 +124,12 @@ func Deregister() error {
 		}
 	}
 
+	// remove potential docker and podman configurations for our registry
+	creds, err := getCredentials()
+	if err == nil {
+		removeRegistryAuthentication(creds.Username, creds.Password)
+	}
+
 	if err := deregisterSystem(); err != nil {
 		return err
 	}
@@ -350,13 +356,6 @@ func DeactivateProduct(product Product) (Service, error) {
 
 // DeregisterSystem deletes current system in SMT/SCC
 func DeregisterSystem() error {
-	// In case fetching credentials fails do not break
-	// but continue to allow deregistration with remote API
-	creds, err := getCredentials()
-	if err == nil {
-		removeRegistryAuthentication(creds.Username, creds.Password)
-	}
-
 	return deregisterSystem()
 }
 

--- a/internal/connect/client.go
+++ b/internal/connect/client.go
@@ -227,7 +227,11 @@ func announceOrUpdate() error {
 	if err != nil {
 		return err
 	}
-	return writeSystemCredentials(login, password, "")
+
+	if err = writeSystemCredentials(login, password, ""); err == nil {
+		setupRegistryAuthentication(login, password)
+	}
+	return err
 }
 
 // IsRegistered returns true if there is a valid credentials file
@@ -346,6 +350,13 @@ func DeactivateProduct(product Product) (Service, error) {
 
 // DeregisterSystem deletes current system in SMT/SCC
 func DeregisterSystem() error {
+	// In case fetching credentials fails do not break
+	// but continue to allow deregistration with remote API
+	creds, err := getCredentials()
+	if err == nil {
+		removeRegistryAuthentication(creds.Username, creds.Password)
+	}
+
 	return deregisterSystem()
 }
 

--- a/internal/connect/helpers_test.go
+++ b/internal/connect/helpers_test.go
@@ -3,6 +3,7 @@ package connect
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -27,5 +28,19 @@ func createTestCredentials(username, password string, t *testing.T) {
 	err := writeSystemCredentials(username, password, "")
 	if err != nil {
 		t.Fatal(err)
+	}
+}
+
+func testContentMatches(t *testing.T, expected string, got string) {
+	if expected != got {
+		message := []string{"write: Expected content to match:",
+			"---",
+			"%s",
+			"---",
+			"but got:",
+			"---",
+			"%s",
+			"---"}
+		t.Errorf(strings.Join(message, "\n"), expected, got)
 	}
 }

--- a/internal/connect/registry_auth.go
+++ b/internal/connect/registry_auth.go
@@ -1,0 +1,174 @@
+package connect
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// If the configuration file is not found for podman which resides
+// in ${XDG_RUNTIME_DIR}/containers/auth.json it will fall back to
+// docker configuration in ${HOME}/.docker.config.json
+// See: https://docs.podman.io/en/stable/markdown/podman-login.1.html
+
+const (
+	DEFAULT_DOCKER_CLIENT_CONFIG = ".docker/config.json"
+	DEFAULT_PODMAN_CONFIG        = "containers/auth.json"
+	DEFAULT_SUSE_REGISTRY        = "https://registry.suse.com"
+)
+
+// we need this to allow mocking the system function in our tests
+var (
+	readFile  = os.ReadFile
+	writeFile = os.WriteFile
+	userHome  = os.UserHomeDir
+	mkDirAll  = os.MkdirAll
+)
+
+// This is already implemented in containers. But for the fun sake we reinvent the wheel!
+// See: https://github.com/containers/image/blob/main/pkg/docker/config/config.go
+// Theoden: You have no dependency here!
+
+type RegistryAuthConfig struct {
+	AuthConfigs map[string]RegistryAuthentication `json:"auths"`
+	CredHelpers map[string]string                 `json:"credHelpers,omitempty"`
+}
+
+type RegistryAuthentication struct {
+	Auth          string `json:"auth,omitempty"`
+	IdentityToken string `json:"identitytoken,omitempty"`
+}
+
+func newRegistryAuthConfig() *RegistryAuthConfig {
+	return &RegistryAuthConfig{
+		AuthConfigs: map[string]RegistryAuthentication{},
+	}
+}
+
+func (cfg *RegistryAuthConfig) LoadFrom(path string) error {
+	data, err := readFile(path)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(data, cfg)
+}
+
+func (cfg *RegistryAuthConfig) SaveTo(path string) error {
+	data, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		return err
+	}
+	return writeFile(path, data, 0600)
+}
+
+func (cfg *RegistryAuthConfig) isConfigured(registry string) bool {
+	for configured := range cfg.AuthConfigs {
+		if configured == registry {
+			return true
+		}
+	}
+	return false
+}
+
+func (cfg *RegistryAuthConfig) Set(registry string, login string, password string) {
+	if cfg.isConfigured(registry) {
+		Debug.Printf("`%s` is already configured. Skipping", registry)
+		return
+	}
+
+	cred := fmt.Sprintf("%s:%s", login, password)
+	auth := base64.StdEncoding.EncodeToString([]byte(cred))
+
+	cfg.AuthConfigs[registry] = RegistryAuthentication{
+		Auth: auth,
+	}
+}
+
+func (cfg *RegistryAuthConfig) Get(registry string) (string, string, bool) {
+	if cfg.isConfigured(registry) == false {
+		return "", "", false
+	}
+	auth := cfg.AuthConfigs[registry].Auth
+
+	decoded, err := base64.StdEncoding.DecodeString(auth)
+	if err != nil {
+		return "", "", false
+	}
+
+	result := strings.Split(string(decoded), ":")
+	if len(result) != 2 {
+		return "", "", false
+	}
+	return result[0], result[1], true
+}
+
+func (cfg *RegistryAuthConfig) Remove(registry string) {
+	delete(cfg.AuthConfigs, registry)
+}
+
+func dockerConfigPath() (string, bool) {
+	home, err := userHome()
+	return filepath.Join(home, DEFAULT_DOCKER_CLIENT_CONFIG), err == nil
+}
+
+func podmanConfigPath() (string, bool) {
+	path, found := os.LookupEnv("XDG_RUNTIME_DIR")
+	return filepath.Join(path, DEFAULT_PODMAN_CONFIG), found
+}
+
+func setupRegistryAuthentication(login string, password string) {
+	setup := func(pathFn func() (string, bool)) {
+		config := newRegistryAuthConfig()
+
+		if path, ok := pathFn(); ok {
+			// This also fails if the file does not yet exist
+			// so we continue to create it.
+			if err := config.LoadFrom(path); err != nil {
+				Debug.Printf("Could not load `%s`: %s", path, err)
+			}
+			config.Set(DEFAULT_SUSE_REGISTRY, login, password)
+
+			if err := mkDirAll(filepath.Dir(path), 0777); err != nil {
+				Debug.Printf("Could not create directory `%s`: %s", filepath.Dir(path), err)
+				return
+			}
+
+			if err := config.SaveTo(path); err != nil {
+				Debug.Printf("Could not save config to `%s`: %s", path, err)
+			}
+		}
+	}
+	setup(dockerConfigPath)
+	setup(podmanConfigPath)
+}
+
+func removeRegistryAuthentication(login string, password string) {
+	remove := func(pathFn func() (string, bool)) {
+		config := newRegistryAuthConfig()
+
+		if path, ok := pathFn(); ok {
+			if err := config.LoadFrom(path); err != nil {
+				Debug.Printf("Could not load `%s`: %s", path, err)
+				return
+			}
+			l, p, found := config.Get(DEFAULT_SUSE_REGISTRY)
+
+			// Make sure to only delete if the credentials actually match,
+			// to not accidentially remove registry configuration which was
+			// manually added
+			if found == true && login == l && password == p {
+				config.Remove(DEFAULT_SUSE_REGISTRY)
+
+				if err := config.SaveTo(path); err != nil {
+					Debug.Printf("Could not save config to `%s`: %s", path, err)
+				}
+			}
+		}
+
+	}
+	remove(dockerConfigPath)
+	remove(podmanConfigPath)
+}

--- a/internal/connect/registry_auth_test.go
+++ b/internal/connect/registry_auth_test.go
@@ -1,0 +1,132 @@
+package connect
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+var (
+	sampleLogin        = "SCC_a9b5e32370fb41e1baf99349f2780ae4"
+	samplePassword     = "a3cd1331fb714e82"
+	expectedDockerPath = "/home/test/.docker/config.json"
+	expectedPodmanPath = "/var/run/1312/containers/auth.json"
+	expectedRuntimeDir = "/var/run/1312/"
+)
+
+func testPathMatches(t *testing.T, path string) {
+	if path != expectedDockerPath && path != expectedPodmanPath {
+		t.Errorf("JSON path should be:\n `%s` or `%s` \n got: `%s`",
+			expectedDockerPath,
+			expectedPodmanPath,
+			path)
+	}
+}
+
+func mockCurrentUserHome(home string) {
+	userHome = func() (string, error) {
+		return home, nil
+	}
+}
+
+func mockReadFile(t *testing.T, samplefile string) {
+	readFile = func(path string) ([]byte, error) {
+		testPathMatches(t, path)
+
+		samplePath := filepath.Join("registry_auth", samplefile)
+		return readTestFile(samplePath, t), nil
+	}
+}
+
+func mockWriteFile(t *testing.T, matcherfile string) {
+	writeFile = func(path string, content []byte, _ os.FileMode) error {
+		testPathMatches(t, path)
+
+		matcherPath := filepath.Join("registry_auth", matcherfile)
+		expected := strings.Trim(string(readTestFile(matcherPath, t)), "\n")
+
+		testContentMatches(t, expected, string(content))
+		return nil
+	}
+
+}
+
+func mockMkDirAll(t *testing.T) {
+	mkDirAll = func(_ string, perm os.FileMode) error {
+		if perm != 0777 {
+			t.Log(fmt.Sprintf("mkdirall: %s is unlikely the right directory permission. Are you sure?", perm))
+		}
+		return nil
+	}
+}
+
+func TestRegistryAuthSetupSuccessful(t *testing.T) {
+	os.Setenv("XDG_RUNTIME_DIR", expectedRuntimeDir)
+	mockMkDirAll(t)
+	mockCurrentUserHome("/home/test")
+	mockReadFile(t, "auth.json")
+	mockWriteFile(t, "auth_updated.json")
+
+	setupRegistryAuthentication(sampleLogin, samplePassword)
+}
+
+func TestRegistryAuthSetupReadFailed(t *testing.T) {
+	os.Setenv("XDG_RUNTIME_DIR", expectedRuntimeDir)
+	mockMkDirAll(t)
+	mockCurrentUserHome("/home/test")
+	mockWriteFile(t, "auth_write_single.json")
+
+	readFile = func(path string) ([]byte, error) {
+		return []byte{}, os.ErrNotExist
+	}
+
+	// Note: This will never fail, since it must not interrupt
+	//       registration process
+	setupRegistryAuthentication(sampleLogin, samplePassword)
+}
+
+func TestRegistryAuthSetupWriteDockerFailed(t *testing.T) {
+	os.Setenv("XDG_RUNTIME_DIR", expectedRuntimeDir)
+	mockCurrentUserHome("/home/test")
+	mockReadFile(t, "empty_auth.json")
+
+	writeFile = func(path string, content []byte, _ os.FileMode) error {
+		// fail to docker config failed
+		if path == expectedDockerPath {
+			return fmt.Errorf("Permission denied")
+		}
+
+		expected := strings.Trim(string(readTestFile("registry_auth/auth_write_single.json", t)), "\n")
+		testContentMatches(t, expected, string(content))
+		return nil
+	}
+
+	setupRegistryAuthentication(sampleLogin, samplePassword)
+}
+
+func TestRegistryAuthRemoveSuccessful(t *testing.T) {
+	os.Setenv("XDG_RUNTIME_DIR", expectedRuntimeDir)
+	mockCurrentUserHome("/home/test")
+	mockReadFile(t, "auth_updated.json")
+	mockWriteFile(t, "auth.json")
+
+	removeRegistryAuthentication(sampleLogin, samplePassword)
+}
+
+func TestRegistryAuthRemoveReadFailed(t *testing.T) {
+	os.Setenv("XDG_RUNTIME_DIR", expectedRuntimeDir)
+	mockCurrentUserHome("/home/test")
+
+	readFile = func(_ string) ([]byte, error) {
+		return []byte{}, os.ErrNotExist
+	}
+
+	writeFile = func(_ string, _ []byte, _ os.FileMode) error {
+		fmt.Errorf("Expected writeFile to never be called")
+		return nil
+	}
+
+	removeRegistryAuthentication(sampleLogin, samplePassword)
+}

--- a/testdata/registry_auth/auth.json
+++ b/testdata/registry_auth/auth.json
@@ -1,0 +1,11 @@
+{
+  "auths": {
+    "localhost:5000": {
+      "auth": "cmVnY29kZTpzdWJodWItaWQtMTE3ODUwNg==",
+      "identitytoken": "my precious!"
+    }
+  },
+  "credHelpers": {
+    "helper": "some helpful helper"
+  }
+}

--- a/testdata/registry_auth/auth_custom.json
+++ b/testdata/registry_auth/auth_custom.json
@@ -1,0 +1,14 @@
+{
+  "auths": {
+    "https://registry.suse.com": {
+      "auth": "U0NDX0ZPT09PT0JCQkJBUlJSUlI6c3Ryb25ncGFzc3dvcmQ="
+    },
+    "localhost:5000": {
+      "auth": "cmVnY29kZTpzdWJodWItaWQtMTE3ODUwNg==",
+      "identitytoken": "my precious!"
+    }
+  },
+  "credHelpers": {
+    "helper": "some helpful helper"
+  }
+}

--- a/testdata/registry_auth/auth_updated.json
+++ b/testdata/registry_auth/auth_updated.json
@@ -1,0 +1,14 @@
+{
+  "auths": {
+    "https://registry.suse.com": {
+      "auth": "U0NDX2E5YjVlMzIzNzBmYjQxZTFiYWY5OTM0OWYyNzgwYWU0OmEzY2QxMzMxZmI3MTRlODI="
+    },
+    "localhost:5000": {
+      "auth": "cmVnY29kZTpzdWJodWItaWQtMTE3ODUwNg==",
+      "identitytoken": "my precious!"
+    }
+  },
+  "credHelpers": {
+    "helper": "some helpful helper"
+  }
+}

--- a/testdata/registry_auth/auth_write_single.json
+++ b/testdata/registry_auth/auth_write_single.json
@@ -1,0 +1,7 @@
+{
+  "auths": {
+    "https://registry.suse.com": {
+      "auth": "U0NDX2E5YjVlMzIzNzBmYjQxZTFiYWY5OTM0OWYyNzgwYWU0OmEzY2QxMzMxZmI3MTRlODI="
+    }
+  }
+}


### PR DESCRIPTION
## Write system credentials into `docker` and `podman` authentication file
Populate `$HOME/.docker/config.json` and `$XDG_RUNTIME_DIR/containers/auth.json` with system credentials provided after registration.

internal card: https://trello.com/c/k6GueN3v/3051-7asr-suseconnect-ng-preconfigures-docker-configuration

*How to test this feature:*

helpful snippets:
```
# bootstrap container with connect + branch added
host$ docker run --rm -ti --privileged registry.suse.com/suse/sle15:15.5
> zypper ar https://download.opensuse.org/repositories/home:/fschnizlein:/branches:/systemsmanagement:/SCC/SLE_15_SP5/home:fschnizlein:branches:systemsmanagement:SCC.repo
> zypper ref
> zypper in -y suseconnect-ng jq
host$ docker commit <container_id> ng-testing
# docker run --rm -ti --privileged ng-testing

# Paths
docker: $HOME/.docker/config.json
podman: $XDG_RUNTIME_DIR/containers/auth.json

# Check credentials:
cat <path> | jq -Mr '.auths["https://registry.suse.com"].auth' | base64 -d
```

Test matrix:
- Registering a system normally and `XDG_RUNTIME_DIR` is `unset`. Check if login is available in docker config
- Registering a system but before set `XDG_RUNTME_DIR` to `$HOME` And check that `containers/auth.json` is populated
- Check if configs (docker/podman) already exists that the config is added and all existing data is preserved
- Check if a login for `https://registry.suse.com` already exists, nothing is changed
- Check when de-registering that configs are reset
- Check when de-registering that configs are *NOT* reset if the login does not match the system credentials

The hard part:
- Run an environment where you actually populate `XDG_RUNTIME_DIR` with real world values (namely `/var/run/1000`) and make sure the above works

If you need help, feel free to reach out to me!

Thanks for looking into this!