### PR TITLE
Rename name to identifier and friendly_name to name

### DIFF
--- a/internal/connect/extensions.go
+++ b/internal/connect/extensions.go
@@ -25,10 +25,10 @@ var (
 )
 
 type extension struct {
-	Name         string       `json:"name"`
+	Name         string       `json:"identifier"`
 	Version      string       `json:"version"`
 	Arch         string       `json:"arch"`
-	FriendlyName string       `json:"friendly_name"`
+	FriendlyName string       `json:"name"`
 	Activated    bool         `json:"activated"`
 	Available    bool         `json:"available"`
 	Free         bool         `json:"free"`

--- a/internal/connect/extensions_test.go
+++ b/internal/connect/extensions_test.go
@@ -98,7 +98,7 @@ func TestPrintExtensionsAsJSON(t *testing.T) {
 	mockRootWritable(true)
 
 	result, err := RenderExtensionTree(true)
-	json := "{\"name\":\"PackageHub\",\"version\":\"15.4\",\"arch\":\"x86_64\",\"friendly_name\":\"SUSE Package Hub 15 SP4 x86_64\",\"activated\":false,\"available\":false,\"free\":true,\"extensions\":[]}"
+	json := "{\"identifier\":\"PackageHub\",\"version\":\"15.4\",\"arch\":\"x86_64\",\"name\":\"SUSE Package Hub 15 SP4 x86_64\",\"activated\":false,\"available\":false,\"free\":true,\"extensions\":[]}"
 
 	expectNoError(t, err)
 	expectStringMatches(t, result, json)


### PR DESCRIPTION
Addition to: https://github.com/SUSE/connect-ng/pull/195

**How to test this pull request:**

```
$ = host
> = container

$ docker run --rm -it registry.suse.com/suse/sle15:15.5
> zypper in go1.21-openssl jq make vim curl wget

# At this point I would grab the container id on the host and commit it
$ docker ps
$ commit <container_id> connect-devel
> exit

$ docker run --rm -it -v $(pwd):/connect connect-devel
> cd /connect
> make build
> .out/suseconnect -r <regcode>
> .out/suseconnect --list-extensions
> .out/suseconnect --json --list-extensions | jq
# expect: identifier and name both are present and now friendly_name is shown
```

Thank you very much for your review :)