### PR TITLE
Add fetching product activations from SCC

### DIFF
--- a/cmd/public-api-demo/main.go
+++ b/cmd/public-api-demo/main.go
@@ -66,7 +66,7 @@ func runDemo(identifier, version, arch, regcode string) error {
 	bold("++ %s activated\n", root.FriendlyName)
 	waitForUser("Registration complete")
 
-	bold("3) System status // Ping\n")
+	bold("4) System status // Ping\n")
 	systemInformation := map[string]any{
 		"uname": "public api demo - ping",
 	}
@@ -104,7 +104,19 @@ func runDemo(identifier, version, arch, regcode string) error {
 	}
 	waitForUser("System fully activated")
 
-	bold("6) Deregistration of the client\n")
+	bold("6) Show all activations\n")
+	activations, actErr := registration.FetchActivations(conn)
+
+	if actErr != nil {
+		return actErr
+	}
+
+	for i, activation := range activations {
+		fmt.Printf("[%d] %s\n", i, activation.Product.Name)
+	}
+	waitForUser("All activated products are listed")
+
+	bold("7) Deregistration of the client\n")
 	if err := registration.Deregister(conn); err != nil {
 		return err
 	}

--- a/pkg/registration/activation.go
+++ b/pkg/registration/activation.go
@@ -1,0 +1,80 @@
+package registration
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/SUSE/connect-ng/pkg/connection"
+)
+
+// Activation holds information about a product activation.
+// subscription information.
+type Activation struct {
+	Name             string    `json:"name"`
+	Status           string    `json:"status"`
+	RegistrationCode string    `json:"regcode"`
+	Type             string    `json:"type"`
+	StartsAt         time.Time `json:"starts_at"`
+	ExpiresAt        time.Time `json:"expires_at"`
+
+	Metadata *Metadata
+	Product  *Product
+}
+
+type activationResponse struct {
+	Activation
+	MetadataAndProduct activateResponse `json:"service"`
+}
+
+var noActivations = []*Activation{}
+
+// Fetch all known product activations for this system. If there the system has not yet
+// activated a product, it returns an empty array.
+func FetchActivations(conn connection.Connection) ([]*Activation, error) {
+	activations := []*activationResponse{}
+
+	creds := conn.GetCredentials()
+	login, password, credErr := creds.Login()
+
+	if credErr != nil {
+		return noActivations, credErr
+	}
+
+	request, buildErr := conn.BuildRequest("GET", "/connect/systems/activations", nil)
+
+	if buildErr != nil {
+		return noActivations, buildErr
+	}
+
+	connection.AddSystemAuth(request, login, password)
+
+	response, doErr := conn.Do(request)
+	if doErr != nil {
+		return noActivations, doErr
+	}
+
+	if err := json.Unmarshal(response, &activations); err != nil {
+		return noActivations, err
+	}
+
+	return unpackActivations(activations)
+}
+
+func unpackActivations(packed []*activationResponse) ([]*Activation, error) {
+	activations := []*Activation{}
+
+	for _, data := range packed {
+		activation := &data.Activation
+		activation.Product = &data.MetadataAndProduct.Product
+		activation.Metadata = &Metadata{
+			ID:            data.MetadataAndProduct.ID,
+			URL:           data.MetadataAndProduct.URL,
+			Name:          data.MetadataAndProduct.Name,
+			ObsoletedName: data.MetadataAndProduct.ObsoletedName,
+		}
+
+		activations = append(activations, activation)
+	}
+
+	return activations, nil
+}

