### PR TITLE
Add support for service installation skip env var

### DIFF
--- a/internal/connect/client.go
+++ b/internal/connect/client.go
@@ -114,15 +114,17 @@ func registerProduct(product Product, installReleasePkg bool, jsonOutput bool) (
 		}
 
 		if err := addService(service.URL, service.Name, !CFG.NoZypperRefresh); err != nil {
-			return nil, err
+			return Service{}, err
 		}
 	}
-	if installReleasePkg {
+
+	if installReleasePkg && !CFG.SkipServiceInstall {
 		if jsonOutput {
 			Debug.Print("-> Installing release package ...")
 		} else {
 			Info.Print("-> Installing release package ...")
 		}
+
 		if err := InstallReleasePackage(product.Name); err != nil {
 			return Service{}, err
 		}
@@ -366,11 +368,9 @@ func announceOrUpdate(quiet bool) error {
 		return err
 	}
 
-	if !CFG.SkipServiceInstall {
-		if err = writeSystemCredentials(login, password, ""); err == nil {
-			Debug.Print("\nAdding SUSE registry system authentication configuration ...")
-			setupRegistryAuthentication(login, password)
-		}
+	if err = writeSystemCredentials(login, password, ""); err == nil {
+		Debug.Print("\nAdding SUSE registry system authentication configuration ...")
+		setupRegistryAuthentication(login, password)
 	}
 	return err
 }

--- a/internal/connect/client.go
+++ b/internal/connect/client.go
@@ -219,8 +219,10 @@ func Deregister(jsonOutput bool) error {
 		return err
 	}
 
-	if err := removeOrRefreshService(baseProductService, jsonOutput); err != nil {
-		return err
+	if !CFG.SkipServiceInstall {
+		if err := removeOrRefreshService(baseProductService, jsonOutput); err != nil {
+			return err
+		}
 	}
 	if !jsonOutput {
 		Info.Print("\nCleaning up ...")
@@ -258,6 +260,11 @@ func deregisterProduct(product Product, jsonOutput bool, out *RegisterOut) error
 	if err != nil {
 		return err
 	}
+
+	if CFG.SkipServiceInstall {
+		return nil
+	}
+
 	if err := removeOrRefreshService(service, jsonOutput); err != nil {
 		return err
 	}

--- a/internal/connect/client.go
+++ b/internal/connect/client.go
@@ -31,6 +31,12 @@ type ServiceOut struct {
 	Url  string `json:"url"`
 }
 
+var (
+	localAddService             = addService
+	localInstallReleasePackage  = InstallReleasePackage
+	localRemoveOrRefreshService = removeOrRefreshService
+)
+
 // Register announces the system, activates the
 // product on SCC and adds the service to the system
 func Register(jsonOutput bool) error {
@@ -113,7 +119,7 @@ func registerProduct(product Product, installReleasePkg bool, jsonOutput bool) (
 			Info.Print("-> Adding service to system ...")
 		}
 
-		if err := addService(service.URL, service.Name, !CFG.NoZypperRefresh); err != nil {
+		if err := localAddService(service.URL, service.Name, !CFG.NoZypperRefresh); err != nil {
 			return Service{}, err
 		}
 	}
@@ -125,7 +131,7 @@ func registerProduct(product Product, installReleasePkg bool, jsonOutput bool) (
 			Info.Print("-> Installing release package ...")
 		}
 
-		if err := InstallReleasePackage(product.Name); err != nil {
+		if err := localInstallReleasePackage(product.Name); err != nil {
 			return Service{}, err
 		}
 	}
@@ -222,7 +228,7 @@ func Deregister(jsonOutput bool) error {
 	}
 
 	if !CFG.SkipServiceInstall {
-		if err := removeOrRefreshService(baseProductService, jsonOutput); err != nil {
+		if err := localRemoveOrRefreshService(baseProductService, jsonOutput); err != nil {
 			return err
 		}
 	}
@@ -267,7 +273,7 @@ func deregisterProduct(product Product, jsonOutput bool, out *RegisterOut) error
 		return nil
 	}
 
-	if err := removeOrRefreshService(service, jsonOutput); err != nil {
+	if err := localRemoveOrRefreshService(service, jsonOutput); err != nil {
 		return err
 	}
 	if jsonOutput {

--- a/internal/connect/client.go
+++ b/internal/connect/client.go
@@ -106,13 +106,16 @@ func registerProduct(product Product, installReleasePkg bool, jsonOutput bool) (
 		return Service{}, err
 	}
 
-	if jsonOutput {
-		Debug.Print("-> Adding service to system ...")
-	} else {
-		Info.Print("-> Adding service to system ...")
-	}
-	if err := addService(service.URL, service.Name, !CFG.NoZypperRefresh); err != nil {
-		return Service{}, err
+	if !CFG.SkipServiceInstall {
+		if jsonOutput {
+			Debug.Print("-> Adding service to system ...")
+		} else {
+			Info.Print("-> Adding service to system ...")
+		}
+
+		if err := addService(service.URL, service.Name, !CFG.NoZypperRefresh); err != nil {
+			return nil, err
+		}
 	}
 	if installReleasePkg {
 		if jsonOutput {
@@ -356,9 +359,11 @@ func announceOrUpdate(quiet bool) error {
 		return err
 	}
 
-	if err = writeSystemCredentials(login, password, ""); err == nil {
-		Debug.Print("\nAdding SUSE registry system authentication configuration ...")
-		setupRegistryAuthentication(login, password)
+	if !CFG.SkipServiceInstall {
+		if err = writeSystemCredentials(login, password, ""); err == nil {
+			Debug.Print("\nAdding SUSE registry system authentication configuration ...")
+			setupRegistryAuthentication(login, password)
+		}
 	}
 	return err
 }

--- a/internal/connect/client_test.go
+++ b/internal/connect/client_test.go
@@ -1,0 +1,78 @@
+package connect
+
+import "testing"
+
+func mockAddServiceCalled(t *testing.T, expected bool) {
+	counter := 0
+	localAddService = func(string, string, bool) error {
+		counter += 1
+		return nil
+	}
+
+	if !expected {
+		if counter > 1 {
+			t.Errorf("Expected addService not to be called.")
+		}
+	}
+}
+
+func mockInstallReleasePackage(t *testing.T, expected bool) {
+	counter := 0
+	localInstallReleasePackage = func(string) error {
+		counter += 1
+		return nil
+	}
+
+	if !expected {
+		if counter > 1 {
+			t.Errorf("Expected InstallReleasePackage not to be called.")
+		}
+	}
+}
+
+func mockRemoveOrRefreshService(t *testing.T, expected bool) {
+	counter := 0
+	localRemoveOrRefreshService = func(Service, bool) error {
+		counter += 1
+		return nil
+	}
+
+	if !expected {
+		if counter > 1 {
+			t.Errorf("Expected removeOrRefreshService not to be called.")
+		}
+	}
+
+}
+
+func TestClientRegisterWithServiceInstallSkipSuccessful(t *testing.T) {
+	CFG.Product = Product{Name: "sle-module-basesystem", Version: "15.2", Arch: "x86_64"}
+	CFG.SkipServiceInstall = true
+	mockAddServiceCalled(t, false)
+	mockInstallReleasePackage(t, false)
+	Register(false)
+}
+
+func TestClientRegisterWithoutServiceInstallSkipSuccessful(t *testing.T) {
+	CFG.Product = Product{Name: "sle-module-basesystem", Version: "15.2", Arch: "x86_64"}
+	CFG.SkipServiceInstall = false
+	mockAddServiceCalled(t, true)
+	mockInstallReleasePackage(t, true)
+	Register(false)
+}
+
+func TestClientDeregistrationWithServiceInstallSkipSuccessful(t *testing.T) {
+	CFG.Product = Product{Name: "sle-module-basesystem", Version: "15.2", Arch: "x86_64"}
+	CFG.SkipServiceInstall = true
+	mockAddServiceCalled(t, false)
+	mockInstallReleasePackage(t, false)
+	Deregister(false)
+}
+
+func TestClientDeregistrationWithoutServiceInstallSkipSuccessful(t *testing.T) {
+	CFG.Product = Product{Name: "sle-module-basesystem", Version: "15.2", Arch: "x86_64"}
+	CFG.SkipServiceInstall = false
+	mockAddServiceCalled(t, true)
+	mockInstallReleasePackage(t, true)
+	Deregister(false)
+}

--- a/internal/connect/config.go
+++ b/internal/connect/config.go
@@ -20,6 +20,7 @@ const (
 	defaultConfigPath = "/etc/SUSEConnect"
 	defaultBaseURL    = "https://scc.suse.com"
 	defaultInsecure   = false
+	defaultSkip       = false
 )
 
 // Config holds the config!
@@ -38,14 +39,16 @@ type Config struct {
 
 	NoZypperRefresh    bool
 	AutoImportRepoKeys bool
+	SkipServiceInstall bool
 }
 
 // NewConfig returns a Config with defaults
 func NewConfig() Config {
 	return Config{
-		Path:     defaultConfigPath,
-		BaseURL:  defaultBaseURL,
-		Insecure: defaultInsecure,
+		Path:               defaultConfigPath,
+		BaseURL:            defaultBaseURL,
+		Insecure:           defaultInsecure,
+		SkipServiceInstall: defaultSkip,
 	}
 }
 

--- a/suseconnect/suseconnect.go
+++ b/suseconnect/suseconnect.go
@@ -167,6 +167,9 @@ func connectMain() {
 			connect.CFG.Language = lang
 		}
 	}
+	if _, ok := os.LookupEnv("SKIP_SERVICE_INSTALL"); ok {
+		connect.CFG.SkipServiceInstall = true
+	}
 	if autoAgreeWithLicenses {
 		connect.CFG.AutoAgreeEULA = true
 	} else {


### PR DESCRIPTION
This PR introduces an environment variable (`SKIP_SERVICE_INSTALL`) to skip service file persistence to disk. This is a requested feature from the Agama team.

### How to test

1.  Build the package: `make`
2.  Start a docker container with latest connect-ng build: `docker run -it --rm -v $PWD/out:/tmp registry.suse.com/suse/sle15:15.4 bash`

Inside docker:
* move the newly built binary: `mv /tmp/suseconnect /usr/bin`
* Run registration with: `SKIP_SERVICE_INSTALL=1 suseconnect -r <your_regcode>`
* Status shows that only the base product as being registered
* Try deregistration: `SKIP_SERVICE_INSTALL=1 suseconnect -d`

