### PR TITLE
Fix breaking EULA mechanism when switching base product

### DIFF
--- a/internal/connect/eula.go
+++ b/internal/connect/eula.go
@@ -198,6 +198,15 @@ func AcceptEULA() error {
 	if err != nil {
 		return err
 	}
+
+	// If we encounter a switch of base products (e.g. SLES -> SLES_SAP)
+	// we need to switch base products to allow the horizontal migration to happen
+	//
+	// See bsc#1218649 and bsc#1217961
+	if base.ToTriplet() != CFG.Product.ToTriplet() {
+		base = CFG.Product
+	}
+
 	prod, err := showProduct(base)
 	if err != nil {
 		return err

--- a/internal/connect/eula.go
+++ b/internal/connect/eula.go
@@ -200,11 +200,11 @@ func AcceptEULA() error {
 	}
 
 	// If we encounter a switch of base products (e.g. SLES -> SLES_SAP)
-	// we need to switch base products to allow the horizontal migration to happen
-	//
+	// we can not fetch the product information and thus the EULA since there
+	// might be no registration in place right now.
 	// See bsc#1218649 and bsc#1217961
 	if base.ToTriplet() != CFG.Product.ToTriplet() {
-		base = CFG.Product
+		return nil
 	}
 
 	prod, err := showProduct(base)

--- a/suseconnect-ng.changes
+++ b/suseconnect-ng.changes
@@ -5,6 +5,7 @@ Tue Dec 22 08:57:50 UTC 2023 - Miquel Sabate Sola <msabate@suse.com>
   * Configure docker credentials for registry authentication
   * Feature: Support usage from Agama + Cockpit for ALP Micro system registration (bsc#1218364)
   * Add --json output option
+  * Allow horizontal migrations when showing EULAs (bsc#1218649 and bsc#1217961)
 -------------------------------------------------------------------
 Tue Sep 26 08:57:50 UTC 2023 - Miquel Sabate Sola <msabate@suse.com>
 


### PR DESCRIPTION
Showing EULAs break if someone tries to enable a different base product. This pull request fixes this.

part of: https://trello.com/c/QWRUPwKb/3153-suseconnect-ng-cannot-switch-base-product

**How to review this change:**

```
$ cd <connect-ng>
$ docker run --rm -it -v $(pwd):/connect registry.suse.com/suse/sle15:15.3
> zypper rm -y container-suseconnect
> zypper in -y go1.21 make
> cd /connect
> make build
# Check the card for a regcode
> out/suseconnect -r <regcode> # activates sles
> zypper in -y migrate-sles-to-sles4sap
> out/suseconnect -d
> cp out/suseconnect /usr/bin/suseconnect
> /usr/sbin/Migrate_SLES_to_SLES-for-SAP.sh
```

**Thank you for reviewing this pull request!** :rocket:
