### PR TITLE
collectors: fallback to machine ID on ARM64

### DIFF
--- a/internal/collectors/uuid_test.go
+++ b/internal/collectors/uuid_test.go
@@ -65,3 +65,20 @@ func TestUUIDRunS390x(t *testing.T) {
 	assert.NoError(err)
 	assert.Equal(expectedUUID, result["uuid"])
 }
+
+func TestUUIDRunArmNonACPI(t *testing.T) {
+	assert := assert.New(t)
+	actualUUID := "a85d8326f09347ef9f118da1a74a4dd1"
+	expectedUUID := "a85d8326-f093-47ef-9f11-8da1a74a4dd1"
+	uuid := UUID{}
+
+	util.Execute = func(_ []string, _ []int) ([]byte, error) {
+		return []byte{}, nil
+	}
+	mockUtilFileExists(false)
+	mockLocalOsReadfile(t, "/etc/machine-id", actualUUID)
+
+	result, err := uuid.run(ARCHITECTURE_ARM64)
+	assert.NoError(err)
+	assert.Equal(expectedUUID, result["uuid"])
+}


### PR DESCRIPTION
In some devices (e.g. non-ACPI compatible ones) the UUID will not be available through the default way. In these scenarios just fallback to using the value on `/etc/machine-id` just like we do for s390x.

## How to test

1. Pick up a non-ACPI compliant ARM64 machine.
2. Build SUSEConnect there.
3. Now if you do `SUSEConnect --debug --keepalive`, the `uuid` parameter will be set (before it was not).