### PR TITLE
add system uptime capability

### DIFF
--- a/SUSEConnect.example
+++ b/SUSEConnect.example
@@ -15,3 +15,6 @@
 
 ## Automatically agree to extension and module license confirmation prompts (default: false)
 # auto_agree_with_licenses: false
+
+## Enable system uptime tracking. The system uptime log will be sent to SCC/RMT as part of heartbeat.
+# enable_system_uptime_tracking: false

--- a/SUSEConnect.example
+++ b/SUSEConnect.example
@@ -16,5 +16,5 @@
 ## Automatically agree to extension and module license confirmation prompts (default: false)
 # auto_agree_with_licenses: false
 
-## Enable system uptime tracking. The system uptime log will be sent to SCC/RMT as part of heartbeat.
+## Enable system uptime tracking. The system uptime log will be sent to SCC/RMT as part of keepalive.
 # enable_system_uptime_tracking: false

--- a/build/packaging/suseconnect-ng.changes
+++ b/build/packaging/suseconnect-ng.changes
@@ -7,6 +7,9 @@ Thu Apr 25 15:39:00 UTC 2024 - Felix Schnizlein <fschnizlein@suse.com>
   * Add --gpg-auto-import-keys flag before action in zypper command (bsc#1219004)
   * Include /etc/products.d in directories whose content are backed
     up and restored if a zypper-migration rollback happens. (bsc#1219004)
+  * Add the ability to upload the system uptime logs, produced by the
+    suse-uptime-tracker daemon, to SCC/RMT as part of keepalive report.
+    (jsc#PED-7982) (jsc#PED-8018)
 
 -------------------------------------------------------------------
 Tue May  7 14:12:47 UTC 2024 - Thomas Schmidt <tschmidt@suse.com>

--- a/internal/connect/api.go
+++ b/internal/connect/api.go
@@ -1,10 +1,18 @@
 package connect
 
 import (
+	"bufio"
 	"encoding/json"
+	"errors"
 	"net/http"
+	"os"
 
+	"github.com/SUSE/connect-ng/internal/util"
 	"github.com/SUSE/connect-ng/internal/zypper"
+)
+
+const (
+	UptimeLogFilePath = "/etc/zypp/suse-uptime.log"
 )
 
 // announceSystem announces a system to SCC
@@ -176,14 +184,45 @@ func updateSystem(body []byte) error {
 	return err
 }
 
+// readUptimeLogFile reads the system uptime log from a given file and
+// returns them as a string array. If the given file does not exist,
+// it will be interpreted as if the system uptime log feature is not
+// enabled. Hence an empty array will be returned.
+func readUptimeLogFile(uptimeLogFilePath string) ([]string, error) {
+	// NOTE: if uptime log file does not exist, we assume the uptime
+	// tracking feature is not enabled
+	_, err := os.Stat(uptimeLogFilePath)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, nil
+	}
+
+	uptimeLogFile, err := os.Open(uptimeLogFilePath)
+	if err != nil {
+		return nil, err
+	}
+	fileScanner := bufio.NewScanner(uptimeLogFile)
+	fileScanner.Split(bufio.ScanLines)
+	var logEntries []string
+
+	for fileScanner.Scan() {
+		logEntries = append(logEntries, fileScanner.Text())
+	}
+	err = uptimeLogFile.Close()
+	if err != nil {
+		return nil, err
+	}
+	return logEntries, nil
+}
+
 // makeSysInfoBody returns the JSON payload needed for the announce/update system calls
-func makeSysInfoBody(distroTarget, namespace string, instanceData []byte) ([]byte, error) {
+func makeSysInfoBody(distroTarget, namespace string, instanceData []byte, includeUptimeLog bool) ([]byte, error) {
 	var payload struct {
-		Hostname     string `json:"hostname"`
-		DistroTarget string `json:"distro_target"`
-		InstanceData string `json:"instance_data,omitempty"`
-		Namespace    string `json:"namespace,omitempty"`
-		Hwinfo       hwinfo `json:"hwinfo"`
+		Hostname     string   `json:"hostname"`
+		DistroTarget string   `json:"distro_target"`
+		InstanceData string   `json:"instance_data,omitempty"`
+		Namespace    string   `json:"namespace,omitempty"`
+		Hwinfo       hwinfo   `json:"hwinfo"`
+		OnlineAt     []string `json:"online_at,omitempty"`
 	}
 	if distroTarget != "" {
 		payload.DistroTarget = distroTarget
@@ -196,6 +235,16 @@ func makeSysInfoBody(distroTarget, namespace string, instanceData []byte) ([]byt
 	}
 	payload.InstanceData = string(instanceData)
 	payload.Namespace = namespace
+
+	if includeUptimeLog {
+		uptimeLog, err := readUptimeLogFile(UptimeLogFilePath)
+		if err != nil {
+			util.Info.Print("Unable to system uptime log")
+		}
+		if uptimeLog != nil {
+			payload.OnlineAt = uptimeLog
+		}
+	}
 
 	hw, err := getHwinfo()
 	if err != nil {

--- a/internal/connect/api_test.go
+++ b/internal/connect/api_test.go
@@ -307,19 +307,18 @@ func createTestUptimeLogFileWithContent(content string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	defer tempFile.Close()
 	tempFilePath := tempFile.Name()
 	if _, err := tempFile.WriteString(content); err != nil {
 		os.Remove(tempFilePath)
 		return "", err
 	}
-	defer tempFile.Close()
 
 	return tempFilePath, nil
 }
 
 func TestUptimeLogFileDoesNotExist(t *testing.T) {
-	uptimeLogFileContent := ``
-	tempFilePath, err := createTestUptimeLogFileWithContent(uptimeLogFileContent)
+	tempFilePath, err := createTestUptimeLogFileWithContent("")
 	if err != nil {
 		t.Fatalf("Failed to create temp uptime log file for testing")
 	}
@@ -340,7 +339,7 @@ func TestReadUptimeLogFile(t *testing.T) {
 	defer os.Remove(tempFilePath)
 	uptimeLog, err := readUptimeLogFile(tempFilePath)
 	if err != nil {
-		t.Fatalf("Failed to read uptime log file")
+		t.Fatalf("Failed to read uptime log file: %s", err)
 	}
 	if uptimeLog == nil {
 		t.Fatal("Failed to open uptime log file")

--- a/internal/connect/api_test.go
+++ b/internal/connect/api_test.go
@@ -4,6 +4,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 
 	"github.com/SUSE/connect-ng/internal/credentials"
@@ -299,4 +300,52 @@ func TestProductMigrationsSMT(t *testing.T) {
 	assert.NoError(err)
 	assert.Len(migrations, 1, "migrations")
 	assert.Equal(expectedID, migrations[0][0].ID)
+}
+
+func createTestUptimeLogFileWithContent(content string) (string, error) {
+	tempFile, err := os.CreateTemp("", "testUptimeLog")
+	if err != nil {
+		return "", err
+	}
+	tempFilePath := tempFile.Name()
+	if _, err := tempFile.WriteString(content); err != nil {
+		os.Remove(tempFilePath)
+		return "", err
+	}
+	defer tempFile.Close()
+
+	return tempFilePath, nil
+}
+
+func TestUptimeLogFileDoesNotExist(t *testing.T) {
+	uptimeLogFileContent := ``
+	tempFilePath, err := createTestUptimeLogFileWithContent(uptimeLogFileContent)
+	if err != nil {
+		t.Fatalf("Failed to create temp uptime log file for testing")
+	}
+	os.Remove(tempFilePath)
+	uptimeLog, err := readUptimeLogFile(tempFilePath)
+	if uptimeLog != nil && err != nil {
+		t.Fatalf("Expected uptime log and err to be nil if uptime log file does not exist")
+	}
+}
+
+func TestReadUptimeLogFile(t *testing.T) {
+	uptimeLogFileContent := `2024-01-18:000000000000001000110000
+2024-01-13:000000000000000000010000`
+	tempFilePath, err := createTestUptimeLogFileWithContent(uptimeLogFileContent)
+	if err != nil {
+		t.Fatalf("Failed to create temp uptime log file for testing")
+	}
+	defer os.Remove(tempFilePath)
+	uptimeLog, err := readUptimeLogFile(tempFilePath)
+	if err != nil {
+		t.Fatalf("Failed to read uptime log file")
+	}
+	if uptimeLog == nil {
+		t.Fatal("Failed to open uptime log file")
+	}
+	if len(uptimeLog) != 2 {
+		t.Fatalf("Expected two entries in uptime log, got %#v instead", len(uptimeLog))
+	}
 }

--- a/internal/connect/client_test.go
+++ b/internal/connect/client_test.go
@@ -51,6 +51,15 @@ func mockRemoveOrRefreshService(t *testing.T, expected bool) {
 
 }
 
+func mockMakeSysInfoBody(t *testing.T, expectedIncludeUptimeLog bool) {
+	localMakeSysInfoBody = func(distroTarget, namespace string, instanceData []byte, includeUptimeLog bool) ([]byte, error) {
+		if includeUptimeLog != expectedIncludeUptimeLog {
+			t.Errorf("Expected includeUptimeLog to be %v\n", expectedIncludeUptimeLog)
+		}
+		return nil, nil
+	}
+}
+
 // NOTE: This needs to be reworked.
 // The current implementation of logging does not really allow any useful
 // testing mechanics and is overly complicated. Refactor this!
@@ -97,4 +106,33 @@ func TestClientDeregistrationWithoutServiceInstallSkipSuccessful(t *testing.T) {
 	mockAddServiceCalled(t, true)
 	mockInstallReleasePackage(t, true)
 	Deregister(false)
+}
+
+func TestDefaultSystemUptimeTrackingDisable(t *testing.T) {
+	localUpdateSystem = func(body []byte) error {
+		// we don't care about updating the system for unit test
+		return nil
+	}
+	mockMakeSysInfoBody(t, false)
+	UpdateSystem("", "", false, true)
+}
+
+func TestSystemUptimeTrackingEnable(t *testing.T) {
+	CFG.EnableSystemUptimeTracking = true
+	localUpdateSystem = func(body []byte) error {
+		// we don't care about updating the system for unit test
+		return nil
+	}
+	mockMakeSysInfoBody(t, true)
+	UpdateSystem("", "", false, true)
+}
+
+func TestSystemUptimeTrackingEnableNotKeepalive(t *testing.T) {
+	CFG.EnableSystemUptimeTracking = true
+	localUpdateSystem = func(body []byte) error {
+		// we don't care about updating the system for unit test
+		return nil
+	}
+	mockMakeSysInfoBody(t, false)
+	UpdateSystem("", "", false, false)
 }

--- a/internal/connect/config.go
+++ b/internal/connect/config.go
@@ -19,25 +19,27 @@ var (
 )
 
 const (
-	defaultConfigPath = "/etc/SUSEConnect"
-	defaultBaseURL    = "https://scc.suse.com"
-	defaultInsecure   = false
-	defaultSkip       = false
+	defaultConfigPath                 = "/etc/SUSEConnect"
+	defaultBaseURL                    = "https://scc.suse.com"
+	defaultInsecure                   = false
+	defaultSkip                       = false
+	defaultEnableSystemUptimeTracking = false
 )
 
 // Config holds the config!
 type Config struct {
-	Path             string
-	BaseURL          string `json:"url"`
-	Language         string `json:"language"`
-	Insecure         bool   `json:"insecure"`
-	Namespace        string `json:"namespace"`
-	FsRoot           string
-	Token            string
-	Product          Product
-	InstanceDataFile string
-	Email            string `json:"email"`
-	AutoAgreeEULA    bool
+	Path                       string
+	BaseURL                    string `json:"url"`
+	Language                   string `json:"language"`
+	Insecure                   bool   `json:"insecure"`
+	Namespace                  string `json:"namespace"`
+	FsRoot                     string
+	Token                      string
+	Product                    Product
+	InstanceDataFile           string
+	Email                      string `json:"email"`
+	AutoAgreeEULA              bool
+	EnableSystemUptimeTracking bool
 
 	NoZypperRefresh    bool
 	AutoImportRepoKeys bool
@@ -47,10 +49,11 @@ type Config struct {
 // NewConfig returns a Config with defaults
 func NewConfig() Config {
 	return Config{
-		Path:               defaultConfigPath,
-		BaseURL:            defaultBaseURL,
-		Insecure:           defaultInsecure,
-		SkipServiceInstall: defaultSkip,
+		Path:                       defaultConfigPath,
+		BaseURL:                    defaultBaseURL,
+		Insecure:                   defaultInsecure,
+		SkipServiceInstall:         defaultSkip,
+		EnableSystemUptimeTracking: defaultEnableSystemUptimeTracking,
 	}
 }
 
@@ -66,6 +69,7 @@ func (c Config) toYAML() []byte {
 		fmt.Fprintf(&buf, "namespace: %s\n", c.Namespace)
 	}
 	fmt.Fprintf(&buf, "auto_agree_with_licenses: %v\n", c.AutoAgreeEULA)
+	fmt.Fprintf(&buf, "enable_system_uptime_tracking: %v\n", c.EnableSystemUptimeTracking)
 	return buf.Bytes()
 }
 
@@ -113,6 +117,8 @@ func parseConfig(r io.Reader, c *Config) {
 			c.NoZypperRefresh, _ = strconv.ParseBool(val)
 		case "auto_agree_with_licenses":
 			c.AutoAgreeEULA, _ = strconv.ParseBool(val)
+		case "enable_system_uptime_tracking":
+			c.EnableSystemUptimeTracking, _ = strconv.ParseBool(val)
 		default:
 			util.Debug.Printf("Cannot parse line \"%s\" from %s", line, c.Path)
 		}

--- a/internal/connect/config_test.go
+++ b/internal/connect/config_test.go
@@ -12,7 +12,8 @@ insecure: false
 url: https://smt-azure.susecloud.net
 language: en_US.UTF-8
 no_zypper_refs: true
-auto_agree_with_licenses: true`
+auto_agree_with_licenses: true
+enable_system_uptime_tracking: false`
 
 var cfg2 = `---
  insecure: true

--- a/third_party/libsuseconnect/libsuseconnect.go
+++ b/third_party/libsuseconnect/libsuseconnect.go
@@ -82,7 +82,7 @@ func announce_system(clientParams, distroTarget *C.char) *C.char {
 func update_system(clientParams, distroTarget *C.char) *C.char {
 	loadConfig(C.GoString(clientParams))
 
-	if err := connect.UpdateSystem(C.GoString(distroTarget), "", false); err != nil {
+	if err := connect.UpdateSystem(C.GoString(distroTarget), "", false, false); err != nil {
 		return C.CString(errorToJSON(err))
 	}
 


### PR DESCRIPTION
Add the ability to upload the system uptime logs, produced by the suse-uptime-tracker daemon, to SCC/RMT as part of daily heartbeat report. We need to ability to track system uptime to hourly granularity so MSPs can utility that data accordingly (i.e. billing).

This feature is optionally enabled by installing the suse-uptime-tracker package and enabling the suse-uptime-tracker.timer service.