### PR TITLE
Implemented the --json flag when de/registering

### DIFF
--- a/internal/connect/client.go
+++ b/internal/connect/client.go
@@ -1,16 +1,43 @@
 package connect
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
 )
 
+type RegisterOut struct {
+	Success  bool             `json:"success"`
+	Products []ProductService `json:"products"`
+	Message  string           `json:"message"`
+}
+
+type ProductService struct {
+	Product ProductOut `json:"product"`
+	Service ServiceOut `json:"service"`
+}
+
+type ProductOut struct {
+	Name       string `json:"name"`
+	Identifier string `json:"identifier"`
+	Version    string `json:"version"`
+	Arch       string `json:"arch"`
+}
+
+type ServiceOut struct {
+	Id   int    `json:"id"`
+	Name string `json:"name"`
+	Url  string `json:"url"`
+}
+
 // Register announces the system, activates the
 // product on SCC and adds the service to the system
-func Register() error {
-	printInformation("register")
-	err := announceOrUpdate()
+func Register(jsonOutput bool) error {
+	out := &RegisterOut{}
+
+	printInformation("register", jsonOutput)
+	err := announceOrUpdate(jsonOutput)
 	if err != nil {
 		return err
 	}
@@ -25,7 +52,21 @@ func Register() error {
 		installReleasePkg = false
 	}
 
-	if err = registerProduct(product, installReleasePkg); err != nil {
+	if service, err := registerProduct(product, installReleasePkg, jsonOutput); err == nil {
+		out.Products = append(out.Products, ProductService{
+			Product: ProductOut{
+				Name:       product.LongName,
+				Identifier: product.Name,
+				Version:    product.Version,
+				Arch:       product.Arch,
+			},
+			Service: ServiceOut{
+				Id:   service.ID,
+				Name: service.Name,
+				Url:  service.URL,
+			},
+		})
+	} else {
 		return err
 	}
 
@@ -34,43 +75,81 @@ func Register() error {
 		if err != nil {
 			return err
 		}
-		if err := registerProductTree(p); err != nil {
+		if err := registerProductTree(p, jsonOutput, out); err != nil {
 			return err
 		}
 	}
-	Info.Print(bold(greenText("\nSuccessfully registered system")))
+	if jsonOutput {
+		out.Success = true
+		out.Message = "Successfully registered system"
+		out, err := json.Marshal(out)
+		if err != nil {
+			return err
+		}
+		Info.Println(string(out))
+	} else {
+		Info.Print(bold(greenText("\nSuccessfully registered system")))
+	}
 	return nil
 }
 
 // registerProduct activates the product, adds the service and installs the release package
-func registerProduct(product Product, installReleasePkg bool) error {
-	Info.Printf("\nActivating %s %s %s ...\n", product.Name, product.Version, product.Arch)
+func registerProduct(product Product, installReleasePkg bool, jsonOutput bool) (Service, error) {
+	if jsonOutput {
+		Debug.Printf("\nActivating %s %s %s ...\n", product.Name, product.Version, product.Arch)
+	} else {
+		Info.Printf("\nActivating %s %s %s ...\n", product.Name, product.Version, product.Arch)
+	}
+
 	service, err := activateProduct(product, CFG.Email)
 	if err != nil {
-		return err
+		return Service{}, err
 	}
-	Info.Print("-> Adding service to system ...")
+
+	if jsonOutput {
+		Debug.Print("-> Adding service to system ...")
+	} else {
+		Info.Print("-> Adding service to system ...")
+	}
 	if err := addService(service.URL, service.Name, !CFG.NoZypperRefresh); err != nil {
-		return err
+		return Service{}, err
 	}
 	if installReleasePkg {
-		Info.Print("-> Installing release package ...")
+		if jsonOutput {
+			Debug.Print("-> Installing release package ...")
+		} else {
+			Info.Print("-> Installing release package ...")
+		}
 		if err := InstallReleasePackage(product.Name); err != nil {
-			return err
+			return Service{}, err
 		}
 	}
-	return nil
+	return service, nil
 }
 
 // registerProductTree traverses (depth-first search) the product
 // tree and registers the recommended and available products
-func registerProductTree(product Product) error {
+func registerProductTree(product Product, jsonOutput bool, out *RegisterOut) error {
 	for _, extension := range product.Extensions {
 		if extension.Recommended && extension.Available {
-			if err := registerProduct(extension, true); err != nil {
+			if service, err := registerProduct(extension, true, jsonOutput); err == nil {
+				out.Products = append(out.Products, ProductService{
+					Product: ProductOut{
+						Name:       product.LongName,
+						Identifier: product.Name,
+						Version:    product.Version,
+						Arch:       product.Arch,
+					},
+					Service: ServiceOut{
+						Id:   service.ID,
+						Name: service.Name,
+						Url:  service.URL,
+					},
+				})
+			} else {
 				return err
 			}
-			if err := registerProductTree(extension); err != nil {
+			if err := registerProductTree(extension, jsonOutput, out); err != nil {
 				return err
 			}
 		}
@@ -79,7 +158,7 @@ func registerProductTree(product Product) error {
 }
 
 // Deregister deregisters the system
-func Deregister() error {
+func Deregister(jsonOutput bool) error {
 	if fileExists("/usr/sbin/registercloudguest") && CFG.Product.isEmpty() {
 		return fmt.Errorf("SUSE::Connect::UnsupportedOperation: " +
 			"De-registration is disabled for on-demand instances. " +
@@ -90,9 +169,11 @@ func Deregister() error {
 		return ErrSystemNotRegistered
 	}
 
-	printInformation("deregister")
+	out := &RegisterOut{}
+
+	printInformation("deregister", jsonOutput)
 	if !CFG.Product.isEmpty() {
-		return deregisterProduct(CFG.Product)
+		return deregisterProduct(CFG.Product, jsonOutput, out)
 	}
 	baseProd, _ := baseProduct()
 	baseProductService, err := upgradeProduct(baseProd)
@@ -119,7 +200,7 @@ func Deregister() error {
 
 	// reverse loop over dependencies
 	for i := len(dependencies) - 1; i >= 0; i-- {
-		if err := deregisterProduct(dependencies[i]); err != nil {
+		if err := deregisterProduct(dependencies[i], jsonOutput, out); err != nil {
 			return err
 		}
 	}
@@ -135,19 +216,31 @@ func Deregister() error {
 		return err
 	}
 
-	if err := removeOrRefreshService(baseProductService); err != nil {
+	if err := removeOrRefreshService(baseProductService, jsonOutput); err != nil {
 		return err
 	}
-	Info.Print("\nCleaning up ...")
+	if !jsonOutput {
+		Info.Print("\nCleaning up ...")
+	}
 	if err := Cleanup(); err != nil {
 		return err
 	}
-	Info.Print(bold(greenText("Successfully deregistered system")))
+	if jsonOutput {
+		out.Success = true
+		out.Message = "Successfully deregistered system"
+		out, err := json.Marshal(out)
+		if err != nil {
+			return err
+		}
+		Info.Println(string(out))
+	} else {
+		Info.Print(bold(greenText("Successfully deregistered system")))
+	}
 
 	return nil
 }
 
-func deregisterProduct(product Product) error {
+func deregisterProduct(product Product, jsonOutput bool, out *RegisterOut) error {
 	base, err := baseProduct()
 	if err != nil {
 		return err
@@ -155,33 +248,58 @@ func deregisterProduct(product Product) error {
 	if product.ToTriplet() == base.ToTriplet() {
 		return ErrBaseProductDeactivation
 	}
-	Info.Printf("\nDeactivating %s %s %s ...\n", product.Name, product.Version, product.Arch)
+	if !jsonOutput {
+		Info.Printf("\nDeactivating %s %s %s ...\n", product.Name, product.Version, product.Arch)
+	}
 	service, err := deactivateProduct(product)
 	if err != nil {
 		return err
 	}
-	if err := removeOrRefreshService(service); err != nil {
+	if err := removeOrRefreshService(service, jsonOutput); err != nil {
 		return err
 	}
-	Info.Print("-> Removing release package ...")
+	if jsonOutput {
+		out.Products = append(out.Products, ProductService{
+			Product: ProductOut{
+				Name:       product.LongName,
+				Identifier: product.Name,
+				Version:    product.Version,
+				Arch:       product.Arch,
+			},
+			Service: ServiceOut{
+				Id:   service.ID,
+				Name: service.Name,
+				Url:  service.URL,
+			},
+		})
+	} else {
+		Info.Print("-> Removing release package ...")
+	}
 	return removeReleasePackage(product.Name)
 }
 
 // SMT provides one service for all products, removing it would remove all repositories.
 // Refreshing the service instead to remove the repos of deregistered product.
-func removeOrRefreshService(service Service) error {
+func removeOrRefreshService(service Service, jsonOutput bool) error {
 	if service.Name == "SMT_DUMMY_NOREMOVE_SERVICE" {
-		Info.Print("-> Refreshing service ...")
+		if !jsonOutput {
+			Info.Print("-> Refreshing service ...")
+		}
 		refreshAllServices()
 		return nil
 	}
-	Info.Print("-> Removing service from system ...")
+	if !jsonOutput {
+		Info.Print("-> Removing service from system ...")
+	}
 	return removeService(service.Name)
 }
 
 // AnnounceSystem announce system via SCC/Registration Proxy
-func AnnounceSystem(distroTgt string, instanceDataFile string) (string, string, error) {
-	Info.Printf(bold("\nAnnouncing system to %s ..."), CFG.BaseURL)
+func AnnounceSystem(distroTgt string, instanceDataFile string, quiet bool) (string, string, error) {
+	if !quiet {
+		Info.Printf(bold("\nAnnouncing system to %s ..."), CFG.BaseURL)
+	}
+
 	instanceData, err := readInstanceData(instanceDataFile)
 	if err != nil {
 		return "", "", err
@@ -194,8 +312,10 @@ func AnnounceSystem(distroTgt string, instanceDataFile string) (string, string, 
 }
 
 // UpdateSystem resend the system's hardware details on SCC
-func UpdateSystem(distroTarget, instanceDataFile string) error {
-	Info.Printf(bold("\nUpdating system details on %s ..."), CFG.BaseURL)
+func UpdateSystem(distroTarget, instanceDataFile string, quiet bool) error {
+	if !quiet {
+		Info.Printf(bold("\nUpdating system details on %s ..."), CFG.BaseURL)
+	}
 	instanceData, err := readInstanceData(instanceDataFile)
 	if err != nil {
 		return err
@@ -212,25 +332,26 @@ func SendKeepAlivePing() error {
 	if !IsRegistered() {
 		return ErrPingFromUnregistered
 	}
-	err := UpdateSystem("", "")
+	err := UpdateSystem("", "", false)
 	if err == nil {
 		Info.Print(bold(greenText("\nSuccessfully updated system")))
 	}
 	return err
 }
 
-// announceOrUpdate Announces the system to the server, receiving and storing its
-// credentials. When already announced, sends the current hardware details to the server
-func announceOrUpdate() error {
+// announceOrUpdate Announces the system to the server, receiving and storing
+// its credentials. When already announced, sends the current hardware details
+// to the server. The output is not shown on stdout if `quiet` is set to true.
+func announceOrUpdate(quiet bool) error {
 	if IsRegistered() {
-		return UpdateSystem("", "")
+		return UpdateSystem("", "", quiet)
 	}
 
 	distroTgt := ""
 	if !CFG.Product.isEmpty() {
 		distroTgt = CFG.Product.distroTarget()
 	}
-	login, password, err := AnnounceSystem(distroTgt, CFG.InstanceDataFile)
+	login, password, err := AnnounceSystem(distroTgt, CFG.InstanceDataFile, quiet)
 	if err != nil {
 		return err
 	}
@@ -259,7 +380,7 @@ func URLDefault() bool {
 	return CFG.BaseURL == defaultBaseURL
 }
 
-func printInformation(action string) {
+func printInformation(action string, jsonOutput bool) {
 	var server string
 	if URLDefault() {
 		server = "SUSE Customer Center"
@@ -267,15 +388,31 @@ func printInformation(action string) {
 		server = "registration proxy " + CFG.BaseURL
 	}
 	if action == "register" {
-		Info.Printf(bold("Registering system to %s"), server)
+		if jsonOutput {
+			Debug.Printf(bold("Registering system to %s"), server)
+		} else {
+			Info.Printf(bold("Registering system to %s"), server)
+		}
 	} else {
-		Info.Printf(bold("Deregistering system from %s"), server)
+		if jsonOutput {
+			Debug.Printf(bold("Deregistering system from %s"), server)
+		} else {
+			Info.Printf(bold("Deregistering system from %s"), server)
+		}
 	}
 	if CFG.FsRoot != "" {
-		Info.Print("Rooted at:", CFG.FsRoot)
+		if jsonOutput {
+			Debug.Print("Rooted at:", CFG.FsRoot)
+		} else {
+			Info.Print("Rooted at:", CFG.FsRoot)
+		}
 	}
 	if CFG.Email != "" {
-		Info.Print("Using E-Mail:", CFG.Email)
+		if jsonOutput {
+			Debug.Print("Using E-Mail:", CFG.Email)
+		} else {
+			Info.Print("Using E-Mail:", CFG.Email)
+		}
 	}
 }
 

--- a/internal/connect/product.go
+++ b/internal/connect/product.go
@@ -8,6 +8,11 @@ import (
 )
 
 // Product represents an installed product or product information from API
+//
+// NOTE (FTW epic): some of the things here do not map correctly with SCC's API
+// and it's admittedly quite bananas (e.g. SCC's "identifier" being "Name" but
+// then SCC's "name" being "LongName" and claiming that it's used by Yast
+// (wtf?)).
 type Product struct {
 	Name    string `xml:"name,attr" json:"identifier"`
 	Version string `xml:"version,attr" json:"version"`

--- a/libsuseconnect/libsuseconnect.go
+++ b/libsuseconnect/libsuseconnect.go
@@ -60,7 +60,7 @@ func free_string(str *C.char) {
 func announce_system(clientParams, distroTarget *C.char) *C.char {
 	loadConfig(C.GoString(clientParams))
 
-	login, password, err := connect.AnnounceSystem(C.GoString(distroTarget), "")
+	login, password, err := connect.AnnounceSystem(C.GoString(distroTarget), "", false)
 	if err != nil {
 		return C.CString(errorToJSON(err))
 	}
@@ -77,7 +77,7 @@ func announce_system(clientParams, distroTarget *C.char) *C.char {
 func update_system(clientParams, distroTarget *C.char) *C.char {
 	loadConfig(C.GoString(clientParams))
 
-	if err := connect.UpdateSystem(C.GoString(distroTarget), ""); err != nil {
+	if err := connect.UpdateSystem(C.GoString(distroTarget), "", false); err != nil {
 		return C.CString(errorToJSON(err))
 	}
 

--- a/suseconnect/connectUsage.txt
+++ b/suseconnect/connectUsage.txt
@@ -55,4 +55,6 @@ Common options:
                              Automatically trust and import new repository
                              signing keys.
         --debug              Provide debug output.
+        --json               Switch the output format to JSON. This is only
+                             supported by the register and deregister commands.
     -h, --help               Show this message.


### PR DESCRIPTION
## Description

This commit adds the `json` flag just for the register and de-register commands. This flag will then disable all the usual output from both these commands and instead print to stdout the JSON schema as agreed on RFC 0038 regarding the SUSEConnect and Agama integration.

## How to test

Simply build this and call the register/de-register commands with `--json`. If you do so with a command that is not either of those, you will get:

```
# ./out/suseconnect --json -l
SUSEConnect error: cannot use the json option with the 'list-extensions' command
```

Then, if you register:

```
# ./out/suseconnect --json -r <regcode> | jq
```

This will take some time but in the end it will give you JSON output as expected from the RFC. As for de-registering, the RFC does not provide a model, but I have implemented the same schema as for registering. Hence, the following will provide a similar output as the command above:

```
# ./out/suseconnect --json --de-register | jq
```

If the operation fails, a json-formatted error is also given. For example, if you try to de-register a system which is not registered, this is given:

```
# ./out/suseconnect --json --de-register | jq
{
  "success": false,
  "products": null,
  "message": "System not registered"
}
```