### PR TITLE
Allow connect-ng on Tumbleweed

### DIFF
--- a/suseconnect-ng.spec
+++ b/suseconnect-ng.spec
@@ -32,7 +32,15 @@ Summary:        Utility to register a system with the SUSE Customer Center
 Group:          System/Management
 Source:         connect-ng-%{version}.tar.xz
 Source1:        %name-rpmlintrc
-BuildRequires:  go1.18-openssl
+
+# Build against latest golang in Tumbleweed and
+# go1.18-openssl on all other distributions
+%if 0%{?suse_version} >= 1600
+BuildRequires: golang(API)
+%else
+BuildRequires: go1.18-openssl
+%endif
+
 BuildRequires:  golang-packaging
 BuildRequires:  ruby-devel
 BuildRequires:  zypper


### PR DESCRIPTION
Since the introduction of the certified go1.18 package (go1.18-openssl) builds against Factory failing due not existing package. Fix this and make Factory green, allowing submit to new products.

**How to review this pr**

- goto your `connect-ng` package and change the `<param name="revision">main</param>` to `<param name="revision">fix-connect-in-tw</param>` in `_service`.
- build the package against factory and sle 15.3 or similar (testing the old case)

**Thank you very much for the review**:rocket:


