### PR TITLE
Honor auto-import-gpg-keys flag on migration

### DIFF
--- a/cmd/zypper-migration/migration.go
+++ b/cmd/zypper-migration/migration.go
@@ -497,8 +497,8 @@ func compareEditions(left, right string) int {
 	return 0
 }
 
-func cleanupProductRepos(p connect.Product, force bool) error {
-	productPackages, err := zypper.FindProductPackages(p.Name)
+func cleanupProductRepos(p connect.Product, force, autoImportRepoKeys bool) error {
+	productPackages, err := zypper.FindProductPackages(p.Name, autoImportRepoKeys)
 	if err != nil {
 		return err
 	}
@@ -564,7 +564,7 @@ func isSUSEService(service zypper.ZypperService) bool {
 // adds/removes services to match target state
 // disables obsolete repos
 // returns base product version string
-func migrateSystem(migration connect.MigrationPath, forceDisableRepos bool) (string, error) {
+func migrateSystem(migration connect.MigrationPath, forceDisableRepos, autoImportRepoKeys bool) (string, error) {
 	var baseProductVersion string
 
 	systemServices, _ := zypper.InstalledServices()
@@ -587,7 +587,7 @@ func migrateSystem(migration connect.MigrationPath, forceDisableRepos bool) (str
 			}
 		}
 
-		if err := cleanupProductRepos(p, forceDisableRepos); err != nil {
+		if err := cleanupProductRepos(p, forceDisableRepos, autoImportRepoKeys); err != nil {
 			return baseProductVersion, err
 		}
 
@@ -678,7 +678,7 @@ func applyMigration(migration connect.MigrationPath, systemProducts []connect.Pr
 		}
 	}
 
-	baseProductVersion, err := migrateSystem(migration, nonInteractive || forceDisableRepos)
+	baseProductVersion, err := migrateSystem(migration, nonInteractive || forceDisableRepos, autoImportRepoKeys)
 	if err != nil {
 		return fsInconsistent, err
 	}

--- a/internal/zypper/zypper.go
+++ b/internal/zypper/zypper.go
@@ -358,9 +358,13 @@ func parseSearchResultXML(xmlDoc []byte) ([]Package, error) {
 }
 
 // FindProductPackages returns list of product packages for given product
-func FindProductPackages(identifier string) ([]Package, error) {
+func FindProductPackages(identifier string, autoImportRepoKeys bool) ([]Package, error) {
 	args := []string{"--xmlout", "--no-refresh", "--non-interactive", "search", "-s",
 		"--match-exact", "-t", "product", identifier}
+	if autoImportRepoKeys {
+		args = append([]string{"--gpg-auto-import-keys"}, args...)
+	}
+
 	// Don't fail when zypper exits with 104 (no product found) or 6 (no repositories)
 	output, err := zypperRun(args, []int{zypperOK, zypperErrNoRepos, zypperInfoCapNotFound})
 	if err != nil {


### PR DESCRIPTION
## Description

The parsing of CLI arguments and how these are passed through the internal SCC client, zypper and other tools is not ideal and needs to be re-worked quite urgently. This is why other silly bugs have appeared in which we are not passing the correct arguments to our backend code.

Until this rework is not done, let's simply apply this quick fix which simply passes the `--gpg-auto-import-keys` flag to the zypper backend when finding product packages.

Fixes bsc#1231328

## How to test

I have manually tested this code, but I still have to do an end to end test which considers the exact path as described in bsc#1231328.