### PR TITLE
Use `read_values` for the cpu collector on Z

### DIFF
--- a/internal/collectors/virtualization.go
+++ b/internal/collectors/virtualization.go
@@ -11,6 +11,12 @@ const systemdDetectVirtExecutable = "systemd-detect-virt"
 type Virtualization struct{}
 
 func (Virtualization) run(arch string) (Result, error) {
+	// Z systems just work differently in this regard, and this is already
+	// handled when collecting the CPU info. Hence, there's nothing to do here
+	// for these systems.
+	if arch == ARCHITECTURE_Z {
+		return NoResult, nil
+	}
 
 	// We utilize systemd here to fetch the virtualization information. Since we do not hard require systemd
 	// there might be the possibility to run on a system without systemd installed (e.g. containers).

--- a/testdata/collectors/z_lpar_read_values.txt
+++ b/testdata/collectors/z_lpar_read_values.txt
@@ -1,0 +1,10 @@
+Version: 1.0.3
+Type: 8561
+Sequence Code: 00000000000688E8
+CPUs Total: 71
+CPUs IFL: 71
+LPAR Number: 1
+LPAR Name: ZL01
+LPAR Characteristics: Shared
+LPAR CPUs Total: 6
+LPAR CPUs IFL: 6

--- a/testdata/collectors/z_zvm_read_values.txt
+++ b/testdata/collectors/z_zvm_read_values.txt
@@ -1,0 +1,14 @@
+Version: 1.0.3
+Type: 8561
+Sequence Code: 00000000000688E8
+CPUs Total: 71
+CPUs IFL: 71
+LPAR Number: 1
+LPAR Name: ZL01
+LPAR Characteristics: Shared
+LPAR CPUs Total: 6
+LPAR CPUs IFL: 6
+VM00 Name: ASCHNELL
+VM00 Control Program: z/VM    7.3.0
+VM00 CPUs Total: 2
+VM00 IFLs: 2

--- a/testdata/collectors/z_zvm_read_values_with_type_name.txt
+++ b/testdata/collectors/z_zvm_read_values_with_type_name.txt
@@ -1,0 +1,15 @@
+Version: 1.0.0
+Type: 8561
+Type Name: IBM LinuxONE III
+Sequence Code: 00000000000688E8
+Fehler: erg = 0, result_string = NULL
+Fehler: erg = 0, result_string = NULL
+LPAR Number: 1
+LPAR Name: ZL01
+LPAR Characteristics: Shared
+Fehler: erg = 0, result_string = NULL
+Fehler: erg = 0, result_string = NULL
+VM00 Name: ASCHNELL
+VM00 Control Program: z/VM    7.3.0
+VM00 CPUs Total: 2
+VM00 IFLs: 2


### PR DESCRIPTION
Moreover, the virtualization being used can be gathered at the CPU stage as well on these systems, so the handling on the virtualization gatherer is skipped.

### How to test

1. Contact me or @felixsch for access to a Z machine.
2. Build it locally through cross-compilation with `make build-s390`.
3. Copy the resulting binary into the Z machine.
4. Call `./suseconnect --debug --keepalive` (the machine is already registered).

In the output you will notice the new `arch_specs` map being delivered. For the values on `cpus`, `sockets` and `virtualization`, notice that `cpus = sockets` and that they match the value when executing `read_values`. The virtualization is `zvm` on the machine we are using.

### Extra

I have modified the `read_values` program (see SUSE/s390-tools#12) to include `Type name`, which is way more descriptive than the opaque `Type`. Contact with privately on how to use this patched `read_values` on the Z machine we are using.