### PR TITLE
Implement a specific error type for API responses

### DIFF
--- a/cmd/public-api-demo/main.go
+++ b/cmd/public-api-demo/main.go
@@ -141,7 +141,7 @@ func main() {
 	err := runDemo(os.Args[1], os.Args[2], os.Args[3], regcode)
 
 	if err != nil {
-		fmt.Printf("ERROR: %s\n", err)
+		fmt.Printf("%s\n", err)
 		os.Exit(1)
 	}
 }

--- a/pkg/connection/api_error.go
+++ b/pkg/connection/api_error.go
@@ -1,0 +1,36 @@
+package connection
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+// ApiError contains all the information for any given API error response. Don't
+// build it directly, but use `ErrorFromResponse` instead.
+type ApiError struct {
+	Code             int
+	Message          string `json:"error"`
+	LocalizedMessage string `json:"localized_error"`
+}
+
+func (ae *ApiError) Error() string {
+	if ae.LocalizedMessage != "" {
+		return fmt.Sprintf("API error: %v (code: %v)", ae.LocalizedMessage, ae.Code)
+	}
+	return fmt.Sprintf("API error: %v (code: %v)", ae.Message, ae.Code)
+}
+
+// Returns a new ApiError from the given response if it contained an API error
+// response. Otherwise it just returns nil.
+func ErrorFromResponse(resp *http.Response) *ApiError {
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		return nil
+	}
+
+	ae := &ApiError{Code: resp.StatusCode}
+	if err := json.NewDecoder(resp.Body).Decode(ae); err != nil {
+		return nil
+	}
+	return ae
+}


### PR DESCRIPTION
## How to test

```
$ make build
$ REGCODE=invalid ./out/public-api-demo SLES 15.6 x86_64
```

Then you will receive a proper message:

```
public-api-demo: A connect client library demo
1) Setup connection and perform an request
<- fetch token
-> update token
API error: Unknown Registration Code. (code: 401)
```