### PR TITLE
Add uname as collector

### DIFF
--- a/internal/collectors/architecture.go
+++ b/internal/collectors/architecture.go
@@ -1,7 +1,5 @@
 package collectors
 
-import "github.com/SUSE/connect-ng/internal/util"
-
 type Architecture struct{}
 
 func (Architecture) run(arch string) (Result, error) {
@@ -12,21 +10,13 @@ func (Architecture) run(arch string) (Result, error) {
 	return Result{"arch": arch}, nil
 }
 
-var Uname = func(flag string) (string, error) {
-	output, err := util.Execute([]string{"uname", flag}, nil)
-	if err != nil {
-		return "", err
-	}
-	return string(output), err
-}
-
 var DetectArchitecture = func() (string, error) {
-	output, err := Uname("-i")
+	output, err := uname("-i")
 	if err != nil {
 		return "", err
 	}
 	if output == "unknown" {
-		return Uname("-m")
+		return uname("-m")
 	}
 	return output, nil
 }

--- a/internal/collectors/architecture.go
+++ b/internal/collectors/architecture.go
@@ -11,12 +11,12 @@ func (Architecture) run(arch string) (Result, error) {
 }
 
 var DetectArchitecture = func() (string, error) {
-	output, err := uname("-i")
+	output, err := uname([]string{"-i"})
 	if err != nil {
 		return "", err
 	}
 	if output == "unknown" {
-		return uname("-m")
+		return uname([]string{"-m"})
 	}
 	return output, nil
 }

--- a/internal/collectors/architecture_test.go
+++ b/internal/collectors/architecture_test.go
@@ -20,7 +20,7 @@ func TestArchitectureCollectorsRun(t *testing.T) {
 func TestFallBackToUnameM(t *testing.T) {
 	assert := assert.New(t)
 
-	Uname = func(flag string) (string, error) {
+	uname = func(flag string) (string, error) {
 		if flag == "-i" {
 			return "unknown", nil
 		}

--- a/internal/collectors/architecture_test.go
+++ b/internal/collectors/architecture_test.go
@@ -1,6 +1,7 @@
 package collectors
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -20,8 +21,9 @@ func TestArchitectureCollectorsRun(t *testing.T) {
 func TestFallBackToUnameM(t *testing.T) {
 	assert := assert.New(t)
 
-	uname = func(flag string) (string, error) {
-		if flag == "-i" {
+	uname = func(flags []string) (string, error) {
+		params := strings.Join(flags, " ")
+		if params == "-i" {
 			return "unknown", nil
 		}
 		return "aarch64", nil

--- a/internal/collectors/uname.go
+++ b/internal/collectors/uname.go
@@ -1,0 +1,22 @@
+package collectors
+
+import "github.com/SUSE/connect-ng/internal/util"
+
+type Uname struct{}
+
+func (Uname) run(arch string) (Result, error) {
+	output, err := uname("-r -v")
+
+	if err != nil {
+		return NoResult, err
+	}
+	return Result{"uname": output}, nil
+}
+
+var uname = func(flag string) (string, error) {
+	output, err := util.Execute([]string{"uname", flag}, nil)
+	if err != nil {
+		return "", err
+	}
+	return string(output), err
+}

--- a/internal/collectors/uname.go
+++ b/internal/collectors/uname.go
@@ -5,7 +5,7 @@ import "github.com/SUSE/connect-ng/internal/util"
 type Uname struct{}
 
 func (Uname) run(arch string) (Result, error) {
-	output, err := uname("-r -v")
+	output, err := uname([]string{"-r", "-v"})
 
 	if err != nil {
 		return NoResult, err
@@ -13,8 +13,9 @@ func (Uname) run(arch string) (Result, error) {
 	return Result{"uname": output}, nil
 }
 
-var uname = func(flag string) (string, error) {
-	output, err := util.Execute([]string{"uname", flag}, nil)
+var uname = func(flags []string) (string, error) {
+	call := append([]string{"uname"}, flags...)
+	output, err := util.Execute(call, nil)
 	if err != nil {
 		return "", err
 	}

--- a/internal/collectors/uname_test.go
+++ b/internal/collectors/uname_test.go
@@ -1,6 +1,7 @@
 package collectors
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -13,9 +14,10 @@ func TestUnameCollectorsRun(t *testing.T) {
 	expectedUname := "6.8.7-1-default #1 SMP PREEMPT_DYNAMIC Thu Apr 18 07:12:38 UTC 2024 (5c0cf23)"
 	expectedResult := Result{"uname": expectedUname}
 
-	uname = func(flag string) (string, error) {
-		if flag != "-r -v" {
-			assert.Fail("called uname with wrong parameters. Expected `-r -v` but got: `%s`", flag)
+	uname = func(flags []string) (string, error) {
+		params := strings.Join(flags, " ")
+		if params != "-r -v" {
+			assert.Fail("called uname with wrong parameters. Expected `-r -v` but got: `%s`", params)
 			return "unknown", nil
 		}
 		return expectedUname, nil

--- a/internal/collectors/uname_test.go
+++ b/internal/collectors/uname_test.go
@@ -1,0 +1,28 @@
+package collectors
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUnameCollectorsRun(t *testing.T) {
+	assert := assert.New(t)
+	testObj := Uname{}
+
+	expectedUname := "6.8.7-1-default #1 SMP PREEMPT_DYNAMIC Thu Apr 18 07:12:38 UTC 2024 (5c0cf23)"
+	expectedResult := Result{"uname": expectedUname}
+
+	uname = func(flag string) (string, error) {
+		if flag != "-r -v" {
+			assert.Fail("called uname with wrong parameters. Expected `-r -v` but got: `%s`", flag)
+			return "unknown", nil
+		}
+		return expectedUname, nil
+	}
+
+	result, err := testObj.run(ARCHITECTURE_ARM64)
+
+	assert.NoError(err)
+	assert.Equal(expectedResult, result)
+}

--- a/internal/connect/api.go
+++ b/internal/connect/api.go
@@ -271,6 +271,7 @@ var mandatoryCollectors = []collectors.Collector{
 	collectors.CloudProvider{},
 	collectors.Architecture{},
 	collectors.ContainerRuntime{},
+	collectors.Uname{},
 }
 
 func fetchSystemInformation() (collectors.Result, error) {


### PR DESCRIPTION
Adds `uname -r -v` out as collector property.

**How to test this PR:**

- Run `suseconnect --debug -r INVALID` and check that the output includes `uname`