### PR TITLE
Grab the home directory from /etc/passwd if needed

### DIFF
--- a/internal/credentials/credentials.go
+++ b/internal/credentials/credentials.go
@@ -47,12 +47,7 @@ func ServiceCredentialsPath(service string, fsRoot string) string {
 }
 
 func CurlrcCredentialsPath() string {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		// TODO: handle error? log?
-		return ""
-	}
-	return filepath.Join(home, CurlrcUserFile)
+	return filepath.Join(util.CurrentHomeDir(), CurlrcUserFile)
 }
 
 // ReadCredentials returns the credentials from path

--- a/internal/credentials/credentials_test.go
+++ b/internal/credentials/credentials_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/SUSE/connect-ng/internal/util"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestParseCredentials(t *testing.T) {
@@ -135,4 +136,28 @@ func TestParseCurlrcCredentials(t *testing.T) {
 			t.Errorf("parseCurlrcCredentials() == %+v, %s, expected %+v, %s, input: %s", got, err, test.expectCreds, test.expectErr, test.input)
 		}
 	}
+}
+
+func TestCurlrcCredentialsPath(t *testing.T) {
+	assert := assert.New(t)
+
+	// We have to manipulate the path for this test to work.
+	home := os.Getenv("HOME")
+	err := os.Unsetenv("HOME")
+	if err != nil {
+		t.Fatal("could not setup test")
+	}
+	defer os.Setenv("HOME", home)
+
+	// Mocking up important functions
+
+	util.CurrentUser = func() string { return "user" }
+	util.ReadFile = func(path string) []byte {
+		assert.Equal("/etc/passwd", path)
+		return util.ReadTestFile("credentials/passwd.txt", t)
+	}
+
+	// The actual test :)
+
+	assert.Equal("/home/user/.curlrc", CurlrcCredentialsPath(), "bad curlrc credentials path")
 }

--- a/testdata/credentials/passwd.txt
+++ b/testdata/credentials/passwd.txt
@@ -1,0 +1,2 @@
+root:x:0:0:root:/root:/bin/bash
+user:x:498:498:User for Test:/home/user:/bin/bash


### PR DESCRIPTION
Go's `os.UserHomeDir` has one big gotcha: it only fetches the value from the HOME environment variable and that's it: it does not try to fetch this value from anywhere else if that environment variable is not set.

In some conditions (e.g. a systemd service file) this environment variable might not be set and hence some important paths will not be properly generated. This commit ensures that the home directory is picked: if Go's `os.UserHomeDir` fails, then we will try to read this value from `/etc/passwd`.

Fixes bsc#1226128