### PR TITLE
Don't error out in AcceptEULA() if base product wasn't found, just skip

### DIFF
--- a/internal/connect/eula.go
+++ b/internal/connect/eula.go
@@ -196,7 +196,7 @@ func AcceptEULA() error {
 	// Fetch list of extensions and search for requested product
 	base, err := baseProduct()
 	if err != nil {
-		return err
+		return nil
 	}
 
 	// If we encounter a switch of base products (e.g. SLES -> SLES_SAP)

--- a/suseconnect-ng.changes
+++ b/suseconnect-ng.changes
@@ -6,6 +6,7 @@ Tue Dec 22 08:57:50 UTC 2023 - Miquel Sabate Sola <msabate@suse.com>
   * Feature: Support usage from Agama + Cockpit for ALP Micro system registration (bsc#1218364)
   * Add --json output option
   * Allow horizontal migrations when showing EULAs (bsc#1218649 and bsc#1217961)
+
 -------------------------------------------------------------------
 Tue Sep 26 08:57:50 UTC 2023 - Miquel Sabate Sola <msabate@suse.com>
 


### PR DESCRIPTION
How to reproduce: 

```
$ cd <connect-ng>
$ docker run --rm -it -v $(pwd):/connect registry.suse.com/suse/sle15:15.3
> zypper rm -y container-suseconnect
> zypper in -y go1.21 make
> cd /connect
> make build
> zypper in -y http://updates.suse.de/SUSE/Updates/SLE-Module-Server-Applications/15-SP3/x86_64/update/noarch/migrate-sles-to-sles4sap-15.1.2-3.9.1.noarch.rpm
> cp out/suseconnect /usr/sbin/SUSEConnect
# Check the card for a regcode
> /usr/sbin/Migrate_SLES_to_SLES-for-SAP.sh
```