### PR TITLE
Be more specific on the supported ARM architecture

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,8 +72,10 @@ feature-tests:
 test-yast: build-so
 	docker build -t go-connect-test-yast -f third_party/Dockerfile.yast . && docker run -t go-connect-test-yast
 
+# This "arm" means ARM64v8 little endian, the one being delivered currently on
+# OBS.
 build-arm: out internal/connect/version.txt
-	GOOS=linux GOARCH=arm64 GOARM=7 $(GO) build $(GOFLAGS) $(OUT) github.com/SUSE/connect-ng/cmd/suseconnect
+	GOOS=linux GOARCH=arm64 $(GO) build $(GOFLAGS) $(OUT) github.com/SUSE/connect-ng/cmd/suseconnect
 
 build-s390: out internal/connect/version.txt
 	GOOS=linux GOARCH=s390x $(GO) build $(GOFLAGS) $(OUT) github.com/SUSE/connect-ng/cmd/suseconnect

--- a/internal/util/system.go
+++ b/internal/util/system.go
@@ -16,6 +16,10 @@ const (
 	ST_RDONLY = 0x1
 
 	// From <linux/magic.h>
+	//
+	// NOTE: this will not work on 32-bit systems (i.e. armv7 in 32-bit mode).
+	// If we ever consider supporting these systems, then we would need to
+	// change this.
 	BTRFS_SUPER_MAGIC = 0x9123683E
 )
 


### PR DESCRIPTION
The GOARCH and the GOARM environment variables being provided were conflicting: if we are using `arm64`, then GOARM is ignored. If we really wanted `v7`, then we should use GOARCH=arm and GOARM={5, 6, 7}. See: https://go.dev/wiki/GoArm for further documentation on ARM.

To align the development environment to what we actually ship through OBS, I have been more explicit on using arm64 v8, which is the latest version from the ARM family of microprocessors. I also thought on allowing this to be configureable, just in case a developer wanted to mess with older ARM devices, but we actually introduced some 64-bit dependencies when we added magic numbers like `BTRFS_SUPER_MAGIC`.

Because all of this, I have added further comments just in case we decide to go the extra mile for this architecture in the future.