### PR TITLE
collectors: fallback to `uname -m` if -i fails

### DIFF
--- a/internal/collectors/architecture.go
+++ b/internal/collectors/architecture.go
@@ -12,10 +12,21 @@ func (Architecture) run(arch string) (Result, error) {
 	return Result{"arch": arch}, nil
 }
 
-var DetectArchitecture = func() (string, error) {
-	output, err := util.Execute([]string{"uname", "-i"}, nil)
+var Uname = func(flag string) (string, error) {
+	output, err := util.Execute([]string{"uname", flag}, nil)
 	if err != nil {
 		return "", err
 	}
-	return string(output), nil
+	return string(output), err
+}
+
+var DetectArchitecture = func() (string, error) {
+	output, err := Uname("-i")
+	if err != nil {
+		return "", err
+	}
+	if output == "unknown" {
+		return Uname("-m")
+	}
+	return output, nil
 }

--- a/internal/collectors/architecture_test.go
+++ b/internal/collectors/architecture_test.go
@@ -16,3 +16,18 @@ func TestArchitectureCollectorsRun(t *testing.T) {
 	assert.NoError(err)
 	assert.Equal(expectedResult, result)
 }
+
+func TestFallBackToUnameM(t *testing.T) {
+	assert := assert.New(t)
+
+	Uname = func(flag string) (string, error) {
+		if flag == "-i" {
+			return "unknown", nil
+		}
+		return "aarch64", nil
+	}
+
+	arch, err := DetectArchitecture()
+	assert.NoError(err)
+	assert.Equal(arch, "aarch64")
+}


### PR DESCRIPTION
This happens at least on ARM64 for non-ACPI compatible devices.