### PR TITLE
Remove unneeded cpe from Product

### DIFF
--- a/pkg/registration/product.go
+++ b/pkg/registration/product.go
@@ -14,7 +14,6 @@ type Product struct {
 	Arch       string `json:"arch"`
 	Summary    string `json:"summary,omitempty"`
 	IsBase     bool   `json:"isbase"`
-	CPE        string `json:"cpe, omitempty"`
 
 	FriendlyName string `json:"friendly_name,omitempty"`
 	ReleaseType  string `json:"release_type,omitempty"`


### PR DESCRIPTION
The offline registration certificate switched from `Product` to `ProductClass` in `SubscriptionInfo`. I added this but it is not used anymore.

lets remove it!

Added here: https://github.com/SUSE/connect-ng/pull/285/files