### PR TITLE
Start development for 1.19

### DIFF
--- a/build/packaging/suseconnect-ng.changes
+++ b/build/packaging/suseconnect-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Apr 25 15:39:00 UTC 2024 - Felix Schnizlein <fschnizlein@suse.com>
+
+- 1.9.0 (unreleased)
+  * Build zypper-migration and zypper-packages-search as standalone
+    binaries rather then one single binary
+
+-------------------------------------------------------------------
 Wed Mar 13 12:37:29 UTC 2024 - José Gómez <1josegomezr@gmail.com>
 
 - Update to version 1.8.0

--- a/build/packaging/suseconnect-ng.spec
+++ b/build/packaging/suseconnect-ng.spec
@@ -18,7 +18,7 @@
 %global project github.com/SUSE/connect-ng
 
 Name:           suseconnect-ng
-Version:        1.8.0
+Version:        1.9.0
 Release:        0
 URL:            https://github.com/SUSE/connect-ng
 License:        LGPL-2.1-or-later


### PR DESCRIPTION
This adds a not yet released section in `connect-ng` to allow multiple contributes to add their changes to the upcoming release.

TBD: Write documentation how we can handle releases in a more clear way, so everybody can contribute without extra hassle. This should also remove informal knowledge about this process.

cheers,