### PR TITLE
auto import keys flag comes before zypper action bsc#1219004

### DIFF
--- a/build/packaging/suseconnect-ng.changes
+++ b/build/packaging/suseconnect-ng.changes
@@ -4,6 +4,7 @@ Thu Apr 25 15:39:00 UTC 2024 - Felix Schnizlein <fschnizlein@suse.com>
 - 1.9.0 (unreleased)
   * Build zypper-migration and zypper-packages-search as standalone
     binaries rather then one single binary
+  * Add --gpg-auto-import-keys flag before action in zypper command (bsc#1219004)
 
 -------------------------------------------------------------------
 Wed Mar 13 12:37:29 UTC 2024 - José Gómez <1josegomezr@gmail.com>

--- a/internal/zypper/zypper.go
+++ b/internal/zypper/zypper.go
@@ -320,7 +320,7 @@ func RefreshRepos(version string, force, quiet, verbose, nonInteractive bool, au
 		args = append(args, "-f")
 	}
 	if autoImportRepoKeys {
-		args = append(args, "--gpg-auto-import-keys")
+		args = append([]string{"--gpg-auto-import-keys"}, args...)
 	}
 	args = append(flags, args...)
 	_, err := zypperRun(args, []int{zypperOK})


### PR DESCRIPTION
When including the --gpg-auto-import-keys flag in the zypper command line, it must be placed before the action, e.g. ref, rather than after as it is a global flag.

Found while testing DMS migrations after switching to suseconnect-ng based zypper migration workflow.