### PR TITLE
Add configuration messages when configuring container registry authentication

### DIFF
--- a/internal/connect/client.go
+++ b/internal/connect/client.go
@@ -127,6 +127,7 @@ func Deregister() error {
 	// remove potential docker and podman configurations for our registry
 	creds, err := getCredentials()
 	if err == nil {
+		Debug.Print("\nRemoving SUSE registry system authentication configuration ...")
 		removeRegistryAuthentication(creds.Username, creds.Password)
 	}
 
@@ -235,6 +236,7 @@ func announceOrUpdate() error {
 	}
 
 	if err = writeSystemCredentials(login, password, ""); err == nil {
+		Debug.Print("\nAdding SUSE registry system authentication configuration ...")
 		setupRegistryAuthentication(login, password)
 	}
 	return err

--- a/internal/connect/registry_auth.go
+++ b/internal/connect/registry_auth.go
@@ -159,6 +159,8 @@ func setupRegistryAuthentication(login string, password string) {
 			Debug.Printf("Could not save config to `%s`: %s", path, err)
 			return
 		}
+
+		Debug.Printf("SUSE registry system authentication written to `%s`", path)
 	}
 }
 
@@ -183,6 +185,8 @@ func removeRegistryAuthentication(login string, password string) {
 			if err := config.SaveTo(path); err != nil {
 				Debug.Printf("Could not save config to `%s`: %s", path, err)
 			}
+
+			Debug.Printf("SUSE registry system authentication removed from `%s`", path)
 		}
 	}
 


### PR DESCRIPTION
Add missing print statements.

**How to test:**

See: https://github.com/SUSE/connect-ng/pull/191

Check registration with `--debug` e.g. `out/connect --debug -r <regcode>`