### PR TITLE
Added Support for Registration code using File and StdInput

### DIFF
--- a/cmd/suseconnect/suseconnect_test.go
+++ b/cmd/suseconnect/suseconnect_test.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"io/ioutil"
+	"os"
+	"testing"
+)
+
+func TestProcessTokenWithFileToken(t *testing.T) {
+	tempFile, err := ioutil.TempFile("", "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tempFile.Name())
+
+	_, err = tempFile.WriteString("testToken")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	fileToken := fmt.Sprintf("@%s", tempFile.Name())
+	result, err := processToken(fileToken)
+	assert.NoError(t, err)
+	assert.Equal(t, "testToken", result)
+}
+func TestProcessTokenWithNormalToken(t *testing.T) {
+	result, err := processToken("testToken")
+	assert.NoError(t, err)
+	assert.Equal(t, "testToken", result)
+}
+
+func TestProcessTokenWithNonExistentFile(t *testing.T) {
+	fileToken := "@non_existent_file"
+	result, err := processToken(fileToken)
+	assert.Error(t, err)
+	assert.Equal(t, "", result)
+}
+
+func TestProcessTokenWithEmptyFile(t *testing.T) {
+	tempFile, err := ioutil.TempFile("", "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tempFile.Name())
+
+	fileToken := fmt.Sprintf("@%s", tempFile.Name())
+	result, err := processToken(fileToken)
+	assert.Error(t, err)
+	assert.Equal(t, "", result)
+}
+func TestProcessTokenWithStdinError(t *testing.T) {
+	stdinBackup := os.Stdin
+	defer func() { os.Stdin = stdinBackup }()
+	r, w, _ := os.Pipe()
+	r.Close()
+
+	os.Stdin = w
+	result, err := processToken("-")
+	assert.Error(t, err)
+	assert.Equal(t, "", result)
+}
+
+func TestProcessTokenWithStdin(t *testing.T) {
+	// Backup and restore stdin
+	stdinBackup := os.Stdin
+	defer func() { os.Stdin = stdinBackup }()
+
+	// Create a pipe and set the read end as stdin
+	r, w, _ := os.Pipe()
+	os.Stdin = r
+
+	// Write to the write end of the pipe in a separate goroutine
+	go func() {
+		defer w.Close()
+		w.Write([]byte("testToken\n"))
+	}()
+
+	result, err := processToken("-")
+	assert.NoError(t, err)
+	assert.Equal(t, "testToken", result)
+}
+
+func TestProcessTokenWithEmptyString(t *testing.T) {
+	result, err := processToken("")
+	assert.NoError(t, err)
+	assert.Equal(t, "", result)
+}
+
+// TestProcessTokenWithSpecialCharacters tests the processToken function with a token that contains special characters
+func TestProcessTokenWithSpecialCharacters(t *testing.T) {
+	result, err := processToken("!@#$%^&*()")
+	assert.NoError(t, err)
+	assert.Equal(t, "!@#$%^&*()", result)
+}
+
+func TestProcessTokenWithFileTokenWhitespace(t *testing.T) {
+	tempFile, err := ioutil.TempFile("", "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tempFile.Name())
+
+	_, err = tempFile.WriteString(" testToken ")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	fileToken := fmt.Sprintf("@%s", tempFile.Name())
+	result, err := processToken(fileToken)
+	assert.NoError(t, err)
+	assert.Equal(t, " testToken ", result)
+}

--- a/internal/util/constants.go
+++ b/internal/util/constants.go
@@ -1,0 +1,5 @@
+package util
+
+const AtTheRate = "@"
+const EmptyString = ""
+const Dash = "-"

--- a/internal/util/helper.go
+++ b/internal/util/helper.go
@@ -1,0 +1,10 @@
+package util
+
+import "fmt"
+
+func ThrowErrorIfEmpty(token string) (string, error) {
+	if token == EmptyString {
+		return "", fmt.Errorf("string is empty")
+	}
+	return token, nil
+}

--- a/internal/util/helper_test.go
+++ b/internal/util/helper_test.go
@@ -1,0 +1,32 @@
+package util
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestThrowErrorIfEmptyWithNonEmptyString(t *testing.T) {
+	result, err := ThrowErrorIfEmpty("testToken")
+	assert.NoError(t, err)
+	assert.Equal(t, "testToken", result)
+}
+
+func TestThrowErrorIfEmptyWithEmptyString(t *testing.T) {
+	result, err := ThrowErrorIfEmpty("")
+	assert.Error(t, err)
+	assert.Equal(t, "", result)
+	assert.Equal(t, fmt.Errorf("string is empty"), err)
+}
+
+func TestThrowErrorIfEmptyWithWhitespace(t *testing.T) {
+	result, err := ThrowErrorIfEmpty(" ")
+	assert.NoError(t, err)
+	assert.Equal(t, " ", result)
+}
+
+func TestThrowErrorIfEmptyWithNonWhitespace(t *testing.T) {
+	result, err := ThrowErrorIfEmpty("\t\n\r")
+	assert.NoError(t, err)
+	assert.Equal(t, "\t\n\r", result)
+}


### PR DESCRIPTION


## Description

Added Support two new ways to pass regcodes:

- Added support for -r -: passing a dash means "the regcode can be read directly from stdin" (eg.: echo "1234" | suseconnect -r -).

- Adding support for -r @/file/path: if the value starts with an '@' sign, then it means that the regcode is provided at the given file (eg.: suseconnect -r @/my/file)

**processToken Function Documentation**

The processToken function is a part of the suseconnect package in the cmd/suseconnect/suseconnect.go file. This function is responsible for processing the token input. The token can be a string, a file path prefixed with '@', or '-' indicating stdin.

**Function Signature**

`func processToken(token string) (string, error)`

**Function Behavior**

1. If the token starts with '@', it is considered a file path. The function reads the file, and if there's an error, it returns the error. If the file is read successfully, it checks if the content is empty using the util.ThrowErrorIfEmpty function.

2. If the token is '-', it is considered stdin. The function reads from stdin, and if there's an error, it returns the error. If the reading is successful, it checks if the content is empty using the util.ThrowErrorIfEmpty function.


## How to test the change

1. use the below commands to run the first requirement
`go run suseconnect.go -r @/my/file`

2. Second Requirement can be tested by the below code.
`echo "regCode" | go run suseconnect.go -r -`

 Refer to the suseconnect_test.go file for additional test cases
 
 Feel free to correct any inaccuracies or ask for further clarification