### PR TITLE
Quieten ST1005 warning in internal/zypper/error.go

### DIFF
--- a/internal/zypper/error.go
+++ b/internal/zypper/error.go
@@ -19,4 +19,4 @@ func (ze ZypperError) Error() string {
 		strings.Join(ze.Commmand, " "), ze.ExitCode, ze.Output, ze.Err)
 }
 
-var ErrCannotDetectBaseProduct = errors.New("Unable to detect base product")
+var ErrCannotDetectBaseProduct = errors.New("unable to detect base product")


### PR DESCRIPTION
When editing with VS Code I see a warning that error messages should not be capitalized, which is easily quietened.