### PR TITLE
auto import keys flag comes before zypper action bsc#1219004

### DIFF
--- a/internal/connect/zypper.go
+++ b/internal/connect/zypper.go
@@ -280,7 +280,7 @@ func RefreshRepos(version string, force, quiet, verbose, nonInteractive bool) er
 		args = append(args, "-f")
 	}
 	if CFG.AutoImportRepoKeys {
-		args = append(args, "--gpg-auto-import-keys")
+		args = append([]string{"--gpg-auto-import-keys"}, args...)
 	}
 	args = append(flags, args...)
 	_, err := zypperRun(args, []int{zypperOK})


### PR DESCRIPTION
When including the --gpg-auto-import-keys flag in the zypper command line, it must be placed before the action, e.g. ref, rather than after as it is a global flag.

Found while testing DMS migrations after switching to suseconnect-ng based zypper migration workflow.