### PR TITLE
Allow SUSEConnect to work when only /etc is writable

### DIFF
--- a/suseconnect-ng.changes
+++ b/suseconnect-ng.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Feb 14 18:28 UTC 2024 - Felix Schnizlein <fschnizlein@suse.com>
+
+- Update to version 1.7.0
+  * Allow SUSEConnect on read write transactional systems (bsc#1219425)
+
+-------------------------------------------------------------------
 Tue Jan 18 16:00 UTC 2024 - Thomas Schmidt <tschmidt@suse.com>
 
 - Update to version 1.6.0

--- a/suseconnect/suseconnect.go
+++ b/suseconnect/suseconnect.go
@@ -183,9 +183,13 @@ func connectMain() {
 	}
 
 	// Reading the configuration/flags is done, now let's check if the
-	// filesystem can handle operations from SUSEConnect.
-	if err := connect.ReadOnlyFilesystem(connect.CFG.FsRoot); err != nil {
-		exitOnError(err)
+	// filesystem can handle operations from SUSEConnect for specific actions
+	// which require filesystem to be read write (aka writing outside of /etc)
+	// /etc is writable at any time, system token roation works just fine
+	if deRegister || rollback || cleanup {
+		if err := connect.ReadOnlyFilesystem(connect.CFG.FsRoot); err != nil {
+			exitOnError(err)
+		}
 	}
 
 	if status {
@@ -258,6 +262,11 @@ func connectMain() {
 			// disabling the license dialog feature for now due to bsc#1218878, bsc#1218649
 			// err := connect.AcceptEULA()
 			// exitOnError(err)
+
+			// we need a read-write filesystem to install release packages
+			if err := connect.ReadOnlyFilesystem(connect.CFG.FsRoot); err != nil {
+				exitOnError(err)
+			}
 
 			err := connect.Register(jsonFlag)
 			if jsonFlag && err != nil {


### PR DESCRIPTION
Allow SUSEConnect in read-write environment **with** `transactional-update` installed.

**How to test this changes**

I assume you have a running libvirtd which is usable as your user

```
$ curl -k "https://download.suse.de/install/SLE-Micro-6.0-Beta2/SLE-Micro.x86_64-6.0-Default-qcow-Beta2.qcow2" -O
$ sudo cp SLE-Micro.x86_64-6.0-Default-qcow-Beta2.qcow2 /var/lib/libvirt/images
$ virt-install --import --name slem-6.0-beta2 \
--memory 4048 --vcpus 2 --cpu host \
--disk SLE-Micro.x86_64-6.0-Default-qcow-Beta2.qcow2,format=qcow2,bus=virtio \
--network bridge=virbr0,model=virtio \
--os-variant=slem5.3 \
--graphics spice \
--noautoconsole

# In the vm
> passwd root
> echo 'PermitRootLogin yes' > /etc/ssh/sshd_config.d/allow-root.conf
> systemctl restart sshd
> ip addr
# Note down the address of the vm

$ ssh root@<address from vm>
> transactional-update shell 

% curl -k "https://download.suse.de/ibs/home:/fschnizlein:/branches:/Devel:/SCC:/suseconnect/SLE_15_SP4_Update/x86_64/suseconnect-ng-1.6.0~git1.856a1b9-150400.81.1.x86_64.rpm"
%  zypper -yes in suseconnect-ng-1.6.0~git1.856a1b9-150400.81.1.x86_64.rpm
% exit

> SUSEConnect --status-text 
# expect: to not work and hints at transactional-update

> transactional-update register -r <regcode>
# expect: to work

> transactional-update shell
% SUSEConnect --list-extensions
% SUSEConnect -p <any extension>
# expect: Should work
```
As always, thanks for the review and please do not hesitate to reach out to me if something is unclear :rocket: