### PR TITLE
Disable license dialog, due to bsc#1217961

### DIFF
--- a/internal/connect/extensions.go
+++ b/internal/connect/extensions.go
@@ -100,7 +100,7 @@ func renderText(tree *extension, writableRoot bool) (string, error) {
 
 	// If the system is not writable we assume it is a transactional
 	// system and show the appropriate command
-	command := "SUSEConnect"
+	command := "suseconnect"
 	if !writableRoot {
 		command = "transactional-update register"
 	}

--- a/suseconnect-ng.changes
+++ b/suseconnect-ng.changes
@@ -2,7 +2,7 @@
 Tue Jan 18 16:00 UTC 2024 - Thomas Schmidt <tschmidt@suse.com>
 
 - Update to version 1.6.0
-  * Allow horizontal migrations when showing EULAs (bsc#1218649 and bsc#1217961)
+  * Disable EULA display for addons (bsc#1218649 and bsc#1217961)
 
 -------------------------------------------------------------------
 Tue Dec 22 08:57:50 UTC 2023 - Miquel Sabate Sola <msabate@suse.com>

--- a/suseconnect/suseconnect.go
+++ b/suseconnect/suseconnect.go
@@ -250,13 +250,16 @@ func connectMain() {
 			fmt.Println("This system is managed by SUSE Manager / Uyuni, do not use SUSEconnect.")
 			os.Exit(1)
 		} else {
+
 			// If the base system/extensions have EULAs, we need to make sure
 			// that they are accepted before proceeding on the registering. If
 			// they don't have EULA's, then this is a no-op.
-			err := connect.AcceptEULA()
-			exitOnError(err)
 
-			err = connect.Register(jsonFlag)
+			// disabling the license dialog feature for now due to bsc#1218878, bsc#1218649
+			// err := connect.AcceptEULA()
+			// exitOnError(err)
+
+			err := connect.Register(jsonFlag)
 			if jsonFlag && err != nil {
 				out := connect.RegisterOut{Success: false, Message: err.Error()}
 				str, _ := json.Marshal(&out)


### PR DESCRIPTION
Disabling the eula display feature on product activation, because this breaks existing script use of suseconnect-ng, for example in registercloudguest (bsc#1217961).

How to test: 

```
$ cd <connect-ng>
$ docker run --rm -it -v $(pwd):/connect registry.suse.com/suse/sle15:15.3
> zypper rm -y container-suseconnect
> zypper in -y go1.21 make
> cd /connect
> make build
# no eula gets shown
> ./out/suseconnect -r ...
> ./out/suseconnect -p sle-module-desktop-applications/15.3/x86_64
> ./out/suseconnect -p sle-module-development-tools/15.3/x86_64
> ./out/suseconnect -p sle-module-NVIDIA-compute/15/x86_64

# (there is a signature failure for the nvidia repomd.xml, but that's unrelated, important is, that there is no license dialogue)

```