### PR TITLE
Prepare 1.10 release

### DIFF
--- a/build/packaging/suseconnect-ng.changes
+++ b/build/packaging/suseconnect-ng.changes
@@ -1,7 +1,7 @@
 -------------------------------------------------------------------
-Thu Apr 25 15:39:00 UTC 2024 - Felix Schnizlein <fschnizlein@suse.com>
+Thu May 23 15:00:00 UTC 2024 - Felix Schnizlein <fschnizlein@suse.com>
 
-- 1.10.0 (unreleased)
+- Update version to 1.10.0
   * Build zypper-migration and zypper-packages-search as standalone
     binaries rather then one single binary
   * Add --gpg-auto-import-keys flag before action in zypper command (bsc#1219004)
@@ -10,6 +10,8 @@ Thu Apr 25 15:39:00 UTC 2024 - Felix Schnizlein <fschnizlein@suse.com>
   * Add the ability to upload the system uptime logs, produced by the
     suse-uptime-tracker daemon, to SCC/RMT as part of keepalive report.
     (jsc#PED-7982) (jsc#PED-8018)
+  * Add support for third party packages in SUSEConnect
+  * Refactor existing system information collection implementation
 
 -------------------------------------------------------------------
 Tue May  7 14:12:47 UTC 2024 - Thomas Schmidt <tschmidt@suse.com>


### PR DESCRIPTION
its time to release 1.10 but first the changelog needs to be adapted otherwise obs does not want to build the project because of:

```
Building suseconnect-ng.spec for SLE_15_SP5/x86_64
- package has suseconnect-ng-rpmlintrc: (unchanged)

changelog not in sequence:

Thu Apr 25 15:39:00 UTC 2024 - Felix Schnizlein <fschnizlein@suse.com>
* Thu Apr 25 2024 Felix Schnizlein <fschnizlein@suse.com>
- 1.10.0 (unreleased)
  * Build zypper-migration and zypper-packages-search as standalone
  binaries rather then one single binary
  * Add --gpg-auto-import-keys flag before action in zypper command (bsc#1219004)
  * Include /etc/products.d in directories whose content are backed
  up and restored if a zypper-migration rollback happens. (bsc#1219004)
  * Add the ability to upload the system uptime logs, produced by the
  suse-uptime-tracker daemon, to SCC/RMT as part of keepalive report.
  (jsc#PED-7982) (jsc#PED-8018)

Tue May  7 14:12:47 UTC 2024 - Thomas Schmidt <tschmidt@suse.com>
* Tue May 07 2024 Thomas Schmidt <tschmidt@suse.com>
- Update to version 1.9.0
  * Fix certificate import for Yast when using a registration proxy with
  self-signed SSL certificate (bsc#1223107)

```

**How to review this merge request:**

- Check the Changelog entry, make sure its in sequence ;)