### PR TITLE
pkg: Remove *_test packages

### DIFF
--- a/pkg/connection/connection_test.go
+++ b/pkg/connection/connection_test.go
@@ -1,38 +1,37 @@
-package connection_test
+package connection
 
 import (
 	"fmt"
 	"net/http"
 	"testing"
 
-	"github.com/SUSE/connect-ng/pkg/connection"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestConnectionNew(t *testing.T) {
 	assert := assert.New(t)
 
-	opts := connection.DefaultOptions("testApp", "1.0", "en_US")
-	creds := connection.NoCredentials{}
-	conn := connection.New(opts, creds)
+	opts := DefaultOptions("testApp", "1.0", "en_US")
+	creds := NoCredentials{}
+	conn := New(opts, creds)
 
-	assert.Implements((*connection.Connection)(nil), conn, "implements connection interface")
+	assert.Implements((*Connection)(nil), conn, "implements connection interface")
 	assert.Equal(creds, conn.GetCredentials())
 }
 
 func TestConnectionBuildRequest(t *testing.T) {
 	assert := assert.New(t)
 
-	opts := connection.DefaultOptions("testApp", "1.0", "en_US")
-	creds := connection.NoCredentials{}
-	conn := connection.New(opts, creds)
+	opts := DefaultOptions("testApp", "1.0", "en_US")
+	creds := NoCredentials{}
+	conn := New(opts, creds)
 
 	request, err := conn.BuildRequest("GET", "/test/api", nil)
 
 	assert.NoError(err)
 	assert.Equal(request.URL.String(), "https://scc.suse.com/test/api")
 	assert.Contains(request.Header.Get("User-Agent"), "testApp/1.0")
-	assert.Equal(request.Header.Get("Accept"), connection.DefaultAPIVersion)
+	assert.Equal(request.Header.Get("Accept"), DefaultAPIVersion)
 	assert.Equal(request.Header.Get("Accept-Language"), "en_US")
 }
 
@@ -48,11 +47,11 @@ func TestConnectionDoGet(t *testing.T) {
 	server := NewTestServerSetupWith(t, "GET", "/test/api", handler)
 	defer server.Close()
 
-	opts := connection.DefaultOptions("testApp", "1.0", "en_US")
+	opts := DefaultOptions("testApp", "1.0", "en_US")
 	opts.URL = server.URL
 
-	creds := connection.NoCredentials{}
-	conn := connection.New(opts, creds)
+	creds := NoCredentials{}
+	conn := New(opts, creds)
 
 	request, buildErr := conn.BuildRequest("GET", "/test/api", "")
 	assert.NoError(buildErr)
@@ -72,11 +71,11 @@ func TestConnectionDoError(t *testing.T) {
 	server := NewTestServerSetupWith(t, "GET", "/test/api", handler)
 	defer server.Close()
 
-	opts := connection.DefaultOptions("testApp", "1.0", "en_US")
+	opts := DefaultOptions("testApp", "1.0", "en_US")
 	opts.URL = server.URL
 
-	creds := connection.NoCredentials{}
-	conn := connection.New(opts, creds)
+	creds := NoCredentials{}
+	conn := New(opts, creds)
 
 	request, buildErr := conn.BuildRequest("GET", "/test/api", "")
 	assert.NoError(buildErr)
@@ -97,11 +96,11 @@ func TestConnectionDoErrorTranslation(t *testing.T) {
 	server := NewTestServerSetupWith(t, "GET", "/test/api", handler)
 	defer server.Close()
 
-	opts := connection.DefaultOptions("testApp", "1.0", "en_US")
+	opts := DefaultOptions("testApp", "1.0", "en_US")
 	opts.URL = server.URL
 
-	creds := connection.NoCredentials{}
-	conn := connection.New(opts, creds)
+	creds := NoCredentials{}
+	conn := New(opts, creds)
 
 	request, buildErr := conn.BuildRequest("GET", "/test/api", "")
 	assert.NoError(buildErr)
@@ -123,14 +122,14 @@ func TestConnectionUpdateToken(t *testing.T) {
 	server := NewTestServerSetupWith(t, "GET", "/test/api", handler)
 	defer server.Close()
 
-	opts := connection.DefaultOptions("testApp", "1.0", "en_US")
+	opts := DefaultOptions("testApp", "1.0", "en_US")
 	opts.URL = server.URL
 
 	creds := &mockCredentials{}
 	creds.On("Token").Return(oldToken, nil)
 	creds.On("UpdateToken", newToken).Return(nil)
 
-	conn := connection.New(opts, creds)
+	conn := New(opts, creds)
 
 	request, buildErr := conn.BuildRequest("GET", "/test/api", "")
 	assert.NoError(buildErr)

--- a/pkg/connection/helpers_test.go
+++ b/pkg/connection/helpers_test.go
@@ -1,4 +1,4 @@
-package connection_test
+package connection
 
 import (
 	"net/http"

--- a/pkg/connection/mock_credentials_test.go
+++ b/pkg/connection/mock_credentials_test.go
@@ -1,4 +1,4 @@
-package connection_test
+package connection
 
 import "github.com/stretchr/testify/mock"
 

--- a/pkg/registration/activate_test.go
+++ b/pkg/registration/activate_test.go
@@ -1,10 +1,9 @@
-package registration_test
+package registration
 
 import (
 	"errors"
 	"testing"
 
-	"github.com/SUSE/connect-ng/pkg/registration"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
@@ -18,7 +17,7 @@ func TestActivateProductSuccess(t *testing.T) {
 	payload := fixture(t, "pkg/registration/activate_success.json")
 	conn.On("Do", mock.Anything).Return(payload, nil)
 
-	metadata, product, err := registration.Activate(conn, "SLES", "12.1", "x86_64", "regcode")
+	metadata, product, err := Activate(conn, "SLES", "12.1", "x86_64", "regcode")
 	assert.NoError(err)
 
 	assert.Equal("SUSE_Linux_Enterprise_Server_12_x86_64", metadata.ObsoletedName)
@@ -33,7 +32,7 @@ func TestActivateProductInvalidRegcode(t *testing.T) {
 	// 204 No Content
 	conn.On("Do", mock.Anything).Return([]byte{}, errors.New("No valid subscription found"))
 
-	_, _, err := registration.Activate(conn, "SLES", "12.1", "x86_64", "regcode")
+	_, _, err := Activate(conn, "SLES", "12.1", "x86_64", "regcode")
 	assert.Error(err)
 }
 
@@ -46,7 +45,7 @@ func TestDeactivateProductSuccess(t *testing.T) {
 	payload := fixture(t, "pkg/registration/deactivate_success.json")
 	conn.On("Do", mock.Anything).Return(payload, nil)
 
-	metadata, product, err := registration.Deactivate(conn, "SLES", "12.1", "x86_64")
+	metadata, product, err := Deactivate(conn, "SLES", "12.1", "x86_64")
 	assert.NoError(err)
 
 	assert.Equal("SUSE_Linux_Enterprise_Server_12_x86_64", metadata.ObsoletedName)
@@ -61,6 +60,6 @@ func TestDeactivateProductInvalidProduct(t *testing.T) {
 	// 204 No Content
 	conn.On("Do", mock.Anything).Return([]byte{}, errors.New("Product is a base product and cannot be deactivated"))
 
-	_, _, err := registration.Deactivate(conn, "SLES", "12.1", "x86_64")
+	_, _, err := Deactivate(conn, "SLES", "12.1", "x86_64")
 	assert.Error(err)
 }

--- a/pkg/registration/activation_test.go
+++ b/pkg/registration/activation_test.go
@@ -1,9 +1,8 @@
-package registration_test
+package registration
 
 import (
 	"testing"
 
-	"github.com/SUSE/connect-ng/pkg/registration"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
@@ -17,12 +16,12 @@ func TestFetchProductActivations(t *testing.T) {
 	payload := fixture(t, "pkg/registration/activations.json")
 	conn.On("Do", mock.Anything).Return(payload, nil).Run(checkAuthBySystemCredentials(t, login, password))
 
-	activations, err := registration.FetchActivations(conn)
+	activations, err := FetchActivations(conn)
 
 	assert.NoError(err)
 	assert.Equal(4, len(activations))
 
-	sles := &registration.Activation{}
+	sles := &Activation{}
 	for _, activation := range activations {
 		if activation.RegistrationCode == "SOME_TEST_REGCODE" {
 			sles = activation
@@ -40,7 +39,7 @@ func TestFetchProductActivationsEmpty(t *testing.T) {
 
 	conn.On("Do", mock.Anything).Return([]byte("[]"), nil).Run(checkAuthBySystemCredentials(t, login, password))
 
-	activations, err := registration.FetchActivations(conn)
+	activations, err := FetchActivations(conn)
 
 	assert.NoError(err)
 	assert.Equal(0, len(activations))

--- a/pkg/registration/helpers_test.go
+++ b/pkg/registration/helpers_test.go
@@ -1,4 +1,4 @@
-package registration_test
+package registration
 
 import (
 	"encoding/base64"

--- a/pkg/registration/mock_connection_test.go
+++ b/pkg/registration/mock_connection_test.go
@@ -1,4 +1,4 @@
-package registration_test
+package registration
 
 import (
 	"net/http"

--- a/pkg/registration/mock_credentials_test.go
+++ b/pkg/registration/mock_credentials_test.go
@@ -1,4 +1,4 @@
-package registration_test
+package registration
 
 import "github.com/stretchr/testify/mock"
 

--- a/pkg/registration/offline_certificate_test.go
+++ b/pkg/registration/offline_certificate_test.go
@@ -1,11 +1,10 @@
-package registration_test
+package registration
 
 import (
 	"bytes"
 	"testing"
 	"time"
 
-	"github.com/SUSE/connect-ng/pkg/registration"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -15,7 +14,7 @@ func TestOfflineCertificateFromSuccess(t *testing.T) {
 	rawCert := fixture(t, "pkg/registration/offline_certificate/valid.cert")
 	reader := bytes.NewReader(rawCert)
 
-	cert, err := registration.OfflineCertificateFrom(reader)
+	cert, err := OfflineCertificateFrom(reader)
 
 	assert.NoError(err)
 
@@ -30,7 +29,7 @@ func TestOfflineCertificateFromMalformedCertificate(t *testing.T) {
 	rawCert := fixture(t, "pkg/registration/offline_certificate/malformed.cert")
 	reader := bytes.NewReader(rawCert)
 
-	cert, err := registration.OfflineCertificateFrom(reader)
+	cert, err := OfflineCertificateFrom(reader)
 
 	assert.ErrorContains(err, "base64: illegal base64 data")
 	assert.Nil(cert)
@@ -42,7 +41,7 @@ func TestOfflineCertificateIsValidTrue(t *testing.T) {
 	rawCert := fixture(t, "pkg/registration/offline_certificate/valid.cert")
 	reader := bytes.NewReader(rawCert)
 
-	cert, err := registration.OfflineCertificateFrom(reader)
+	cert, err := OfflineCertificateFrom(reader)
 	assert.NoError(err)
 
 	valid, err := cert.IsValid()
@@ -56,7 +55,7 @@ func TestOfflineCertificateIsValidFalse(t *testing.T) {
 	rawCert := fixture(t, "pkg/registration/offline_certificate/invalid.cert")
 	reader := bytes.NewReader(rawCert)
 
-	cert, err := registration.OfflineCertificateFrom(reader)
+	cert, err := OfflineCertificateFrom(reader)
 	assert.NoError(err)
 
 	valid, err := cert.IsValid()
@@ -70,7 +69,7 @@ func TestOfflineCertificateIsValidMalformedSignature(t *testing.T) {
 	rawCert := fixture(t, "pkg/registration/offline_certificate/malformed-signature.cert")
 	reader := bytes.NewReader(rawCert)
 
-	cert, err := registration.OfflineCertificateFrom(reader)
+	cert, err := OfflineCertificateFrom(reader)
 	assert.NoError(err)
 
 	valid, err := cert.IsValid()
@@ -84,7 +83,7 @@ func TestOfflineCertificateExtractPayloadSuccess(t *testing.T) {
 	rawCert := fixture(t, "pkg/registration/offline_certificate/valid.cert")
 	reader := bytes.NewReader(rawCert)
 
-	cert, err := registration.OfflineCertificateFrom(reader)
+	cert, err := OfflineCertificateFrom(reader)
 	assert.NoError(err)
 
 	payload, extractErr := cert.ExtractPayload()
@@ -101,7 +100,7 @@ func TestOfflineCertificateExtractPayloadInvalidJSON(t *testing.T) {
 	rawCert := fixture(t, "pkg/registration/offline_certificate/invalid-json-payload.cert")
 	reader := bytes.NewReader(rawCert)
 
-	cert, err := registration.OfflineCertificateFrom(reader)
+	cert, err := OfflineCertificateFrom(reader)
 	assert.NoError(err)
 
 	payload, extractErr := cert.ExtractPayload()
@@ -116,7 +115,7 @@ func TestOfflineCertificateRegcodeMatches(t *testing.T) {
 	rawCert := fixture(t, "pkg/registration/offline_certificate/valid.cert")
 	reader := bytes.NewReader(rawCert)
 
-	cert, readErr := registration.OfflineCertificateFrom(reader)
+	cert, readErr := OfflineCertificateFrom(reader)
 	assert.NoError(readErr)
 
 	matches, matchErr := cert.RegcodeMatches("some-scc-regcode")
@@ -134,7 +133,7 @@ func TestOfflineCertificateUUIDMatches(t *testing.T) {
 	rawCert := fixture(t, "pkg/registration/offline_certificate/valid.cert")
 	reader := bytes.NewReader(rawCert)
 
-	cert, readErr := registration.OfflineCertificateFrom(reader)
+	cert, readErr := OfflineCertificateFrom(reader)
 	assert.NoError(readErr)
 
 	matches, matchErr := cert.UUIDMatches("3a4d46b4-0b06-488f-8d20-a931d398d357")
@@ -152,7 +151,7 @@ func TestOfflineCertificateProductClassIncluded(t *testing.T) {
 	rawCert := fixture(t, "pkg/registration/offline_certificate/valid.cert")
 	reader := bytes.NewReader(rawCert)
 
-	cert, readErr := registration.OfflineCertificateFrom(reader)
+	cert, readErr := OfflineCertificateFrom(reader)
 	assert.NoError(readErr)
 
 	shouldBeIncluded, matchErr := cert.ProductClassIncluded("RANCHER-X86")
@@ -171,7 +170,7 @@ func TestOfflineCertificateExpireDate(t *testing.T) {
 	rawCert := fixture(t, "pkg/registration/offline_certificate/valid.cert")
 	reader := bytes.NewReader(rawCert)
 
-	cert, readErr := registration.OfflineCertificateFrom(reader)
+	cert, readErr := OfflineCertificateFrom(reader)
 	assert.NoError(readErr)
 
 	expectedExpirationDate := time.Date(2026, time.January, 27, 11, 53, 51, 223000000, time.UTC)

--- a/pkg/registration/product_test.go
+++ b/pkg/registration/product_test.go
@@ -1,11 +1,10 @@
-package registration_test
+package registration
 
 import (
 	"encoding/json"
 	"fmt"
 	"testing"
 
-	"github.com/SUSE/connect-ng/pkg/registration"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
@@ -14,7 +13,7 @@ func TestProductTraverseExtensionsFull(t *testing.T) {
 	assert := assert.New(t)
 
 	productJson := fixture(t, "pkg/registration/product_tree.json")
-	product := registration.Product{}
+	product := Product{}
 
 	actual := []string{}
 	expected := []string{
@@ -40,7 +39,7 @@ func TestProductTraverseExtensionsFull(t *testing.T) {
 
 	assert.NoError(json.Unmarshal(productJson, &product))
 
-	err := product.TraverseExtensions(func(p registration.Product) (bool, error) {
+	err := product.TraverseExtensions(func(p Product) (bool, error) {
 		actual = append(actual, fmt.Sprintf("%s/%s/%s", p.Identifier, p.Version, p.Arch))
 		return true, nil
 	})
@@ -52,7 +51,7 @@ func TestProductTraverseExtensionsSkipBranch(t *testing.T) {
 	assert := assert.New(t)
 
 	productJson := fixture(t, "pkg/registration/product_tree.json")
-	product := registration.Product{}
+	product := Product{}
 
 	actual := []string{}
 	expected := []string{
@@ -73,7 +72,7 @@ func TestProductTraverseExtensionsSkipBranch(t *testing.T) {
 
 	assert.NoError(json.Unmarshal(productJson, &product))
 
-	err := product.TraverseExtensions(func(p registration.Product) (bool, error) {
+	err := product.TraverseExtensions(func(p Product) (bool, error) {
 		triplet := fmt.Sprintf("%s/%s/%s", p.Identifier, p.Version, p.Arch)
 
 		// Skip everything based on server-applications
@@ -97,7 +96,7 @@ func TestFetchProductInfo(t *testing.T) {
 	payload := fixture(t, "pkg/registration/product_tree.json")
 	conn.On("Do", mock.Anything).Return(payload, nil).Run(checkAuthBySystemCredentials(t, login, password))
 
-	product, err := registration.FetchProductInfo(conn, "SLES", "15.5", "x86_64")
+	product, err := FetchProductInfo(conn, "SLES", "15.5", "x86_64")
 	assert.NoError(err)
 
 	assert.Equal("SUSE Linux Enterprise Server 15 SP5 x86_64", product.FriendlyName)

--- a/pkg/registration/register_test.go
+++ b/pkg/registration/register_test.go
@@ -1,10 +1,9 @@
-package registration_test
+package registration
 
 import (
 	"errors"
 	"testing"
 
-	"github.com/SUSE/connect-ng/pkg/registration"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
@@ -20,7 +19,7 @@ func TestRegisterSuccess(t *testing.T) {
 	conn.On("Do", mock.Anything).Return(payload, nil).Run(checkAuthByRegcode(t, "regcode"))
 	creds.On("SetLogin", "SCC_login", "sample-password").Return(nil)
 
-	_, err := registration.Register(conn, "regcode", "hostname", nil)
+	_, err := Register(conn, "regcode", "hostname", nil)
 	assert.NoError(err)
 
 	conn.AssertExpectations(t)
@@ -34,7 +33,7 @@ func TestRegisterFailed(t *testing.T) {
 	// 404 Not found / announce failed
 	conn.On("Do", mock.Anything).Return([]byte{}, errors.New("Invalid registration token supplied"))
 
-	_, err := registration.Register(conn, "regcode", "hostname", nil)
+	_, err := Register(conn, "regcode", "hostname", nil)
 	assert.ErrorContains(err, "Invalid registration token")
 
 	conn.AssertExpectations(t)
@@ -49,7 +48,7 @@ func TestDeRegisterSuccess(t *testing.T) {
 	conn.On("Do", mock.Anything).Return([]byte{}, nil)
 	creds.On("SetLogin", "", "").Return(nil)
 
-	err := registration.Deregister(conn)
+	err := Deregister(conn)
 	assert.NoError(err)
 
 	conn.AssertExpectations(t)
@@ -63,7 +62,7 @@ func TestDeRegisterInvalid(t *testing.T) {
 	// 404 Not found / announce failed
 	conn.On("Do", mock.Anything).Return([]byte{}, errors.New("Not found"))
 
-	err := registration.Deregister(conn)
+	err := Deregister(conn)
 	assert.Error(err)
 
 	conn.AssertExpectations(t)

--- a/pkg/registration/status_test.go
+++ b/pkg/registration/status_test.go
@@ -1,4 +1,4 @@
-package registration_test
+package registration
 
 import (
 	"errors"
@@ -6,8 +6,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
-
-	"github.com/SUSE/connect-ng/pkg/registration"
 )
 
 const (
@@ -23,9 +21,9 @@ func TestStatusRegistered(t *testing.T) {
 	// 204 No Content
 	conn.On("Do", mock.Anything).Return([]byte(""), nil).Run(checkAuthBySystemCredentials(t, login, password))
 
-	status, err := registration.Status(conn, hostname, nil)
+	status, err := Status(conn, hostname, nil)
 	assert.NoError(err)
-	assert.Equal(registration.Registered, status)
+	assert.Equal(Registered, status)
 }
 
 func TestStatusUnregistered(t *testing.T) {
@@ -36,9 +34,9 @@ func TestStatusUnregistered(t *testing.T) {
 	// 404 Not Found
 	conn.On("Do", mock.Anything).Return([]byte(""), errors.New("system not found"))
 
-	status, err := registration.Status(conn, hostname, nil)
+	status, err := Status(conn, hostname, nil)
 	assert.NoError(err)
-	assert.Equal(registration.Unregistered, status)
+	assert.Equal(Unregistered, status)
 }
 
 func TestStatusWithSystemInformation(t *testing.T) {
@@ -54,7 +52,7 @@ func TestStatusWithSystemInformation(t *testing.T) {
 	expected := string(fixture(t, "pkg/registration/status_with_system_information.json"))
 	conn.On("Do", mock.AnythingOfType("*http.Request")).Return([]byte(""), nil).Run(matchBody(t, expected))
 
-	status, err := registration.Status(conn, hostname, payload)
+	status, err := Status(conn, hostname, payload)
 	assert.NoError(err)
-	assert.Equal(registration.Registered, status)
+	assert.Equal(Registered, status)
 }


### PR DESCRIPTION
This is against Go's conventions and it makes importing these packages more difficult.

## How to test

Run `make test` and check that everything still passes.