### PR TITLE
Bring back EULA display

### DIFF
--- a/internal/connect/eula.go
+++ b/internal/connect/eula.go
@@ -199,22 +199,19 @@ func AcceptEULA() error {
 		return nil
 	}
 
-	// If we encounter a switch of base products (e.g. SLES -> SLES_SAP)
-	// we can not fetch the product information and thus the EULA since there
+	// Skip if we can not fetch the product information and thus the EULA since there
 	// might be no registration in place right now.
 	// See bsc#1218649 and bsc#1217961
-	if base.ToTriplet() != CFG.Product.ToTriplet() {
-		return nil
-	}
-
 	prod, err := showProduct(base)
 	if err != nil {
-		return err
+		Debug.Print("Cannot load base product details for EULA.")
+		return nil
 	}
 	extension, _ := prod.findExtension(CFG.Product)
 
 	// No EULA or product not found (handle in registration code)
 	if strings.TrimSpace(extension.EULAURL) == "" {
+		Debug.Printf("No EULA found for '%s'.", CFG.Product.Name)
 		return nil
 	}
 

--- a/suseconnect-ng.changes
+++ b/suseconnect-ng.changes
@@ -1,11 +1,16 @@
 -------------------------------------------------------------------
+Tue Jan 18 16:00 UTC 2024 - Thomas Schmidt <tschmidt@suse.com>
+
+- Update to version 1.6.0
+  * Allow horizontal migrations when showing EULAs (bsc#1218649 and bsc#1217961)
+
+-------------------------------------------------------------------
 Tue Dec 22 08:57:50 UTC 2023 - Miquel Sabate Sola <msabate@suse.com>
 
 - Update to version 1.5.0
   * Configure docker credentials for registry authentication
   * Feature: Support usage from Agama + Cockpit for ALP Micro system registration (bsc#1218364)
   * Add --json output option
-  * Allow horizontal migrations when showing EULAs (bsc#1218649 and bsc#1217961)
 
 -------------------------------------------------------------------
 Tue Sep 26 08:57:50 UTC 2023 - Miquel Sabate Sola <msabate@suse.com>

--- a/suseconnect-ng.spec
+++ b/suseconnect-ng.spec
@@ -1,7 +1,7 @@
 #
 # spec file for package suseconnect-ng
 #
-# Copyright (c) 2023 SUSE LLC
+# Copyright (c) 2024 SUSE LLC
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed
@@ -32,8 +32,8 @@ Summary:        Utility to register a system with the SUSE Customer Center
 Group:          System/Management
 Source:         connect-ng-%{version}.tar.xz
 Source1:        %name-rpmlintrc
-BuildRequires:  golang-packaging
 BuildRequires:  go1.18-openssl
+BuildRequires:  golang-packaging
 BuildRequires:  ruby-devel
 BuildRequires:  zypper
 


### PR DESCRIPTION
Bring back eula display on product activation, but skip when the base product cannot get loaded, for example because the system is not yet registered, or it is switching the base product.

How to test: 

```
docker run --rm -it -v $(pwd):/connect connect-devel
cd connect
make build
# direct base product activation works
./out/suseconnect -p sles/15.5/x86_64 -r ...
./out/suseconnect -d
# base product switch works
./out/suseconnect -p SLES_SAP/15.5/x86_64 -r ...
./out/suseconnect -d
# show eula
./out/suseconnect -r ...
./out/suseconnect -p sle-module-desktop-applications/15.5/x86_64
./out/suseconnect -p sle-module-development-tools/15.5/x86_64
./out/suseconnect -p sle-module-NVIDIA-compute/15/x86_64

```