--- a/pkg/registration/activation_test.go
+++ b/pkg/registration/activation_test.go
@@ -1,0 +1,47 @@
+package registration_test
+
+import (
+	"testing"
+
+	"github.com/SUSE/connect-ng/pkg/registration"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestFetchProductActivations(t *testing.T) {
+	assert := assert.New(t)
+
+	conn, creds := mockConnectionWithCredentials()
+	login, password, _ := creds.Login()
+
+	payload := fixture(t, "pkg/registration/activations.json")
+	conn.On("Do", mock.Anything).Return(payload, nil).Run(checkAuthBySystemCredentials(t, login, password))
+
+	activations, err := registration.FetchActivations(conn)
+
+	assert.NoError(err)
+	assert.Equal(4, len(activations))
+
+	sles := &registration.Activation{}
+	for _, activation := range activations {
+		if activation.RegistrationCode == "SOME_TEST_REGCODE" {
+			sles = activation
+		}
+	}
+	assert.Equal("15.6", sles.Product.Version)
+	assert.Equal("SUSE_Linux_Enterprise_Server_15_SP6_x86_64", sles.Metadata.Name)
+}
+
+func TestFetchProductActivationsEmpty(t *testing.T) {
+	assert := assert.New(t)
+
+	conn, creds := mockConnectionWithCredentials()
+	login, password, _ := creds.Login()
+
+	conn.On("Do", mock.Anything).Return([]byte("[]"), nil).Run(checkAuthBySystemCredentials(t, login, password))
+
+	activations, err := registration.FetchActivations(conn)
+
+	assert.NoError(err)
+	assert.Equal(0, len(activations))
+}

--- a/testdata/pkg/registration/activations.json
+++ b/testdata/pkg/registration/activations.json
@@ -1,0 +1,1562 @@
+[
+  {
+    "id": 91903689,
+    "name": null,
+    "regcode": null,
+    "type": null,
+    "status": null,
+    "starts_at": null,
+    "expires_at": null,
+    "system_id": 18492582,
+    "service": {
+      "id": 2562,
+      "name": "Python_3_Module_15_SP6_x86_64",
+      "url": "https://scc.suse.com/access/services/2562?credentials=Python_3_Module_15_SP6_x86_64",
+      "obsoleted_service_name": "",
+      "product": {
+        "id": 2683,
+        "name": "Python 3 Module",
+        "identifier": "sle-module-python3",
+        "former_identifier": "sle-module-python3",
+        "version": "15.6",
+        "release_type": null,
+        "arch": "x86_64",
+        "friendly_name": "Python 3 Module 15 SP6 x86_64",
+        "product_class": "MODULE",
+        "cpe": "cpe:/o:suse:sle-module-python3:15:sp6",
+        "free": true,
+        "description": "<p> This module contains the Python 3 packages. </p> <p> Access to the Python 3 Module is included in your SUSE Linux Enterprise subscription. The module has a different lifecycle than SUSE Linux Enterprise itself; please check the Release Notes for further details. </p>",
+        "eula_url": "",
+        "repositories": [
+          {
+            "id": 6663,
+            "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Python3/15-SP6/x86_64/update",
+            "name": "SLE-Module-Python3-15-SP6-Updates",
+            "distro_target": "sle-15-x86_64",
+            "description": "SLE-Module-Python3-15-SP6-Updates for sle-15-x86_64",
+            "enabled": true,
+            "autorefresh": true
+          },
+          {
+            "id": 6664,
+            "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Python3/15-SP6/x86_64/update_debug",
+            "name": "SLE-Module-Python3-15-SP6-Debuginfo-Updates",
+            "distro_target": "sle-15-x86_64",
+            "description": "SLE-Module-Python3-15-SP6-Debuginfo-Updates for sle-15-x86_64",
+            "enabled": false,
+            "autorefresh": true
+          },
+          {
+            "id": 6665,
+            "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Python3/15-SP6/x86_64/product",
+            "name": "SLE-Module-Python3-15-SP6-Pool",
+            "distro_target": "sle-15-x86_64",
+            "description": "SLE-Module-Python3-15-SP6-Pool for sle-15-x86_64",
+            "enabled": true,
+            "autorefresh": false
+          },
+          {
+            "id": 6666,
+            "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Python3/15-SP6/x86_64/product_debug",
+            "name": "SLE-Module-Python3-15-SP6-Debuginfo-Pool",
+            "distro_target": "sle-15-x86_64",
+            "description": "SLE-Module-Python3-15-SP6-Debuginfo-Pool for sle-15-x86_64",
+            "enabled": false,
+            "autorefresh": false
+          },
+          {
+            "id": 6667,
+            "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Python3/15-SP6/x86_64/product_source",
+            "name": "SLE-Module-Python3-15-SP6-Source-Pool",
+            "distro_target": "sle-15-x86_64",
+            "description": "SLE-Module-Python3-15-SP6-Source-Pool for sle-15-x86_64",
+            "enabled": false,
+            "autorefresh": false
+          }
+        ],
+        "product_type": "module",
+        "extensions": []
+      }
+    }
+  },
+  {
+    "id": 91903684,
+    "name": null,
+    "regcode": null,
+    "type": null,
+    "status": null,
+    "starts_at": null,
+    "expires_at": null,
+    "system_id": 18492582,
+    "service": {
+      "id": 2502,
+      "name": "Basesystem_Module_15_SP6_x86_64",
+      "url": "https://scc.suse.com/access/services/2502?credentials=Basesystem_Module_15_SP6_x86_64",
+      "obsoleted_service_name": "",
+      "product": {
+        "id": 2618,
+        "name": "Basesystem Module",
+        "identifier": "sle-module-basesystem",
+        "former_identifier": "sle-module-basesystem",
+        "version": "15.6",
+        "release_type": null,
+        "arch": "x86_64",
+        "friendly_name": "Basesystem Module 15 SP6 x86_64",
+        "product_class": "MODULE",
+        "cpe": "cpe:/o:suse:sle-module-basesystem:15:sp6",
+        "free": true,
+        "description": "<p> The SUSE Linux Enterprise Basesystem Module delivers the base system of the product. </p>",
+        "eula_url": "",
+        "repositories": [
+          {
+            "id": 6345,
+            "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Basesystem/15-SP6/x86_64/update",
+            "name": "SLE-Module-Basesystem15-SP6-Updates",
+            "distro_target": "sle-15-x86_64",
+            "description": "SLE-Module-Basesystem15-SP6-Updates for sle-15-x86_64",
+            "enabled": true,
+            "autorefresh": true
+          },
+          {
+            "id": 6346,
+            "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Basesystem/15-SP6/x86_64/update_debug",
+            "name": "SLE-Module-Basesystem15-SP6-Debuginfo-Updates",
+            "distro_target": "sle-15-x86_64",
+            "description": "SLE-Module-Basesystem15-SP6-Debuginfo-Updates for sle-15-x86_64",
+            "enabled": false,
+            "autorefresh": true
+          },
+          {
+            "id": 6347,
+            "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Basesystem/15-SP6/x86_64/product",
+            "name": "SLE-Module-Basesystem15-SP6-Pool",
+            "distro_target": "sle-15-x86_64",
+            "description": "SLE-Module-Basesystem15-SP6-Pool for sle-15-x86_64",
+            "enabled": true,
+            "autorefresh": false
+          },
+          {
+            "id": 6348,
+            "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Basesystem/15-SP6/x86_64/product_debug",
+            "name": "SLE-Module-Basesystem15-SP6-Debuginfo-Pool",
+            "distro_target": "sle-15-x86_64",
+            "description": "SLE-Module-Basesystem15-SP6-Debuginfo-Pool for sle-15-x86_64",
+            "enabled": false,
+            "autorefresh": false
+          },
+          {
+            "id": 6349,
+            "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Basesystem/15-SP6/x86_64/product_source",
+            "name": "SLE-Module-Basesystem15-SP6-Source-Pool",
+            "distro_target": "sle-15-x86_64",
+            "description": "SLE-Module-Basesystem15-SP6-Source-Pool for sle-15-x86_64",
+            "enabled": false,
+            "autorefresh": false
+          }
+        ],
+        "product_type": "module",
+        "extensions": []
+      }
+    }
+  },
+  {
+    "id": 91903682,
+    "name": "SUSE Linux Enterprise Server happy subscription",
+    "regcode": "SOME_TEST_REGCODE",
+    "type": "test",
+    "status": "ACTIVE",
+    "starts_at": "2017-07-03T11:54:04.354Z",
+    "expires_at": "2029-01-01T23:56:05.311Z",
+    "system_id": 18492582,
+    "service": {
+      "id": 2493,
+      "name": "SUSE_Linux_Enterprise_Server_15_SP6_x86_64",
+      "url": "https://scc.suse.com/access/services/2493?credentials=SUSE_Linux_Enterprise_Server_15_SP6_x86_64",
+      "obsoleted_service_name": "",
+      "product": {
+        "id": 2609,
+        "name": "SUSE Linux Enterprise Server",
+        "identifier": "SLES",
+        "former_identifier": "SLES",
+        "version": "15.6",
+        "release_type": null,
+        "arch": "x86_64",
+        "friendly_name": "SUSE Linux Enterprise Server 15 SP6 x86_64",
+        "product_class": "7261",
+        "cpe": "cpe:/o:suse:sles:15:sp6",
+        "free": false,
+        "description": "SUSE Linux Enterprise offers a comprehensive suite of products built on a single code base. The platform addresses business needs from the smallest thin-client devices to the world's most powerful high-performance computing and mainframe servers. SUSE Linux Enterprise offers common management tools and technology certifications across the platform, and each product is enterprise-class.",
+        "eula_url": "https://updates.suse.com/SUSE/Products/SLE-Product-SLES/15-SP6/x86_64/product.license/",
+        "repositories": [
+          {
+            "id": 6298,
+            "url": "https://updates.suse.com/SUSE/Updates/SLE-Product-SLES/15-SP6/x86_64/update",
+            "name": "SLE-Product-SLES15-SP6-Updates",
+            "distro_target": "sle-15-x86_64",
+            "description": "SLE-Product-SLES15-SP6-Updates for sle-15-x86_64",
+            "enabled": true,
+            "autorefresh": true
+          },
+          {
+            "id": 6299,
+            "url": "https://updates.suse.com/SUSE/Updates/SLE-Product-SLES/15-SP6/x86_64/update_debug",
+            "name": "SLE-Product-SLES15-SP6-Debuginfo-Updates",
+            "distro_target": "sle-15-x86_64",
+            "description": "SLE-Product-SLES15-SP6-Debuginfo-Updates for sle-15-x86_64",
+            "enabled": false,
+            "autorefresh": true
+          },
+          {
+            "id": 6301,
+            "url": "https://updates.suse.com/SUSE/Products/SLE-Product-SLES/15-SP6/x86_64/product",
+            "name": "SLE-Product-SLES15-SP6-Pool",
+            "distro_target": "sle-15-x86_64",
+            "description": "SLE-Product-SLES15-SP6-Pool for sle-15-x86_64",
+            "enabled": true,
+            "autorefresh": false
+          },
+          {
+            "id": 6302,
+            "url": "https://updates.suse.com/SUSE/Products/SLE-Product-SLES/15-SP6/x86_64/product_debug",
+            "name": "SLE-Product-SLES15-SP6-Debuginfo-Pool",
+            "distro_target": "sle-15-x86_64",
+            "description": "SLE-Product-SLES15-SP6-Debuginfo-Pool for sle-15-x86_64",
+            "enabled": false,
+            "autorefresh": false
+          },
+          {
+            "id": 6303,
+            "url": "https://updates.suse.com/SUSE/Products/SLE-Product-SLES/15-SP6/x86_64/product_source",
+            "name": "SLE-Product-SLES15-SP6-Source-Pool",
+            "distro_target": "sle-15-x86_64",
+            "description": "SLE-Product-SLES15-SP6-Source-Pool for sle-15-x86_64",
+            "enabled": false,
+            "autorefresh": false
+          }
+        ],
+        "product_type": "base",
+        "extensions": [
+          {
+            "id": 2618,
+            "name": "Basesystem Module",
+            "identifier": "sle-module-basesystem",
+            "former_identifier": "sle-module-basesystem",
+            "version": "15.6",
+            "release_type": null,
+            "arch": "x86_64",
+            "friendly_name": "Basesystem Module 15 SP6 x86_64",
+            "product_class": "MODULE",
+            "cpe": "cpe:/o:suse:sle-module-basesystem:15:sp6",
+            "free": true,
+            "description": "<p> The SUSE Linux Enterprise Basesystem Module delivers the base system of the product. </p>",
+            "eula_url": "",
+            "repositories": [
+              {
+                "id": 6345,
+                "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Basesystem/15-SP6/x86_64/update",
+                "name": "SLE-Module-Basesystem15-SP6-Updates",
+                "distro_target": "sle-15-x86_64",
+                "description": "SLE-Module-Basesystem15-SP6-Updates for sle-15-x86_64",
+                "enabled": true,
+                "autorefresh": true
+              },
+              {
+                "id": 6346,
+                "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Basesystem/15-SP6/x86_64/update_debug",
+                "name": "SLE-Module-Basesystem15-SP6-Debuginfo-Updates",
+                "distro_target": "sle-15-x86_64",
+                "description": "SLE-Module-Basesystem15-SP6-Debuginfo-Updates for sle-15-x86_64",
+                "enabled": false,
+                "autorefresh": true
+              },
+              {
+                "id": 6347,
+                "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Basesystem/15-SP6/x86_64/product",
+                "name": "SLE-Module-Basesystem15-SP6-Pool",
+                "distro_target": "sle-15-x86_64",
+                "description": "SLE-Module-Basesystem15-SP6-Pool for sle-15-x86_64",
+                "enabled": true,
+                "autorefresh": false
+              },
+              {
+                "id": 6348,
+                "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Basesystem/15-SP6/x86_64/product_debug",
+                "name": "SLE-Module-Basesystem15-SP6-Debuginfo-Pool",
+                "distro_target": "sle-15-x86_64",
+                "description": "SLE-Module-Basesystem15-SP6-Debuginfo-Pool for sle-15-x86_64",
+                "enabled": false,
+                "autorefresh": false
+              },
+              {
+                "id": 6349,
+                "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Basesystem/15-SP6/x86_64/product_source",
+                "name": "SLE-Module-Basesystem15-SP6-Source-Pool",
+                "distro_target": "sle-15-x86_64",
+                "description": "SLE-Module-Basesystem15-SP6-Source-Pool for sle-15-x86_64",
+                "enabled": false,
+                "autorefresh": false
+              }
+            ],
+            "product_type": "module",
+            "extensions": [
+              {
+                "id": 2622,
+                "name": "Desktop Applications Module",
+                "identifier": "sle-module-desktop-applications",
+                "former_identifier": "sle-module-desktop-applications",
+                "version": "15.6",
+                "release_type": null,
+                "arch": "x86_64",
+                "friendly_name": "Desktop Applications Module 15 SP6 x86_64",
+                "product_class": "MODULE",
+                "cpe": "cpe:/o:suse:sle-module-desktop-applications:15:sp6",
+                "free": true,
+                "description": "<p> The SUSE Linux Enterprise Desktop Applications Module delivers a basic set of Desktop functionality. </p> <p> Access to the Desktop Applications Module is included in your SUSE Linux Enterprise product subscription. </p>",
+                "eula_url": "",
+                "repositories": [
+                  {
+                    "id": 6365,
+                    "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Desktop-Applications/15-SP6/x86_64/update",
+                    "name": "SLE-Module-Desktop-Applications15-SP6-Updates",
+                    "distro_target": "sle-15-x86_64",
+                    "description": "SLE-Module-Desktop-Applications15-SP6-Updates for sle-15-x86_64",
+                    "enabled": true,
+                    "autorefresh": true
+                  },
+                  {
+                    "id": 6366,
+                    "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Desktop-Applications/15-SP6/x86_64/update_debug",
+                    "name": "SLE-Module-Desktop-Applications15-SP6-Debuginfo-Updates",
+                    "distro_target": "sle-15-x86_64",
+                    "description": "SLE-Module-Desktop-Applications15-SP6-Debuginfo-Updates for sle-15-x86_64",
+                    "enabled": false,
+                    "autorefresh": true
+                  },
+                  {
+                    "id": 6367,
+                    "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Desktop-Applications/15-SP6/x86_64/product",
+                    "name": "SLE-Module-Desktop-Applications15-SP6-Pool",
+                    "distro_target": "sle-15-x86_64",
+                    "description": "SLE-Module-Desktop-Applications15-SP6-Pool for sle-15-x86_64",
+                    "enabled": true,
+                    "autorefresh": false
+                  },
+                  {
+                    "id": 6368,
+                    "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Desktop-Applications/15-SP6/x86_64/product_debug",
+                    "name": "SLE-Module-Desktop-Applications15-SP6-Debuginfo-Pool",
+                    "distro_target": "sle-15-x86_64",
+                    "description": "SLE-Module-Desktop-Applications15-SP6-Debuginfo-Pool for sle-15-x86_64",
+                    "enabled": false,
+                    "autorefresh": false
+                  },
+                  {
+                    "id": 6369,
+                    "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Desktop-Applications/15-SP6/x86_64/product_source",
+                    "name": "SLE-Module-Desktop-Applications15-SP6-Source-Pool",
+                    "distro_target": "sle-15-x86_64",
+                    "description": "SLE-Module-Desktop-Applications15-SP6-Source-Pool for sle-15-x86_64",
+                    "enabled": false,
+                    "autorefresh": false
+                  }
+                ],
+                "product_type": "module",
+                "extensions": [
+                  {
+                    "id": 2641,
+                    "name": "Development Tools Module",
+                    "identifier": "sle-module-development-tools",
+                    "former_identifier": "sle-sdk",
+                    "version": "15.6",
+                    "release_type": null,
+                    "arch": "x86_64",
+                    "friendly_name": "Development Tools Module 15 SP6 x86_64",
+                    "product_class": "MODULE",
+                    "cpe": "cpe:/o:suse:sle-module-development-tools:15:sp6",
+                    "free": true,
+                    "description": "<p> The Development Tools Module helps you developing applications for SUSE Linux Enterprise 15. </p> <p> Access to the Development Tools Module is included in your SUSE Linux Enterprise product subscription. The module has a different lifecycle than SUSE Linux Enterprise itself. </p>",
+                    "eula_url": "",
+                    "repositories": [
+                      {
+                        "id": 6460,
+                        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Development-Tools/15-SP6/x86_64/update",
+                        "name": "SLE-Module-DevTools15-SP6-Updates",
+                        "distro_target": "sle-15-x86_64",
+                        "description": "SLE-Module-DevTools15-SP6-Updates for sle-15-x86_64",
+                        "enabled": true,
+                        "autorefresh": true
+                      },
+                      {
+                        "id": 6461,
+                        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Development-Tools/15-SP6/x86_64/update_debug",
+                        "name": "SLE-Module-DevTools15-SP6-Debuginfo-Updates",
+                        "distro_target": "sle-15-x86_64",
+                        "description": "SLE-Module-DevTools15-SP6-Debuginfo-Updates for sle-15-x86_64",
+                        "enabled": false,
+                        "autorefresh": true
+                      },
+                      {
+                        "id": 6462,
+                        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Development-Tools/15-SP6/x86_64/product",
+                        "name": "SLE-Module-DevTools15-SP6-Pool",
+                        "distro_target": "sle-15-x86_64",
+                        "description": "SLE-Module-DevTools15-SP6-Pool for sle-15-x86_64",
+                        "enabled": true,
+                        "autorefresh": false
+                      },
+                      {
+                        "id": 6463,
+                        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Development-Tools/15-SP6/x86_64/product_debug",
+                        "name": "SLE-Module-DevTools15-SP6-Debuginfo-Pool",
+                        "distro_target": "sle-15-x86_64",
+                        "description": "SLE-Module-DevTools15-SP6-Debuginfo-Pool for sle-15-x86_64",
+                        "enabled": false,
+                        "autorefresh": false
+                      },
+                      {
+                        "id": 6464,
+                        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Development-Tools/15-SP6/x86_64/product_source",
+                        "name": "SLE-Module-DevTools15-SP6-Source-Pool",
+                        "distro_target": "sle-15-x86_64",
+                        "description": "SLE-Module-DevTools15-SP6-Source-Pool for sle-15-x86_64",
+                        "enabled": false,
+                        "autorefresh": false
+                      }
+                    ],
+                    "product_type": "module",
+                    "extensions": [
+                      {
+                        "id": 2131,
+                        "name": "NVIDIA Compute Module",
+                        "identifier": "sle-module-NVIDIA-compute",
+                        "former_identifier": "sle-module-NVIDIA-compute",
+                        "version": "15",
+                        "release_type": null,
+                        "arch": "x86_64",
+                        "friendly_name": "NVIDIA Compute Module 15 x86_64",
+                        "product_class": "MODULE",
+                        "cpe": "cpe:/o:suse:sle-module-nvidia-compute:15",
+                        "free": true,
+                        "description": "NVIDIA Compute Drivers - NVIDIA CUDA This Module contains software under the terms and conditions of a 3rd party EULA (End User License Agreement). The EULA can be found at https://docs.nvidia.com/cuda/eula/index.html. By using this software you agree to fully comply with the terms and conditions of the EULA. If you do not agree to the terms and conditions of the EULA, do not use the software.",
+                        "eula_url": "https://updates.suse.com/SUSE/Products/SLE-Module-NVIDIA-Compute/15/x86_64/product.license/",
+                        "repositories": [
+                          {
+                            "id": 4554,
+                            "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-NVIDIA-Compute/15/x86_64/update",
+                            "name": "SLE-Module-NVIDIA-Compute-15-Updates",
+                            "distro_target": "sle-15-x86_64",
+                            "description": "SLE-Module-NVIDIA-Compute-15-Updates for sle-15-x86_64",
+                            "enabled": true,
+                            "autorefresh": true
+                          },
+                          {
+                            "id": 4556,
+                            "url": "https://updates.suse.com/SUSE/Products/SLE-Module-NVIDIA-Compute/15/x86_64/product",
+                            "name": "SLE-Module-NVIDIA-Compute-15-Pool",
+                            "distro_target": "sle-15-x86_64",
+                            "description": "SLE-Module-NVIDIA-Compute-15-Pool for sle-15-x86_64",
+                            "enabled": true,
+                            "autorefresh": false
+                          },
+                          {
+                            "id": 4563,
+                            "url": "https://developer.download.nvidia.com/compute/cuda/repos/sles15/x86_64",
+                            "name": "NVIDIA-Compute-SLE-15",
+                            "distro_target": null,
+                            "description": "NVIDIA-Compute-SLE-15",
+                            "enabled": true,
+                            "autorefresh": true
+                          }
+                        ],
+                        "product_type": "module",
+                        "extensions": []
+                      },
+                      {
+                        "id": 2727,
+                        "name": "SAP Business One Module",
+                        "identifier": "sle-module-sap-business-one",
+                        "former_identifier": "sle-module-sap-business-one",
+                        "version": "15.6",
+                        "release_type": null,
+                        "arch": "x86_64",
+                        "friendly_name": "SAP Business One Module 15 SP6 x86_64",
+                        "product_class": "MODULE",
+                        "cpe": "cpe:/o:suse:sle-module-sap-business-one:15:sp6",
+                        "free": true,
+                        "description": "<p> The SAP Business One module contains the specialized tools for the installation of SAP Business One product. </p> <p> The module is maintained and supported by the SUSE Linux Enterprise Server product subscription. </p>",
+                        "eula_url": "",
+                        "repositories": [
+                          {
+                            "id": 6848,
+                            "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-SAP-Business-One/15-SP6/x86_64/update",
+                            "name": "SLE-Module-SAP-Business-One15-SP6-Updates",
+                            "distro_target": "sle-15-x86_64",
+                            "description": "SLE-Module-SAP-Business-One15-SP6-Updates for sle-15-x86_64",
+                            "enabled": true,
+                            "autorefresh": true
+                          },
+                          {
+                            "id": 6849,
+                            "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-SAP-Business-One/15-SP6/x86_64/update_debug",
+                            "name": "SLE-Module-SAP-Business-One15-SP6-Debuginfo-Updates",
+                            "distro_target": "sle-15-x86_64",
+                            "description": "SLE-Module-SAP-Business-One15-SP6-Debuginfo-Updates for sle-15-x86_64",
+                            "enabled": false,
+                            "autorefresh": true
+                          },
+                          {
+                            "id": 6850,
+                            "url": "https://updates.suse.com/SUSE/Products/SLE-Module-SAP-Business-One/15-SP6/x86_64/product",
+                            "name": "SLE-Module-SAP-Business-One15-SP6-Pool",
+                            "distro_target": "sle-15-x86_64",
+                            "description": "SLE-Module-SAP-Business-One15-SP6-Pool for sle-15-x86_64",
+                            "enabled": true,
+                            "autorefresh": false
+                          },
+                          {
+                            "id": 6851,
+                            "url": "https://updates.suse.com/SUSE/Products/SLE-Module-SAP-Business-One/15-SP6/x86_64/product_debug",
+                            "name": "SLE-Module-SAP-Business-One15-SP6-Debuginfo-Pool",
+                            "distro_target": "sle-15-x86_64",
+                            "description": "SLE-Module-SAP-Business-One15-SP6-Debuginfo-Pool for sle-15-x86_64",
+                            "enabled": false,
+                            "autorefresh": false
+                          },
+                          {
+                            "id": 6852,
+                            "url": "https://updates.suse.com/SUSE/Products/SLE-Module-SAP-Business-One/15-SP6/x86_64/product_source",
+                            "name": "SLE-Module-SAP-Business-One15-SP6-Source-Pool",
+                            "distro_target": "sle-15-x86_64",
+                            "description": "SLE-Module-SAP-Business-One15-SP6-Source-Pool for sle-15-x86_64",
+                            "enabled": false,
+                            "autorefresh": false
+                          }
+                        ],
+                        "product_type": "module",
+                        "extensions": []
+                      }
+                    ]
+                  },
+                  {
+                    "id": 2661,
+                    "name": "SUSE Linux Enterprise Workstation Extension",
+                    "identifier": "sle-we",
+                    "former_identifier": "sle-we",
+                    "version": "15.6",
+                    "release_type": null,
+                    "arch": "x86_64",
+                    "friendly_name": "SUSE Linux Enterprise Workstation Extension 15 SP6 x86_64",
+                    "product_class": "SLE-WE",
+                    "cpe": "cpe:/o:suse:sle-we:15:sp6",
+                    "free": false,
+                    "description": "SUSE Linux Enterprise Workstation Extension adds additional functionality to a base SUSE Linux Enterprise installation. The Workstation Extension offers additional desktop applications (office suite, email client, graphical editor, multimedia tools) and libraries. Workstation Extension is enabled and installed by default on SUSE Linux Enterprise Desktop installation. Adding the Workstation Extension to a SUSE Linux Enterprise Server installation allows to seamlessly combine both products to create a full featured server workstation.",
+                    "eula_url": "https://updates.suse.com/SUSE/Products/SLE-Product-WE/15-SP6/x86_64/product.license/",
+                    "repositories": [
+                      {
+                        "id": 6560,
+                        "url": "https://updates.suse.com/SUSE/Updates/SLE-Product-WE/15-SP6/x86_64/update",
+                        "name": "SLE-Product-WE15-SP6-Updates",
+                        "distro_target": "sle-15-x86_64",
+                        "description": "SLE-Product-WE15-SP6-Updates for sle-15-x86_64",
+                        "enabled": true,
+                        "autorefresh": true
+                      },
+                      {
+                        "id": 6561,
+                        "url": "https://updates.suse.com/SUSE/Updates/SLE-Product-WE/15-SP6/x86_64/update_debug",
+                        "name": "SLE-Product-WE15-SP6-Debuginfo-Updates",
+                        "distro_target": "sle-15-x86_64",
+                        "description": "SLE-Product-WE15-SP6-Debuginfo-Updates for sle-15-x86_64",
+                        "enabled": false,
+                        "autorefresh": true
+                      },
+                      {
+                        "id": 6562,
+                        "url": "https://updates.suse.com/SUSE/Products/SLE-Product-WE/15-SP6/x86_64/product",
+                        "name": "SLE-Product-WE15-SP6-Pool",
+                        "distro_target": "sle-15-x86_64",
+                        "description": "SLE-Product-WE15-SP6-Pool for sle-15-x86_64",
+                        "enabled": true,
+                        "autorefresh": false
+                      },
+                      {
+                        "id": 6563,
+                        "url": "https://updates.suse.com/SUSE/Products/SLE-Product-WE/15-SP6/x86_64/product_debug",
+                        "name": "SLE-Product-WE15-SP6-Debuginfo-Pool",
+                        "distro_target": "sle-15-x86_64",
+                        "description": "SLE-Product-WE15-SP6-Debuginfo-Pool for sle-15-x86_64",
+                        "enabled": false,
+                        "autorefresh": false
+                      },
+                      {
+                        "id": 6564,
+                        "url": "https://updates.suse.com/SUSE/Products/SLE-Product-WE/15-SP6/x86_64/product_source",
+                        "name": "SLE-Product-WE15-SP6-Source-Pool",
+                        "distro_target": "sle-15-x86_64",
+                        "description": "SLE-Product-WE15-SP6-Source-Pool for sle-15-x86_64",
+                        "enabled": false,
+                        "autorefresh": false
+                      },
+                      {
+                        "id": 6894,
+                        "url": "https://download.nvidia.com/suse/sle15sp6",
+                        "name": "SLE-15-SP6-Desktop-NVIDIA-Driver",
+                        "distro_target": null,
+                        "description": "SLE-15-SP6-Desktop-NVIDIA-Driver",
+                        "enabled": true,
+                        "autorefresh": true
+                      }
+                    ],
+                    "product_type": "extension",
+                    "extensions": []
+                  }
+                ]
+              },
+              {
+                "id": 2626,
+                "name": "Server Applications Module",
+                "identifier": "sle-module-server-applications",
+                "former_identifier": "sle-module-server-applications",
+                "version": "15.6",
+                "release_type": null,
+                "arch": "x86_64",
+                "friendly_name": "Server Applications Module 15 SP6 x86_64",
+                "product_class": "MODULE",
+                "cpe": "cpe:/o:suse:sle-module-server-applications:15:sp6",
+                "free": true,
+                "description": "<p> The SUSE Linux Enterprise Server Applications Module delivers a basic set of Server functionality. </p> <p> Access to the Server Applications Module is included in your SUSE Linux Enterprise Server subscription. </p>",
+                "eula_url": "",
+                "repositories": [
+                  {
+                    "id": 6385,
+                    "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Server-Applications/15-SP6/x86_64/update",
+                    "name": "SLE-Module-Server-Applications15-SP6-Updates",
+                    "distro_target": "sle-15-x86_64",
+                    "description": "SLE-Module-Server-Applications15-SP6-Updates for sle-15-x86_64",
+                    "enabled": true,
+                    "autorefresh": true
+                  },
+                  {
+                    "id": 6386,
+                    "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Server-Applications/15-SP6/x86_64/update_debug",
+                    "name": "SLE-Module-Server-Applications15-SP6-Debuginfo-Updates",
+                    "distro_target": "sle-15-x86_64",
+                    "description": "SLE-Module-Server-Applications15-SP6-Debuginfo-Updates for sle-15-x86_64",
+                    "enabled": false,
+                    "autorefresh": true
+                  },
+                  {
+                    "id": 6387,
+                    "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Server-Applications/15-SP6/x86_64/product",
+                    "name": "SLE-Module-Server-Applications15-SP6-Pool",
+                    "distro_target": "sle-15-x86_64",
+                    "description": "SLE-Module-Server-Applications15-SP6-Pool for sle-15-x86_64",
+                    "enabled": true,
+                    "autorefresh": false
+                  },
+                  {
+                    "id": 6388,
+                    "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Server-Applications/15-SP6/x86_64/product_debug",
+                    "name": "SLE-Module-Server-Applications15-SP6-Debuginfo-Pool",
+                    "distro_target": "sle-15-x86_64",
+                    "description": "SLE-Module-Server-Applications15-SP6-Debuginfo-Pool for sle-15-x86_64",
+                    "enabled": false,
+                    "autorefresh": false
+                  },
+                  {
+                    "id": 6389,
+                    "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Server-Applications/15-SP6/x86_64/product_source",
+                    "name": "SLE-Module-Server-Applications15-SP6-Source-Pool",
+                    "distro_target": "sle-15-x86_64",
+                    "description": "SLE-Module-Server-Applications15-SP6-Source-Pool for sle-15-x86_64",
+                    "enabled": false,
+                    "autorefresh": false
+                  }
+                ],
+                "product_type": "module",
+                "extensions": [
+                  {
+                    "id": 2631,
+                    "name": "SUSE Linux Enterprise High Availability Extension",
+                    "identifier": "sle-ha",
+                    "former_identifier": "sle-ha",
+                    "version": "15.6",
+                    "release_type": null,
+                    "arch": "x86_64",
+                    "friendly_name": "SUSE Linux Enterprise High Availability Extension 15 SP6 x86_64",
+                    "product_class": "SLE-HAE-X86",
+                    "cpe": "cpe:/o:suse:sle-ha:15:sp6",
+                    "free": false,
+                    "description": "SUSE Linux High Availability Extension provides mature, industry-leading open-source high-availability clustering technologies that are easy to set up and use. It can be deployed in physical and/or virtual environments, and can cluster physical servers, virtual servers, or any combination of the two to suit your business’ needs.",
+                    "eula_url": "",
+                    "repositories": [
+                      {
+                        "id": 6410,
+                        "url": "https://updates.suse.com/SUSE/Updates/SLE-Product-HA/15-SP6/x86_64/update",
+                        "name": "SLE-Product-HA15-SP6-Updates",
+                        "distro_target": "sle-15-x86_64",
+                        "description": "SLE-Product-HA15-SP6-Updates for sle-15-x86_64",
+                        "enabled": true,
+                        "autorefresh": true
+                      },
+                      {
+                        "id": 6411,
+                        "url": "https://updates.suse.com/SUSE/Updates/SLE-Product-HA/15-SP6/x86_64/update_debug",
+                        "name": "SLE-Product-HA15-SP6-Debuginfo-Updates",
+                        "distro_target": "sle-15-x86_64",
+                        "description": "SLE-Product-HA15-SP6-Debuginfo-Updates for sle-15-x86_64",
+                        "enabled": false,
+                        "autorefresh": true
+                      },
+                      {
+                        "id": 6412,
+                        "url": "https://updates.suse.com/SUSE/Products/SLE-Product-HA/15-SP6/x86_64/product",
+                        "name": "SLE-Product-HA15-SP6-Pool",
+                        "distro_target": "sle-15-x86_64",
+                        "description": "SLE-Product-HA15-SP6-Pool for sle-15-x86_64",
+                        "enabled": true,
+                        "autorefresh": false
+                      },
+                      {
+                        "id": 6413,
+                        "url": "https://updates.suse.com/SUSE/Products/SLE-Product-HA/15-SP6/x86_64/product_debug",
+                        "name": "SLE-Product-HA15-SP6-Debuginfo-Pool",
+                        "distro_target": "sle-15-x86_64",
+                        "description": "SLE-Product-HA15-SP6-Debuginfo-Pool for sle-15-x86_64",
+                        "enabled": false,
+                        "autorefresh": false
+                      },
+                      {
+                        "id": 6414,
+                        "url": "https://updates.suse.com/SUSE/Products/SLE-Product-HA/15-SP6/x86_64/product_source",
+                        "name": "SLE-Product-HA15-SP6-Source-Pool",
+                        "distro_target": "sle-15-x86_64",
+                        "description": "SLE-Product-HA15-SP6-Source-Pool for sle-15-x86_64",
+                        "enabled": false,
+                        "autorefresh": false
+                      }
+                    ],
+                    "product_type": "extension",
+                    "extensions": []
+                  },
+                  {
+                    "id": 2646,
+                    "name": "Web and Scripting Module",
+                    "identifier": "sle-module-web-scripting",
+                    "former_identifier": "sle-module-web-scripting",
+                    "version": "15.6",
+                    "release_type": null,
+                    "arch": "x86_64",
+                    "friendly_name": "Web and Scripting Module 15 SP6 x86_64",
+                    "product_class": "MODULE",
+                    "cpe": "cpe:/o:suse:sle-module-web-scripting:15:sp6",
+                    "free": true,
+                    "description": "<p> The SUSE Linux Enterprise Web and Scripting Module should contains additional packages that are helpful when running a webserver. </p> <p> Access to the Web and Scripting Module is included in your SUSE Linux Enterprise Server subscription. The module has a different lifecycle than SUSE Linux Enterprise Server itself: Package versions in this module are usually supported for at most three years. We are planning to release more recent versions on a schedule of approximately 18 month; the exact dates may differ per package. </p>",
+                    "eula_url": "",
+                    "repositories": [
+                      {
+                        "id": 6485,
+                        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Web-Scripting/15-SP6/x86_64/update",
+                        "name": "SLE-Module-Web-Scripting15-SP6-Updates",
+                        "distro_target": "sle-15-x86_64",
+                        "description": "SLE-Module-Web-Scripting15-SP6-Updates for sle-15-x86_64",
+                        "enabled": true,
+                        "autorefresh": true
+                      },
+                      {
+                        "id": 6486,
+                        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Web-Scripting/15-SP6/x86_64/update_debug",
+                        "name": "SLE-Module-Web-Scripting15-SP6-Debuginfo-Updates",
+                        "distro_target": "sle-15-x86_64",
+                        "description": "SLE-Module-Web-Scripting15-SP6-Debuginfo-Updates for sle-15-x86_64",
+                        "enabled": false,
+                        "autorefresh": true
+                      },
+                      {
+                        "id": 6487,
+                        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Web-Scripting/15-SP6/x86_64/product",
+                        "name": "SLE-Module-Web-Scripting15-SP6-Pool",
+                        "distro_target": "sle-15-x86_64",
+                        "description": "SLE-Module-Web-Scripting15-SP6-Pool for sle-15-x86_64",
+                        "enabled": true,
+                        "autorefresh": false
+                      },
+                      {
+                        "id": 6488,
+                        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Web-Scripting/15-SP6/x86_64/product_debug",
+                        "name": "SLE-Module-Web-Scripting15-SP6-Debuginfo-Pool",
+                        "distro_target": "sle-15-x86_64",
+                        "description": "SLE-Module-Web-Scripting15-SP6-Debuginfo-Pool for sle-15-x86_64",
+                        "enabled": false,
+                        "autorefresh": false
+                      },
+                      {
+                        "id": 6489,
+                        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Web-Scripting/15-SP6/x86_64/product_source",
+                        "name": "SLE-Module-Web-Scripting15-SP6-Source-Pool",
+                        "distro_target": "sle-15-x86_64",
+                        "description": "SLE-Module-Web-Scripting15-SP6-Source-Pool for sle-15-x86_64",
+                        "enabled": false,
+                        "autorefresh": false
+                      }
+                    ],
+                    "product_type": "module",
+                    "extensions": [
+                      {
+                        "id": 2648,
+                        "name": "HPC Module",
+                        "identifier": "sle-module-hpc",
+                        "former_identifier": "sle-module-hpc",
+                        "version": "15.6",
+                        "release_type": null,
+                        "arch": "x86_64",
+                        "friendly_name": "HPC Module 15 SP6 x86_64",
+                        "product_class": "MODULE",
+                        "cpe": "cpe:/o:suse:sle-module-hpc:15:sp6",
+                        "free": true,
+                        "description": "<p> The SUSE Linux Enterprise Server High Performance Computing (HPC) module delivers specific tools commonly used for high performance, numerically intensive workloads. </p> <p> SUSE packages these tools in the SLES HPC Module to provide greater flexibility to deliver new versions or new tools more rapidly than the standard SUSE Linux Enterprise lifecycle would permit. </p> <p> Packages in this module are generally supported until a newer version of the package is released or the package is dropped from the module. </p>",
+                        "eula_url": "",
+                        "repositories": [
+                          {
+                            "id": 6495,
+                            "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-HPC/15-SP6/x86_64/update",
+                            "name": "SLE-Module-HPC15-SP6-Updates",
+                            "distro_target": "sle-15-x86_64",
+                            "description": "SLE-Module-HPC15-SP6-Updates for sle-15-x86_64",
+                            "enabled": true,
+                            "autorefresh": true
+                          },
+                          {
+                            "id": 6496,
+                            "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-HPC/15-SP6/x86_64/update_debug",
+                            "name": "SLE-Module-HPC15-SP6-Debuginfo-Updates",
+                            "distro_target": "sle-15-x86_64",
+                            "description": "SLE-Module-HPC15-SP6-Debuginfo-Updates for sle-15-x86_64",
+                            "enabled": false,
+                            "autorefresh": true
+                          },
+                          {
+                            "id": 6497,
+                            "url": "https://updates.suse.com/SUSE/Products/SLE-Module-HPC/15-SP6/x86_64/product",
+                            "name": "SLE-Module-HPC15-SP6-Pool",
+                            "distro_target": "sle-15-x86_64",
+                            "description": "SLE-Module-HPC15-SP6-Pool for sle-15-x86_64",
+                            "enabled": true,
+                            "autorefresh": false
+                          },
+                          {
+                            "id": 6498,
+                            "url": "https://updates.suse.com/SUSE/Products/SLE-Module-HPC/15-SP6/x86_64/product_debug",
+                            "name": "SLE-Module-HPC15-SP6-Debuginfo-Pool",
+                            "distro_target": "sle-15-x86_64",
+                            "description": "SLE-Module-HPC15-SP6-Debuginfo-Pool for sle-15-x86_64",
+                            "enabled": false,
+                            "autorefresh": false
+                          },
+                          {
+                            "id": 6499,
+                            "url": "https://updates.suse.com/SUSE/Products/SLE-Module-HPC/15-SP6/x86_64/product_source",
+                            "name": "SLE-Module-HPC15-SP6-Source-Pool",
+                            "distro_target": "sle-15-x86_64",
+                            "description": "SLE-Module-HPC15-SP6-Source-Pool for sle-15-x86_64",
+                            "enabled": false,
+                            "autorefresh": false
+                          }
+                        ],
+                        "product_type": "module",
+                        "extensions": []
+                      }
+                    ]
+                  },
+                  {
+                    "id": 2652,
+                    "name": "Legacy Module",
+                    "identifier": "sle-module-legacy",
+                    "former_identifier": "sle-module-legacy",
+                    "version": "15.6",
+                    "release_type": null,
+                    "arch": "x86_64",
+                    "friendly_name": "Legacy Module 15 SP6 x86_64",
+                    "product_class": "MODULE",
+                    "cpe": "cpe:/o:suse:sle-module-legacy:15:sp6",
+                    "free": true,
+                    "description": "<p> The Legacy Module helps you migrating applications from SUSE Linux Enterprise 12 and other systems to SUSE Linux Enterprise 15, by providing packages which are discontinued on SUSE Linux Enterprise Server, such as: ntp, IBM Java 8, and a number of libraries. </p> <p> Access to the Legacy Module is included in your SUSE Linux Enterprise Server subscription. The module has a different lifecycle than SUSE Linux Enterprise Server itself. Packages in the this module are usually supported for at most three years. </p>",
+                    "eula_url": "",
+                    "repositories": [
+                      {
+                        "id": 6515,
+                        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Legacy/15-SP6/x86_64/update",
+                        "name": "SLE-Module-Legacy15-SP6-Updates",
+                        "distro_target": "sle-15-x86_64",
+                        "description": "SLE-Module-Legacy15-SP6-Updates for sle-15-x86_64",
+                        "enabled": true,
+                        "autorefresh": true
+                      },
+                      {
+                        "id": 6516,
+                        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Legacy/15-SP6/x86_64/update_debug",
+                        "name": "SLE-Module-Legacy15-SP6-Debuginfo-Updates",
+                        "distro_target": "sle-15-x86_64",
+                        "description": "SLE-Module-Legacy15-SP6-Debuginfo-Updates for sle-15-x86_64",
+                        "enabled": false,
+                        "autorefresh": true
+                      },
+                      {
+                        "id": 6517,
+                        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Legacy/15-SP6/x86_64/product",
+                        "name": "SLE-Module-Legacy15-SP6-Pool",
+                        "distro_target": "sle-15-x86_64",
+                        "description": "SLE-Module-Legacy15-SP6-Pool for sle-15-x86_64",
+                        "enabled": true,
+                        "autorefresh": false
+                      },
+                      {
+                        "id": 6518,
+                        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Legacy/15-SP6/x86_64/product_debug",
+                        "name": "SLE-Module-Legacy15-SP6-Debuginfo-Pool",
+                        "distro_target": "sle-15-x86_64",
+                        "description": "SLE-Module-Legacy15-SP6-Debuginfo-Pool for sle-15-x86_64",
+                        "enabled": false,
+                        "autorefresh": false
+                      },
+                      {
+                        "id": 6519,
+                        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Legacy/15-SP6/x86_64/product_source",
+                        "name": "SLE-Module-Legacy15-SP6-Source-Pool",
+                        "distro_target": "sle-15-x86_64",
+                        "description": "SLE-Module-Legacy15-SP6-Source-Pool for sle-15-x86_64",
+                        "enabled": false,
+                        "autorefresh": false
+                      }
+                    ],
+                    "product_type": "module",
+                    "extensions": []
+                  },
+                  {
+                    "id": 2656,
+                    "name": "Public Cloud Module",
+                    "identifier": "sle-module-public-cloud",
+                    "former_identifier": "sle-module-public-cloud",
+                    "version": "15.6",
+                    "release_type": null,
+                    "arch": "x86_64",
+                    "friendly_name": "Public Cloud Module 15 SP6 x86_64",
+                    "product_class": "MODULE",
+                    "cpe": "cpe:/o:suse:sle-module-public-cloud:15:sp6",
+                    "free": true,
+                    "description": "<p> The Public Cloud Module is a collection of tools that enables you to create and manage cloud images from the commandline on SUSE Linux Enterprise Server. When building your own images with KIWI or SUSE Studio, initialization code specific to the target cloud is included in that image. </p> <p> Access to the Public Cloud Module is included in your SUSE Linux Enterprise Server subscription. The module has a different lifecycle than SUSE Linux Enterprise Server itself; please check the Release Notes for further details. </p>",
+                    "eula_url": "",
+                    "repositories": [
+                      {
+                        "id": 6535,
+                        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Public-Cloud/15-SP6/x86_64/update",
+                        "name": "SLE-Module-Public-Cloud15-SP6-Updates",
+                        "distro_target": "sle-15-x86_64",
+                        "description": "SLE-Module-Public-Cloud15-SP6-Updates for sle-15-x86_64",
+                        "enabled": true,
+                        "autorefresh": true
+                      },
+                      {
+                        "id": 6536,
+                        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Public-Cloud/15-SP6/x86_64/update_debug",
+                        "name": "SLE-Module-Public-Cloud15-SP6-Debuginfo-Updates",
+                        "distro_target": "sle-15-x86_64",
+                        "description": "SLE-Module-Public-Cloud15-SP6-Debuginfo-Updates for sle-15-x86_64",
+                        "enabled": false,
+                        "autorefresh": true
+                      },
+                      {
+                        "id": 6537,
+                        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Public-Cloud/15-SP6/x86_64/product",
+                        "name": "SLE-Module-Public-Cloud15-SP6-Pool",
+                        "distro_target": "sle-15-x86_64",
+                        "description": "SLE-Module-Public-Cloud15-SP6-Pool for sle-15-x86_64",
+                        "enabled": true,
+                        "autorefresh": false
+                      },
+                      {
+                        "id": 6538,
+                        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Public-Cloud/15-SP6/x86_64/product_debug",
+                        "name": "SLE-Module-Public-Cloud15-SP6-Debuginfo-Pool",
+                        "distro_target": "sle-15-x86_64",
+                        "description": "SLE-Module-Public-Cloud15-SP6-Debuginfo-Pool for sle-15-x86_64",
+                        "enabled": false,
+                        "autorefresh": false
+                      },
+                      {
+                        "id": 6539,
+                        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Public-Cloud/15-SP6/x86_64/product_source",
+                        "name": "SLE-Module-Public-Cloud15-SP6-Source-Pool",
+                        "distro_target": "sle-15-x86_64",
+                        "description": "SLE-Module-Public-Cloud15-SP6-Source-Pool for sle-15-x86_64",
+                        "enabled": false,
+                        "autorefresh": false
+                      }
+                    ],
+                    "product_type": "module",
+                    "extensions": []
+                  },
+                  {
+                    "id": 2760,
+                    "name": "Confidential Computing Module",
+                    "identifier": "sle-module-confidential-computing",
+                    "former_identifier": "sle-module-confidential-computing",
+                    "version": "15.6",
+                    "release_type": null,
+                    "arch": "x86_64",
+                    "friendly_name": "Confidential Computing Module 15 SP6 x86_64",
+                    "product_class": "MODULE",
+                    "cpe": "cpe:/o:suse:sle-module-confidential-computing:15:sp6",
+                    "free": true,
+                    "description": "<p> This module contains Confidential Computing related packages. </p> <p> Access to the Confidential Computing module is included in your SUSE Linux Enterprise subscription. The module is a Technical Preview and is not supported. </p>",
+                    "eula_url": "",
+                    "repositories": [
+                      {
+                        "id": 6922,
+                        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Confidential-Computing/15-SP6/x86_64/update",
+                        "name": "SLE-Module-Confidential-Computing-15-SP6-Updates",
+                        "distro_target": "sle-15-x86_64",
+                        "description": "SLE-Module-Confidential-Computing-15-SP6-Updates for sle-15-x86_64",
+                        "enabled": true,
+                        "autorefresh": true
+                      },
+                      {
+                        "id": 6923,
+                        "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Confidential-Computing/15-SP6/x86_64/update_debug",
+                        "name": "SLE-Module-Confidential-Computing-15-SP6-Debuginfo-Updates",
+                        "distro_target": "sle-15-x86_64",
+                        "description": "SLE-Module-Confidential-Computing-15-SP6-Debuginfo-Updates for sle-15-x86_64",
+                        "enabled": false,
+                        "autorefresh": true
+                      },
+                      {
+                        "id": 6924,
+                        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Confidential-Computing/15-SP6/x86_64/product",
+                        "name": "SLE-Module-Confidential-Computing-15-SP6-Pool",
+                        "distro_target": "sle-15-x86_64",
+                        "description": "SLE-Module-Confidential-Computing-15-SP6-Pool for sle-15-x86_64",
+                        "enabled": true,
+                        "autorefresh": false
+                      },
+                      {
+                        "id": 6925,
+                        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Confidential-Computing/15-SP6/x86_64/product_debug",
+                        "name": "SLE-Module-Confidential-Computing-15-SP6-Debuginfo-Pool",
+                        "distro_target": "sle-15-x86_64",
+                        "description": "SLE-Module-Confidential-Computing-15-SP6-Debuginfo-Pool for sle-15-x86_64",
+                        "enabled": false,
+                        "autorefresh": false
+                      },
+                      {
+                        "id": 6926,
+                        "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Confidential-Computing/15-SP6/x86_64/product_source",
+                        "name": "SLE-Module-Confidential-Computing-15-SP6-Source-Pool",
+                        "distro_target": "sle-15-x86_64",
+                        "description": "SLE-Module-Confidential-Computing-15-SP6-Source-Pool for sle-15-x86_64",
+                        "enabled": false,
+                        "autorefresh": false
+                      }
+                    ],
+                    "product_type": "module",
+                    "extensions": []
+                  }
+                ]
+              },
+              {
+                "id": 2637,
+                "name": "Containers Module",
+                "identifier": "sle-module-containers",
+                "former_identifier": "sle-module-containers",
+                "version": "15.6",
+                "release_type": null,
+                "arch": "x86_64",
+                "friendly_name": "Containers Module 15 SP6 x86_64",
+                "product_class": "MODULE",
+                "cpe": "cpe:/o:suse:sle-module-containers:15:sp6",
+                "free": true,
+                "description": "<p>This Module contains several packages revolving around containers and related tools. </p>",
+                "eula_url": "",
+                "repositories": [
+                  {
+                    "id": 6440,
+                    "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Containers/15-SP6/x86_64/update",
+                    "name": "SLE-Module-Containers15-SP6-Updates",
+                    "distro_target": "sle-15-x86_64",
+                    "description": "SLE-Module-Containers15-SP6-Updates for sle-15-x86_64",
+                    "enabled": true,
+                    "autorefresh": true
+                  },
+                  {
+                    "id": 6441,
+                    "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Containers/15-SP6/x86_64/update_debug",
+                    "name": "SLE-Module-Containers15-SP6-Debuginfo-Updates",
+                    "distro_target": "sle-15-x86_64",
+                    "description": "SLE-Module-Containers15-SP6-Debuginfo-Updates for sle-15-x86_64",
+                    "enabled": false,
+                    "autorefresh": true
+                  },
+                  {
+                    "id": 6442,
+                    "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Containers/15-SP6/x86_64/product",
+                    "name": "SLE-Module-Containers15-SP6-Pool",
+                    "distro_target": "sle-15-x86_64",
+                    "description": "SLE-Module-Containers15-SP6-Pool for sle-15-x86_64",
+                    "enabled": true,
+                    "autorefresh": false
+                  },
+                  {
+                    "id": 6443,
+                    "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Containers/15-SP6/x86_64/product_debug",
+                    "name": "SLE-Module-Containers15-SP6-Debuginfo-Pool",
+                    "distro_target": "sle-15-x86_64",
+                    "description": "SLE-Module-Containers15-SP6-Debuginfo-Pool for sle-15-x86_64",
+                    "enabled": false,
+                    "autorefresh": false
+                  },
+                  {
+                    "id": 6444,
+                    "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Containers/15-SP6/x86_64/product_source",
+                    "name": "SLE-Module-Containers15-SP6-Source-Pool",
+                    "distro_target": "sle-15-x86_64",
+                    "description": "SLE-Module-Containers15-SP6-Source-Pool for sle-15-x86_64",
+                    "enabled": false,
+                    "autorefresh": false
+                  }
+                ],
+                "product_type": "module",
+                "extensions": []
+              },
+              {
+                "id": 2660,
+                "name": "Transactional Server Module",
+                "identifier": "sle-module-transactional-server",
+                "former_identifier": "sle-module-transactional-server",
+                "version": "15.6",
+                "release_type": null,
+                "arch": "x86_64",
+                "friendly_name": "Transactional Server Module 15 SP6 x86_64",
+                "product_class": "MODULE",
+                "cpe": "cpe:/o:suse:sle-module-transactional-server:15:sp6",
+                "free": true,
+                "description": "<p> Transactional Updates provide SUSE Linux Enterprise systems with a method of updating the operating system and its packages in an entirely ‘atomic’ way. Updates are either applied to the system all together in a single transaction, or not at all. This happens without influencing the running system. If an update fails, or if the successful update is deemed to be incompatible or otherwise incorrect, it can be discarded to immediately return the system to its previous functioning state. </p> <p> Access to theTransactional Server Module is included in your SUSE Linux Enterprise Server subscription. The module has a different lifecycle than SUSE Linux Enterprise Server itself: Package versions in the this module are usually supported for at most three years. We are planning to release more recent versions on a schedule of approximately 18 month; the exact dates may differ per package. </p>",
+                "eula_url": "",
+                "repositories": [
+                  {
+                    "id": 6555,
+                    "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Transactional-Server/15-SP6/x86_64/update",
+                    "name": "SLE-Module-Transactional-Server15-SP6-Updates",
+                    "distro_target": "sle-15-x86_64",
+                    "description": "SLE-Module-Transactional-Server15-SP6-Updates for sle-15-x86_64",
+                    "enabled": true,
+                    "autorefresh": true
+                  },
+                  {
+                    "id": 6556,
+                    "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Transactional-Server/15-SP6/x86_64/update_debug",
+                    "name": "SLE-Module-Transactional-Server15-SP6-Debuginfo-Updates",
+                    "distro_target": "sle-15-x86_64",
+                    "description": "SLE-Module-Transactional-Server15-SP6-Debuginfo-Updates for sle-15-x86_64",
+                    "enabled": false,
+                    "autorefresh": true
+                  },
+                  {
+                    "id": 6557,
+                    "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Transactional-Server/15-SP6/x86_64/product",
+                    "name": "SLE-Module-Transactional-Server15-SP6-Pool",
+                    "distro_target": "sle-15-x86_64",
+                    "description": "SLE-Module-Transactional-Server15-SP6-Pool for sle-15-x86_64",
+                    "enabled": true,
+                    "autorefresh": false
+                  },
+                  {
+                    "id": 6558,
+                    "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Transactional-Server/15-SP6/x86_64/product_debug",
+                    "name": "SLE-Module-Transactional-Server15-SP6-Debuginfo-Pool",
+                    "distro_target": "sle-15-x86_64",
+                    "description": "SLE-Module-Transactional-Server15-SP6-Debuginfo-Pool for sle-15-x86_64",
+                    "enabled": false,
+                    "autorefresh": false
+                  },
+                  {
+                    "id": 6559,
+                    "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Transactional-Server/15-SP6/x86_64/product_source",
+                    "name": "SLE-Module-Transactional-Server15-SP6-Source-Pool",
+                    "distro_target": "sle-15-x86_64",
+                    "description": "SLE-Module-Transactional-Server15-SP6-Source-Pool for sle-15-x86_64",
+                    "enabled": false,
+                    "autorefresh": false
+                  }
+                ],
+                "product_type": "module",
+                "extensions": []
+              },
+              {
+                "id": 2664,
+                "name": "SUSE Linux Enterprise Live Patching",
+                "identifier": "sle-module-live-patching",
+                "former_identifier": "sle-module-live-patching",
+                "version": "15.6",
+                "release_type": null,
+                "arch": "x86_64",
+                "friendly_name": "SUSE Linux Enterprise Live Patching 15 SP6 x86_64",
+                "product_class": "SLE-LP",
+                "cpe": "cpe:/o:suse:sle-module-live-patching:15:sp6",
+                "free": false,
+                "description": "<p> SUSE Linux Enterprise Live Patching provides packages to update critical components in SUSE Linux Enterprise. With SUSE Linux Enterprise Live Patching, you can perform critical patching without shutting down your system, reducing the need for planned downtime and increasing service availability. <p>",
+                "eula_url": "",
+                "repositories": [
+                  {
+                    "id": 6575,
+                    "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Live-Patching/15-SP6/x86_64/update",
+                    "name": "SLE-Module-Live-Patching15-SP6-Updates",
+                    "distro_target": "sle-15-x86_64",
+                    "description": "SLE-Module-Live-Patching15-SP6-Updates for sle-15-x86_64",
+                    "enabled": true,
+                    "autorefresh": true
+                  },
+                  {
+                    "id": 6576,
+                    "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Live-Patching/15-SP6/x86_64/update_debug",
+                    "name": "SLE-Module-Live-Patching15-SP6-Debuginfo-Updates",
+                    "distro_target": "sle-15-x86_64",
+                    "description": "SLE-Module-Live-Patching15-SP6-Debuginfo-Updates for sle-15-x86_64",
+                    "enabled": false,
+                    "autorefresh": true
+                  },
+                  {
+                    "id": 6577,
+                    "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Live-Patching/15-SP6/x86_64/product",
+                    "name": "SLE-Module-Live-Patching15-SP6-Pool",
+                    "distro_target": "sle-15-x86_64",
+                    "description": "SLE-Module-Live-Patching15-SP6-Pool for sle-15-x86_64",
+                    "enabled": true,
+                    "autorefresh": false
+                  },
+                  {
+                    "id": 6578,
+                    "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Live-Patching/15-SP6/x86_64/product_debug",
+                    "name": "SLE-Module-Live-Patching15-SP6-Debuginfo-Pool",
+                    "distro_target": "sle-15-x86_64",
+                    "description": "SLE-Module-Live-Patching15-SP6-Debuginfo-Pool for sle-15-x86_64",
+                    "enabled": false,
+                    "autorefresh": false
+                  },
+                  {
+                    "id": 6579,
+                    "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Live-Patching/15-SP6/x86_64/product_source",
+                    "name": "SLE-Module-Live-Patching15-SP6-Source-Pool",
+                    "distro_target": "sle-15-x86_64",
+                    "description": "SLE-Module-Live-Patching15-SP6-Source-Pool for sle-15-x86_64",
+                    "enabled": false,
+                    "autorefresh": false
+                  }
+                ],
+                "product_type": "extension",
+                "extensions": []
+              },
+              {
+                "id": 2683,
+                "name": "Python 3 Module",
+                "identifier": "sle-module-python3",
+                "former_identifier": "sle-module-python3",
+                "version": "15.6",
+                "release_type": null,
+                "arch": "x86_64",
+                "friendly_name": "Python 3 Module 15 SP6 x86_64",
+                "product_class": "MODULE",
+                "cpe": "cpe:/o:suse:sle-module-python3:15:sp6",
+                "free": true,
+                "description": "<p> This module contains the Python 3 packages. </p> <p> Access to the Python 3 Module is included in your SUSE Linux Enterprise subscription. The module has a different lifecycle than SUSE Linux Enterprise itself; please check the Release Notes for further details. </p>",
+                "eula_url": "",
+                "repositories": [
+                  {
+                    "id": 6663,
+                    "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Python3/15-SP6/x86_64/update",
+                    "name": "SLE-Module-Python3-15-SP6-Updates",
+                    "distro_target": "sle-15-x86_64",
+                    "description": "SLE-Module-Python3-15-SP6-Updates for sle-15-x86_64",
+                    "enabled": true,
+                    "autorefresh": true
+                  },
+                  {
+                    "id": 6664,
+                    "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Python3/15-SP6/x86_64/update_debug",
+                    "name": "SLE-Module-Python3-15-SP6-Debuginfo-Updates",
+                    "distro_target": "sle-15-x86_64",
+                    "description": "SLE-Module-Python3-15-SP6-Debuginfo-Updates for sle-15-x86_64",
+                    "enabled": false,
+                    "autorefresh": true
+                  },
+                  {
+                    "id": 6665,
+                    "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Python3/15-SP6/x86_64/product",
+                    "name": "SLE-Module-Python3-15-SP6-Pool",
+                    "distro_target": "sle-15-x86_64",
+                    "description": "SLE-Module-Python3-15-SP6-Pool for sle-15-x86_64",
+                    "enabled": true,
+                    "autorefresh": false
+                  },
+                  {
+                    "id": 6666,
+                    "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Python3/15-SP6/x86_64/product_debug",
+                    "name": "SLE-Module-Python3-15-SP6-Debuginfo-Pool",
+                    "distro_target": "sle-15-x86_64",
+                    "description": "SLE-Module-Python3-15-SP6-Debuginfo-Pool for sle-15-x86_64",
+                    "enabled": false,
+                    "autorefresh": false
+                  },
+                  {
+                    "id": 6667,
+                    "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Python3/15-SP6/x86_64/product_source",
+                    "name": "SLE-Module-Python3-15-SP6-Source-Pool",
+                    "distro_target": "sle-15-x86_64",
+                    "description": "SLE-Module-Python3-15-SP6-Source-Pool for sle-15-x86_64",
+                    "enabled": false,
+                    "autorefresh": false
+                  }
+                ],
+                "product_type": "module",
+                "extensions": []
+              },
+              {
+                "id": 2687,
+                "name": "SUSE Package Hub",
+                "identifier": "PackageHub",
+                "former_identifier": "PackageHub",
+                "version": "15.6",
+                "release_type": null,
+                "arch": "x86_64",
+                "friendly_name": "SUSE Package Hub 15 SP6 x86_64",
+                "product_class": "MODULE",
+                "cpe": "cpe:/o:suse:packagehub:15:sp6",
+                "free": true,
+                "description": "SUSE Package Hub is a free of charge module providing access to community maintained packages built to run on SUSE Linux Enterprise Server. Built from the same sources used in the openSUSE distributions, these quality packages provide additional software to what is found in the SUSE Linux Enterprise Server product. Packages from the Package Hub are delivered without L3 support from SUSE. General updates and fixes to the packages in SUSE Package Hub are provided by the openSUSE community based on their discretion, though SUSE will monitor and ensure that any known critical security issues will be addressed. Packages in the Package Hub are approved by SUSE for use with SUSE Linux Enterprise Server 15-SP6 and to not interfere with the supportability of SUSE Linux Enterprise Server, its modules and extensions. For more information about SUSE Package Hub please visit https://packagehub.suse.com.",
+                "eula_url": "",
+                "repositories": [
+                  {
+                    "id": 6692,
+                    "url": "https://updates.suse.com/SUSE/Backports/SLE-15-SP6_x86_64/standard",
+                    "name": "SUSE-PackageHub-15-SP6-Backports-Pool",
+                    "distro_target": "sle-15-x86_64",
+                    "description": "SUSE-PackageHub-15-SP6-Backports-Pool for sle-15-x86_64",
+                    "enabled": true,
+                    "autorefresh": false
+                  },
+                  {
+                    "id": 6693,
+                    "url": "https://updates.suse.com/SUSE/Backports/SLE-15-SP6_x86_64/standard_debug",
+                    "name": "SUSE-PackageHub-15-SP6-Backports-Debuginfo",
+                    "distro_target": "sle-15-x86_64",
+                    "description": "SUSE-PackageHub-15-SP6-Backports-Debuginfo for sle-15-x86_64",
+                    "enabled": false,
+                    "autorefresh": true
+                  },
+                  {
+                    "id": 6694,
+                    "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Packagehub-Subpackages/15-SP6/x86_64/update",
+                    "name": "SLE-Module-Packagehub-Subpackages15-SP6-Updates",
+                    "distro_target": "sle-15-x86_64",
+                    "description": "SLE-Module-Packagehub-Subpackages15-SP6-Updates for sle-15-x86_64",
+                    "enabled": true,
+                    "autorefresh": true
+                  },
+                  {
+                    "id": 6695,
+                    "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Packagehub-Subpackages/15-SP6/x86_64/update_debug",
+                    "name": "SLE-Module-Packagehub-Subpackages15-SP6-Debuginfo-Updates",
+                    "distro_target": "sle-15-x86_64",
+                    "description": "SLE-Module-Packagehub-Subpackages15-SP6-Debuginfo-Updates for sle-15-x86_64",
+                    "enabled": false,
+                    "autorefresh": true
+                  },
+                  {
+                    "id": 6696,
+                    "url": "https://updates.suse.com/SUSE/Backports/SLE-15-SP6_x86_64/product",
+                    "name": "SUSE-PackageHub-15-SP6-Pool",
+                    "distro_target": "sle-15-x86_64",
+                    "description": "SUSE-PackageHub-15-SP6-Pool for sle-15-x86_64",
+                    "enabled": true,
+                    "autorefresh": false
+                  },
+                  {
+                    "id": 6697,
+                    "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Packagehub-Subpackages/15-SP6/x86_64/product",
+                    "name": "SLE-Module-Packagehub-Subpackages15-SP6-Pool",
+                    "distro_target": "sle-15-x86_64",
+                    "description": "SLE-Module-Packagehub-Subpackages15-SP6-Pool for sle-15-x86_64",
+                    "enabled": true,
+                    "autorefresh": false
+                  },
+                  {
+                    "id": 6698,
+                    "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Packagehub-Subpackages/15-SP6/x86_64/product_debug",
+                    "name": "SLE-Module-Packagehub-Subpackages15-SP6-Debuginfo-Pool",
+                    "distro_target": "sle-15-x86_64",
+                    "description": "SLE-Module-Packagehub-Subpackages15-SP6-Debuginfo-Pool for sle-15-x86_64",
+                    "enabled": false,
+                    "autorefresh": false
+                  },
+                  {
+                    "id": 6699,
+                    "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Packagehub-Subpackages/15-SP6/x86_64/product_source",
+                    "name": "SLE-Module-Packagehub-Subpackages15-SP6-Source-Pool",
+                    "distro_target": "sle-15-x86_64",
+                    "description": "SLE-Module-Packagehub-Subpackages15-SP6-Source-Pool for sle-15-x86_64",
+                    "enabled": false,
+                    "autorefresh": false
+                  }
+                ],
+                "product_type": "module",
+                "extensions": []
+              }
+            ]
+          },
+          {
+            "id": 2726,
+            "name": "Certifications Module",
+            "identifier": "sle-module-certifications",
+            "former_identifier": "sle-module-certifications",
+            "version": "15.6",
+            "release_type": null,
+            "arch": "x86_64",
+            "friendly_name": "Certifications Module 15 SP6 x86_64",
+            "product_class": "MODULE",
+            "cpe": "cpe:/o:suse:sle-module-certifications:15:sp6",
+            "free": true,
+            "description": "<p> This module contains the certification packages. </p> <p> Access to the Certifications Module is included in your SUSE Linux Enterprise subscription. The module has a different lifecycle than SUSE Linux Enterprise itself; please check the Release Notes for further details. </p>",
+            "eula_url": "",
+            "repositories": [
+              {
+                "id": 6836,
+                "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Certifications/15-SP6/x86_64/update",
+                "name": "SLE-Module-Certifications-15-SP6-Updates",
+                "distro_target": "sle-15-x86_64",
+                "description": "SLE-Module-Certifications-15-SP6-Updates for sle-15-x86_64",
+                "enabled": true,
+                "autorefresh": true
+              },
+              {
+                "id": 6837,
+                "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Certifications/15-SP6/x86_64/update_debug",
+                "name": "SLE-Module-Certifications-15-SP6-Debuginfo-Updates",
+                "distro_target": "sle-15-x86_64",
+                "description": "SLE-Module-Certifications-15-SP6-Debuginfo-Updates for sle-15-x86_64",
+                "enabled": false,
+                "autorefresh": true
+              },
+              {
+                "id": 6838,
+                "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Certifications/15-SP6/x86_64/product",
+                "name": "SLE-Module-Certifications-15-SP6-Pool",
+                "distro_target": "sle-15-x86_64",
+                "description": "SLE-Module-Certifications-15-SP6-Pool for sle-15-x86_64",
+                "enabled": true,
+                "autorefresh": false
+              },
+              {
+                "id": 6839,
+                "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Certifications/15-SP6/x86_64/product_debug",
+                "name": "SLE-Module-Certifications-15-SP6-Debuginfo-Pool",
+                "distro_target": "sle-15-x86_64",
+                "description": "SLE-Module-Certifications-15-SP6-Debuginfo-Pool for sle-15-x86_64",
+                "enabled": false,
+                "autorefresh": false
+              },
+              {
+                "id": 6840,
+                "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Certifications/15-SP6/x86_64/product_source",
+                "name": "SLE-Module-Certifications-15-SP6-Source-Pool",
+                "distro_target": "sle-15-x86_64",
+                "description": "SLE-Module-Certifications-15-SP6-Source-Pool for sle-15-x86_64",
+                "enabled": false,
+                "autorefresh": false
+              }
+            ],
+            "product_type": "module",
+            "extensions": []
+          }
+        ]
+      }
+    }
+  },
+  {
+    "id": 91903685,
+    "name": null,
+    "regcode": null,
+    "type": null,
+    "status": null,
+    "starts_at": null,
+    "expires_at": null,
+    "system_id": 18492582,
+    "service": {
+      "id": 2510,
+      "name": "Server_Applications_Module_15_SP6_x86_64",
+      "url": "https://scc.suse.com/access/services/2510?credentials=Server_Applications_Module_15_SP6_x86_64",
+      "obsoleted_service_name": "",
+      "product": {
+        "id": 2626,
+        "name": "Server Applications Module",
+        "identifier": "sle-module-server-applications",
+        "former_identifier": "sle-module-server-applications",
+        "version": "15.6",
+        "release_type": null,
+        "arch": "x86_64",
+        "friendly_name": "Server Applications Module 15 SP6 x86_64",
+        "product_class": "MODULE",
+        "cpe": "cpe:/o:suse:sle-module-server-applications:15:sp6",
+        "free": true,
+        "description": "<p> The SUSE Linux Enterprise Server Applications Module delivers a basic set of Server functionality. </p> <p> Access to the Server Applications Module is included in your SUSE Linux Enterprise Server subscription. </p>",
+        "eula_url": "",
+        "repositories": [
+          {
+            "id": 6385,
+            "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Server-Applications/15-SP6/x86_64/update",
+            "name": "SLE-Module-Server-Applications15-SP6-Updates",
+            "distro_target": "sle-15-x86_64",
+            "description": "SLE-Module-Server-Applications15-SP6-Updates for sle-15-x86_64",
+            "enabled": true,
+            "autorefresh": true
+          },
+          {
+            "id": 6386,
+            "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Server-Applications/15-SP6/x86_64/update_debug",
+            "name": "SLE-Module-Server-Applications15-SP6-Debuginfo-Updates",
+            "distro_target": "sle-15-x86_64",
+            "description": "SLE-Module-Server-Applications15-SP6-Debuginfo-Updates for sle-15-x86_64",
+            "enabled": false,
+            "autorefresh": true
+          },
+          {
+            "id": 6387,
+            "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Server-Applications/15-SP6/x86_64/product",
+            "name": "SLE-Module-Server-Applications15-SP6-Pool",
+            "distro_target": "sle-15-x86_64",
+            "description": "SLE-Module-Server-Applications15-SP6-Pool for sle-15-x86_64",
+            "enabled": true,
+            "autorefresh": false
+          },
+          {
+            "id": 6388,
+            "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Server-Applications/15-SP6/x86_64/product_debug",
+            "name": "SLE-Module-Server-Applications15-SP6-Debuginfo-Pool",
+            "distro_target": "sle-15-x86_64",
+            "description": "SLE-Module-Server-Applications15-SP6-Debuginfo-Pool for sle-15-x86_64",
+            "enabled": false,
+            "autorefresh": false
+          },
+          {
+            "id": 6389,
+            "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Server-Applications/15-SP6/x86_64/product_source",
+            "name": "SLE-Module-Server-Applications15-SP6-Source-Pool",
+            "distro_target": "sle-15-x86_64",
+            "description": "SLE-Module-Server-Applications15-SP6-Source-Pool for sle-15-x86_64",
+            "enabled": false,
+            "autorefresh": false
+          }
+        ],
+        "product_type": "module",
+        "extensions": []
+      }
+    }
+  }
+]


### PR DESCRIPTION
card: https://trello.com/c/hnFo5GtQ/3724-rr2-library-add-systems-activations-functionality

This adds fetching `activation` from `/connect/systems/activations` and enables library users to determine which products are already activated on their system, as well as have a minimal input into the subscription consumed.

**How to test:**
```bash
$ cd <connect>
$ git checkout library-support-fetching-activations
$ make build
$ env REGCODE=<you know it!> ./out/public-api-demo SLES 15.6 x86_64
# expect: There is step 6 which shows all activation of the SLES system
```

**As always, if you need help testing this merge request or anything else, do not hesitate to reach out to me!**:rocket:

Thank you!