### PR TITLE
zypper-migration: Mark beta products

### DIFF
--- a/cmd/zypper-migration/migration.go
+++ b/cmd/zypper-migration/migration.go
@@ -437,6 +437,9 @@ func printMigrations(migrations []connect.MigrationPath,
 			if installedIDs.Contains(p.ToTriplet()) {
 				suffix = suffix + " (already installed)"
 			}
+			if strings.Contains(strings.TrimSpace(p.ReleaseStage), "beta") {
+				suffix = suffix + " (BETA)"
+			}
 			fmt.Printf("%s%s%s\n", prefix, p.FriendlyName, suffix)
 		}
 		fmt.Print("\n")


### PR DESCRIPTION
## Description

Mark beta products in an uppercase "BETA" string so customers are aware of this fact. This is similar to what we do with products that are already installed, for example.

Fixes bsc#1211609

## How to test

Run this inside of a container. On the repository run the following command:

```
$ docker run --rm --privileged -ti -v $(pwd):/connect registry.suse.com/bci/golang:1.21-openssl
```

And now from inside the container:

```
# git config --global --add safe.directory /connect
# cd /connect
# make build
# ./out/suseconnect -r <regcode>
# ./out/zypper-migration
```

The last step might need to be run twice if the zypper stack is old (which it was in my case). Then, whenever the migration is really computed, it should show something like:

```
Available migrations:

    1 |SUSE Linux Enterprise Server 15 SP7 x86_64 (BETA)
(and more)
```

Notice the "BETA" sign, this is the newly introduced string.