### PR TITLE
add system uptime capability

### DIFF
--- a/internal/connect/api_test.go
+++ b/internal/connect/api_test.go
@@ -2,8 +2,10 @@ package connect
 
 import (
 	"io"
+	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 )
 
@@ -299,5 +301,56 @@ func TestProductMigrationsSMT(t *testing.T) {
 	expectedID := 101361
 	if gotID != expectedID {
 		t.Fatalf("Got ID: %d, expected: %d", gotID, expectedID)
+	}
+}
+
+func createTestUptimeLogFileWithContent(content string) (string, error) {
+	tempFile, err := ioutil.TempFile("", "testUptimeLog")
+	if err != nil {
+		return "", err
+	}
+	tempFilePath := tempFile.Name()
+	if _, err := tempFile.WriteString(content); err != nil {
+		os.Remove(tempFilePath)
+		return "", err
+	}
+	if err := tempFile.Close(); err != nil {
+		os.Remove(tempFilePath)
+		return "", err
+	}
+
+	return tempFilePath, nil
+}
+
+func TestUptimeLogFileDoesNotExist(t *testing.T) {
+	uptimeLogFileContent := ``
+	tempFilePath, err := createTestUptimeLogFileWithContent(uptimeLogFileContent)
+	if err != nil {
+		t.Fatalf("Failed to create temp uptime log file for testing")
+	}
+	os.Remove(tempFilePath)
+	uptimeLog, err := readUptimeLogFile(tempFilePath)
+	if uptimeLog != nil && err != nil {
+		t.Fatalf("Expected uptime log and err to be nil if uptime log file does not exist")
+	}
+}
+
+func TestReadUptimeLogFile(t *testing.T) {
+	uptimeLogFileContent := `2024-01-18:000000000000001000110000
+2024-01-13:000000000000000000010000`
+	tempFilePath, err := createTestUptimeLogFileWithContent(uptimeLogFileContent)
+	if err != nil {
+		t.Fatalf("Failed to create temp uptime log file for testing")
+	}
+	defer os.Remove(tempFilePath)
+	uptimeLog, err := readUptimeLogFile(tempFilePath)
+	if err != nil {
+		t.Fatalf("Failed to read uptime log file")
+	}
+	if uptimeLog == nil {
+		t.Fatal("Failed to open uptime log file")
+	}
+	if len(uptimeLog) != 2 {
+		t.Fatalf("Expected two entries in uptime log, got %#v instead", len(uptimeLog))
 	}
 }


### PR DESCRIPTION
Add the ability to upload the system uptime logs, produced by the suse-uptime-tracker daemon, to SCC/RMT as part of daily heartbeat report. We need to ability to track system uptime to hourly granularity so MSPs can utility that data accordingly (i.e. billing).

This feature is optionally enabled by installing the suse-uptime-tracker package and enabling the suse-uptime-tracker.timer service.