### PR TITLE
run-feature-tests has no set -e set and thus not failing at all

### DIFF
--- a/.github/workflows/features.yml
+++ b/.github/workflows/features.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: registry.suse.com/bci/golang:1.21-openssl
-      options: --user root
+      options: --user root --privileged
 
     steps:
       - uses: actions/checkout@v4

--- a/build/ci/configure
+++ b/build/ci/configure
@@ -16,6 +16,7 @@ fail() { echo "::error::$1"; exit 1; }
 group "install suseconnect"
 pushd "$BUILD_DIR/RPMS/${ARCH}"
   zypper --non-interactive --no-refresh install --allow-unsigned-rpm *.rpm
+  zypper --non-interactive --no-refresh install systemd
 popd
 groupend
 

--- a/build/ci/run-feature-tests
+++ b/build/ci/run-feature-tests
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 # Where the connect-ng source is located within the container
 SOURCE=${SOURCE:-/usr/src/connect-ng}


### PR DESCRIPTION
yes...

**How to review this merge request:**

CI feature tests are green with `set -e` set!