### PR TITLE
'processor_information' -> 'arch_specs' on ARM64

### DIFF
--- a/internal/collectors/cpu.go
+++ b/internal/collectors/cpu.go
@@ -112,15 +112,15 @@ func addArm64Extras(result Result) Result {
 	} else {
 		output, _ := util.Execute([]string{"dmidecode", "-t", "processor"}, nil)
 
-		pinfo := make(map[string]string)
-		pinfo["family"] = exactStringMatch("Family", output)
-		pinfo["manufacturer"] = exactStringMatch("Manufacturer", output)
-		pinfo["signature"] = exactStringMatch("Signature", output)
-		if len(pinfo["family"]) == 0 && len(pinfo["manufacturer"]) == 0 && len(pinfo["signature"]) == 0 {
+		specs := make(map[string]string)
+		specs["family"] = exactStringMatch("Family", output)
+		specs["manufacturer"] = exactStringMatch("Manufacturer", output)
+		specs["signature"] = exactStringMatch("Signature", output)
+		if len(specs["family"]) == 0 && len(specs["manufacturer"]) == 0 && len(specs["signature"]) == 0 {
 			return result
 		}
 
-		result["processor_information"] = pinfo
+		result["arch_specs"] = specs
 	}
 	return result
 }

--- a/internal/collectors/cpu_test.go
+++ b/internal/collectors/cpu_test.go
@@ -74,12 +74,12 @@ func TestArm64ACPI(t *testing.T) {
 	mockDmidecode(t, "processor", util.ReadTestFile("collectors/dmidecode_aarch64_acpi.txt", t))
 	addArm64Extras(res)
 
-	pinfo := res["processor_information"].(map[string]string)
-	assert.NotNil(pinfo)
+	specs := res["arch_specs"].(map[string]string)
+	assert.NotNil(specs)
 
-	assert.Equal("ARMv8", pinfo["family"], "bad processor family")
-	assert.Equal("AppliedMicro(R)", pinfo["manufacturer"], "bad processor manufacturer")
-	assert.Equal(0, len(pinfo["signature"]), "expecting an empty signature")
+	assert.Equal("ARMv8", specs["family"], "bad processor family")
+	assert.Equal("AppliedMicro(R)", specs["manufacturer"], "bad processor manufacturer")
+	assert.Equal(0, len(specs["signature"]), "expecting an empty signature")
 }
 
 func TestArm64BadACPI(t *testing.T) {


### PR DESCRIPTION
This makes it consistent with values stored by other architectures.