### PR TITLE
cmd: Remove the `CFG` global variable from `internal/connect`

### DIFF
--- a/cmd/suseconnect/suseconnect.go
+++ b/cmd/suseconnect/suseconnect.go
@@ -7,16 +7,16 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"github.com/SUSE/connect-ng/internal/connect"
-	"github.com/SUSE/connect-ng/internal/util"
-	"github.com/SUSE/connect-ng/internal/zypper"
 	"io"
 	"net/http"
 	"net/url"
 	"os"
-	"runtime"
 	"strings"
 	"syscall"
+
+	"github.com/SUSE/connect-ng/internal/connect"
+	"github.com/SUSE/connect-ng/internal/util"
+	"github.com/SUSE/connect-ng/internal/zypper"
 )
 
 var (
@@ -45,15 +45,9 @@ func (p *singleStringFlag) Set(value string) error {
 }
 
 func main() {
-	// Disallow the usage of SUSEConnect outside of Linux. The `runtime.GOOS`
-	// constant is provided by the standard library and is filled on a platform
-	// basis through an internal `goos` package. You can check the value being
-	// filled specifically for Linux here:
-	// https://cs.opensource.google/go/go/+/master:src/internal/goos/zgoos_linux.go
-	//
-	// NOTE: Android is considered a different platform than "Linux".
-	if runtime.GOOS != "linux" {
-		exitOnError(fmt.Errorf("platform '%v' is not supported. Use Linux instead", runtime.GOOS))
+	// SUSEConnect only works on Linux.
+	if err := util.EnsureLinux(); err != nil {
+		exitOnError(err)
 	}
 
 	var (

--- a/cmd/suseconnect/suseconnect.go
+++ b/cmd/suseconnect/suseconnect.go
@@ -447,7 +447,7 @@ func readTokenFromReader(reader io.Reader) (string, error) {
 	}
 	token := strings.TrimSpace(tokenBytes)
 	if token == "" {
-		return "", fmt.Errorf("error: token cannot be empty after reading")
+		return "", fmt.Errorf("token cannot be empty after reading")
 	}
 	return token, nil
 }

--- a/cmd/suseconnect/suseconnect_test.go
+++ b/cmd/suseconnect/suseconnect_test.go
@@ -1,280 +1,104 @@
 package main
 
 import (
-	"errors"
-	"fmt"
-	"github.com/SUSE/connect-ng/internal/connect"
-	"github.com/SUSE/connect-ng/internal/util"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 	"os"
 	"strings"
 	"testing"
 )
 
-var processTokenFunc = processToken
+func TestEmptyToken(t *testing.T) {
+	token, err := processToken("")
 
-var exitCalled bool
-var exit = func(code int) {
-	exitCalled = true
-}
-
-type MockProcessToken struct {
-	mock.Mock
-}
-
-func (m *MockProcessToken) ProcessToken(token string) (string, error) {
-	args := m.Called(token)
-	return args.String(0), args.Error(1)
-}
-
-func init() {
-	processTokenFunc = processToken
-}
-
-type errorReader struct{}
-
-func (e *errorReader) Read(p []byte) (n int, err error) {
-	return 0, fmt.Errorf("forced reader error")
-}
-
-func TestReadTokenFromErrorValidToken(t *testing.T) {
-	inputToken := "validToken\n"
-	reader := strings.NewReader(inputToken)
-	token, err := readTokenFromReader(reader)
 	if err != nil {
-		t.Fatalf("Expected no error but got %v", err)
+		t.Fatalf("expecting no errors, but '%v' was given", err)
 	}
-	if token != "validToken" {
-		t.Fatalf("Expected token string to be 'validToken' but got '%s'", token)
+	if token != "" {
+		t.Fatalf("expecting an empty token, but '%v' was given", token)
 	}
 }
 
-func TestReadTokenFromReader_MultipleNewlines(t *testing.T) {
-	input := "firstToken\nsecondToken\n"
-	reader := strings.NewReader(input)
+func TestProcessTokenRaw(t *testing.T) {
+	token, err := processToken("token")
 
-	token, err := readTokenFromReader(reader)
 	if err != nil {
-		t.Fatalf("Expected no error, but got %v", err)
+		t.Fatalf("expecting no errors, but '%v' was given", err)
 	}
-
-	expected := "firstToken"
-	if token != expected {
-		t.Errorf("Expected token to be '%s', but got '%s'", expected, token)
+	if token != "token" {
+		t.Fatalf("expecting 'token', but '%v' was given", token)
 	}
 }
 
-func TestReadTokenFromReader_EmptyInput(t *testing.T) {
-	reader := strings.NewReader("")
+func TestProcessTokenFromStdin(t *testing.T) {
+	// Setup our mock stdin.
+	tempFile, err := os.CreateTemp("", "suseconnect-test-stdin")
+	if err != nil {
+		t.Fatalf("Failed to create temp file: %v", err)
+	}
+	defer func() {
+		tempFile.Close()
+		os.Remove(tempFile.Name())
+	}()
 
-	token, err := readTokenFromReader(reader)
-	if err == nil {
-		t.Fatalf("Expected error, but got none")
+	expectedToken := "stdinToken\n"
+	if _, err := tempFile.WriteString(expectedToken); err != nil {
+		t.Fatalf("Failed to write to temp file: %v", err)
 	}
 
-	expectedError := "error: token cannot be empty after reading"
-	if err.Error() != expectedError {
-		t.Errorf("Expected error '%s', but got '%s'", expectedError, err.Error())
+	// Save the stdin from the OS and restore it before leaving.
+	file, err := os.Open(tempFile.Name())
+	if err != nil {
+		t.Fatalf("Failed to open temp file: %v", err)
 	}
+	oldStdin := os.Stdin
+	defer func() {
+		file.Close()
+		os.Stdin = oldStdin
+	}()
+	os.Stdin = file
 
-	if token != "" {
-		t.Errorf("Expected empty token, but got '%s'", token)
-	}
-}
-
-func TestReadTokenFromReader_OnlyNewline(t *testing.T) {
-	reader := strings.NewReader("\n")
-
-	token, err := readTokenFromReader(reader)
-	if err == nil {
-		t.Fatalf("Expected error, but got none")
-	}
-
-	expectedError := "error: token cannot be empty after reading"
-	if err.Error() != expectedError {
-		t.Errorf("Expected error '%s', but got '%s'", expectedError, err.Error())
-	}
-
-	if token != "" {
-		t.Errorf("Expected empty token, but got '%s'", token)
-	}
-}
-
-func TestReadTokenFromReader_ErrorProducingReader(t *testing.T) {
-	reader := &errorReader{}
-
-	token, err := readTokenFromReader(reader)
-	if err == nil {
-		t.Fatalf("Expected error, but got none")
-	}
-
-	expectedError := "failed to read token from reader: forced reader error"
-	if err.Error() != expectedError {
-		t.Errorf("Expected error '%s', but got '%s'", expectedError, err.Error())
-	}
-
-	if token != "" {
-		t.Errorf("Expected empty token, but got '%s'", token)
-	}
-}
-
-func TestProcessToken_RegularToken(t *testing.T) {
-	token := "myRegularToken"
-	result, err := processToken(token)
+	// Now the actual test :)
+	result, err := processToken("-")
 	if err != nil {
 		t.Fatalf("Expected no error, but got %v", err)
 	}
-
-	if result != token {
-		t.Errorf("Expected token to be '%s', but got '%s'", token, result)
+	expectedToken = strings.TrimSpace(expectedToken)
+	if result != expectedToken {
+		t.Errorf("Expected token to be '%s', but got '%s'", expectedToken, result)
 	}
 }
 
-func TestProcessToken_TokenFromFile(t *testing.T) {
+func TestProcessTokenFromFile(t *testing.T) {
 	tmpFile, err := os.CreateTemp("", "tokenfile")
 	if err != nil {
 		t.Fatalf("Failed to create temp file: %v", err)
 	}
-	defer os.Remove(tmpFile.Name())
+	defer func() {
+		tmpFile.Close()
+		os.Remove(tmpFile.Name())
+	}()
 
-	expectedToken := "fileToken\n"
-	if _, err := tmpFile.WriteString(expectedToken); err != nil {
+	expectedToken := "fileToken"
+	if _, err := tmpFile.WriteString(expectedToken + "\n"); err != nil {
 		t.Fatalf("Failed to write to temp file: %v", err)
 	}
-	tmpFile.Close()
 
 	token := "@" + tmpFile.Name()
 	result, err := processToken(token)
 	if err != nil {
 		t.Fatalf("Expected no error, but got %v", err)
 	}
-
-	expectedToken = strings.TrimSpace(expectedToken)
 	if result != expectedToken {
 		t.Errorf("Expected token to be '%s', but got '%s'", expectedToken, result)
 	}
 }
 
-func TestProcessToken_NonExistentFile(t *testing.T) {
-	token := "@/non/existent/file"
-	_, err := processToken(token)
-	if err == nil {
-		t.Fatalf("Expected error for non-existent file, but got none")
+func TestProcessTokenFromBadFile(t *testing.T) {
+	token := "@/lala/error/whatever"
+	prefix := "failed to open token file"
+
+	if _, err := processToken(token); err == nil {
+		t.Fatalf("Expecting an error")
+	} else if !strings.HasPrefix(err.Error(), prefix) {
+		t.Fatalf("Bad error message; got '%v'", err)
 	}
-
-	expectedError := "failed to open token file '/non/existent/file'"
-	if !strings.Contains(err.Error(), expectedError) {
-		t.Errorf("Expected error containing '%s', but got '%v'", expectedError, err)
-	}
-}
-
-func TestProcessToken_TokenFromStdin(t *testing.T) {
-	tempFile, err := os.CreateTemp("", "test_stdin")
-	if err != nil {
-		t.Fatalf("Failed to create temp file: %v", err)
-	}
-	defer os.Remove(tempFile.Name())
-	expectedToken := "stdinToken\n"
-	if _, err := tempFile.WriteString(expectedToken); err != nil {
-		t.Fatalf("Failed to write to temp file: %v", err)
-	}
-
-	tempFile.Close()
-
-	oldStdin := os.Stdin
-	defer func() { os.Stdin = oldStdin }()
-	file, err := os.Open(tempFile.Name())
-	if err != nil {
-		t.Fatalf("Failed to open temp file: %v", err)
-	}
-	os.Stdin = file
-
-	result, err := processToken("-")
-	if err != nil {
-		t.Fatalf("Expected no error, but got %v", err)
-	}
-
-	expectedToken = strings.TrimSpace(expectedToken)
-	if result != expectedToken {
-		t.Errorf("Expected token to be '%s', but got '%s'", expectedToken, result)
-	}
-}
-
-func TestProcessToken_ErrorReadingStdin(t *testing.T) {
-	tempFile, err := os.CreateTemp("", "test_stdin_empty")
-	if err != nil {
-		t.Fatalf("Failed to create temp file: %v", err)
-	}
-	defer os.Remove(tempFile.Name())
-
-	tempFile.Close()
-	oldStdin := os.Stdin
-	defer func() { os.Stdin = oldStdin }()
-	file, err := os.Open(tempFile.Name())
-	if err != nil {
-		t.Fatalf("Failed to open temp file: %v", err)
-	}
-	os.Stdin = file
-
-	_, err = processToken("-")
-	if err == nil {
-		t.Fatalf("Expected error reading from stdin, but got none")
-	}
-
-	expectedError := "error: token cannot be empty after reading"
-	if !strings.Contains(err.Error(), expectedError) {
-		t.Errorf("Expected error containing '%s', but got '%v'", expectedError, err)
-	}
-}
-
-func parseRegistrationTokenWithInjection(token string) {
-	if token != "" {
-		connect.CFG.Token = token
-		processedToken, processTokenErr := processTokenFunc(token)
-		if processTokenErr != nil {
-			util.Debug.Printf("Error Processing token %+v", processTokenErr)
-			exit(1)
-		}
-		connect.CFG.Token = processedToken
-	}
-}
-
-func TestParseToken_Success(t *testing.T) {
-	mockProcessToken := new(MockProcessToken)
-	mockProcessToken.On("ProcessToken", "valid-token").Return("processed-token", nil)
-
-	processTokenFunc = mockProcessToken.ProcessToken
-
-	exitCalled = false
-
-	parseRegistrationTokenWithInjection("valid-token")
-
-	assert.Equal(t, "processed-token", connect.CFG.Token, "Token should be processed correctly")
-	assert.False(t, exitCalled, "os.Exit (simulated) should not be called in a successful case")
-
-	mockProcessToken.AssertExpectations(t)
-}
-
-func TestParseToken_ProcessTokenError(t *testing.T) {
-	mockProcessToken := new(MockProcessToken)
-	mockProcessToken.On("ProcessToken", "invalid-token").Return("", errors.New("failed to process token"))
-
-	processTokenFunc = mockProcessToken.ProcessToken
-
-	exitCalled = false
-
-	parseRegistrationTokenWithInjection("invalid-token")
-
-	assert.True(t, exitCalled, "os.Exit (simulated) should be called when processToken fails")
-	assert.Equal(t, "", connect.CFG.Token, "Token should not be updated when processToken fails")
-
-	mockProcessToken.AssertExpectations(t)
-}
-
-func TestParseToken_EmptyToken(t *testing.T) {
-	exitCalled = false
-	parseRegistrationTokenWithInjection("")
-	assert.Empty(t, connect.CFG.Token, "Token should not be updated when input token is empty")
-	assert.False(t, exitCalled, "os.Exit (simulated) should not be called for empty token")
 }

--- a/cmd/zypper-migration/migration.go
+++ b/cmd/zypper-migration/migration.go
@@ -50,6 +50,12 @@ func (a *multiArg) Set(v string) error {
 }
 
 func main() {
+	// Ensure Zypper is installed.
+	if err := util.EnsureZypper(); err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
 	var (
 		debug                    bool
 		verbose                  bool

--- a/cmd/zypper-migration/migration.go
+++ b/cmd/zypper-migration/migration.go
@@ -140,11 +140,15 @@ func main() {
 		QuietOut.SetOutput(os.Stdout)
 	}
 
-	connect.CFG.Load()
+	opts, err := connect.ReadFromConfiguration(connect.DefaultConfigPath)
+	if err != nil {
+		fmt.Printf("Something went wrong when reading the configuration: %v\n")
+		os.Exit(1)
+	}
 
 	// pass root to connect config
 	if fsRoot != "" {
-		connect.CFG.FsRoot = fsRoot
+		opts.FsRoot = fsRoot
 		zypper.SetFilesystemRoot(fsRoot)
 		// if we update a chroot system, we cannot create snapshots of it
 		noSnapshots = true
@@ -160,10 +164,15 @@ func main() {
 		os.Exit(1)
 	}
 
+	// TODO(mssola): to be removed by the end of RR4.
+	connect.CFG = opts
+
 	if selfUpdate {
 		// reset root (if set) as the update stack can be outside of
 		// the to be updated system
-		connect.CFG.FsRoot = ""
+		opts.FsRoot = ""
+		// TODO(mssola): to be removed by the end of RR4.
+		connect.CFG = opts
 		echo := util.SetSystemEcho(true)
 		if pending, err := zypper.PatchCheck(true, quiet, verbose, nonInteractive, false); err != nil {
 			fmt.Printf("patch pre-check failed: %v\n", err)
@@ -197,7 +206,9 @@ func main() {
 		util.SetSystemEcho(echo)
 		// restore root if needed
 		if fsRoot != "" {
-			connect.CFG.FsRoot = fsRoot
+			opts.FsRoot = fsRoot
+			// TODO(mssola): to be removed by the end of RR4.
+			connect.CFG = opts
 		}
 	}
 	QuietOut.Print("\n")
@@ -323,7 +334,7 @@ func main() {
 	}()
 
 	dupArgs := zypperDupArgs()
-	fsInconsistent, err := applyMigration(migration, systemProducts,
+	fsInconsistent, err := applyMigration(migration, opts.BaseURL, systemProducts,
 		quiet, verbose, nonInteractive, disableRepos, autoAgreeLicenses, autoImportRepoKeys,
 		failDupOnlyOnFatalErrors, dupArgs)
 
@@ -562,8 +573,8 @@ func cleanupProductRepos(p connect.Product, force, autoImportRepoKeys bool) erro
 }
 
 // checks if given service is provided by SUSE
-func isSUSEService(service zypper.ZypperService) bool {
-	return strings.Contains(service.URL, connect.CFG.BaseURL) ||
+func isSUSEService(service zypper.ZypperService, baseURL string) bool {
+	return strings.Contains(service.URL, baseURL) ||
 		strings.Contains(service.URL, "plugin:/susecloud") ||
 		strings.Contains(service.URL, "plugin:susecloud") ||
 		strings.Contains(service.URL, "susecloud.net")
@@ -573,7 +584,7 @@ func isSUSEService(service zypper.ZypperService) bool {
 // adds/removes services to match target state
 // disables obsolete repos
 // returns base product version string
-func migrateSystem(migration connect.MigrationPath, forceDisableRepos, autoImportRepoKeys bool) (string, error) {
+func migrateSystem(migration connect.MigrationPath, baseURL string, forceDisableRepos, autoImportRepoKeys bool) (string, error) {
 	var baseProductVersion string
 
 	systemServices, _ := zypper.InstalledServices()
@@ -619,7 +630,7 @@ func migrateSystem(migration connect.MigrationPath, forceDisableRepos, autoImpor
 	}
 	// remove SUSE services which don't have migration available (bsc#1161891)
 	for _, s := range systemServices {
-		if isSUSEService(s) && !migratedServices.Contains(s.Name) {
+		if isSUSEService(s, baseURL) && !migratedServices.Contains(s.Name) {
 			msg := "Removing service " + s.Name + " (no migration available)"
 			VerboseOut.Println(msg)
 			err := connect.MigrationRemoveService(s.Name)
@@ -658,7 +669,7 @@ func isFatalZypperError(code int) bool {
 }
 
 // returns fs_inconsistent flag
-func applyMigration(migration connect.MigrationPath, systemProducts []connect.Product,
+func applyMigration(migration connect.MigrationPath, baseURL string, systemProducts []connect.Product,
 	quiet, verbose, nonInteractive, forceDisableRepos, autoAgreeLicenses, autoImportRepoKeys, failDupOnlyOnFatalErrors bool,
 	dupArgs []string) (bool, error) {
 
@@ -687,7 +698,7 @@ func applyMigration(migration connect.MigrationPath, systemProducts []connect.Pr
 		}
 	}
 
-	baseProductVersion, err := migrateSystem(migration, nonInteractive || forceDisableRepos, autoImportRepoKeys)
+	baseProductVersion, err := migrateSystem(migration, baseURL, nonInteractive || forceDisableRepos, autoImportRepoKeys)
 	if err != nil {
 		return fsInconsistent, err
 	}

--- a/cmd/zypper-search-packages/search-packages.go
+++ b/cmd/zypper-search-packages/search-packages.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 
 	"github.com/SUSE/connect-ng/internal/connect"
+	"github.com/SUSE/connect-ng/internal/util"
 )
 
 var (
@@ -74,6 +75,12 @@ func (sr searchResult) MarshalXML(e *xml.Encoder, start xml.StartElement) error 
 }
 
 func main() {
+	// Ensure Zypper is installed.
+	if err := util.EnsureZypper(); err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
 	var (
 		matchExact    bool
 		caseSensitive bool

--- a/cmd/zypper-search-packages/search-packages.go
+++ b/cmd/zypper-search-packages/search-packages.go
@@ -157,6 +157,14 @@ func main() {
 		os.Exit(1)
 	}
 
+	opts, err := connect.ReadFromConfiguration(connect.DefaultConfigPath)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	// TODO(mssola): to be removed by the end of RR4.
+	connect.CFG = opts
+
 	results := searchInModules(flag.Args(), matchExact, caseSensitive)
 	if !noLocalRepos {
 		repoResults := searchInRepos(flag.Args(), matchExact, caseSensitive)

--- a/internal/connect/api_test.go
+++ b/internal/connect/api_test.go
@@ -14,6 +14,11 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// TODO(mssola): remove before finishing RR4.
+func shittyGlobalVariableNeededForNow() {
+	CFG = DefaultOptions()
+}
+
 // NOTE: Until there is a better implementation of the credentials package
 //
 //	we need to set the file creation path for SCCCredentials to /tmp
@@ -26,6 +31,8 @@ func setRootToTmp() {
 }
 
 func TestAnnounceSystem(t *testing.T) {
+	shittyGlobalVariableNeededForNow()
+
 	assert := assert.New(t)
 
 	setRootToTmp()
@@ -51,6 +58,8 @@ func TestAnnounceSystem(t *testing.T) {
 }
 
 func TestGetActivations(t *testing.T) {
+	shittyGlobalVariableNeededForNow()
+
 	assert := assert.New(t)
 	response := util.ReadTestFile("activations.json", t)
 
@@ -71,6 +80,8 @@ func TestGetActivations(t *testing.T) {
 }
 
 func TestGetActivationsRequest(t *testing.T) {
+	shittyGlobalVariableNeededForNow()
+
 	var gotRequest *http.Request
 
 	assert := assert.New(t)
@@ -102,6 +113,8 @@ func TestGetActivationsRequest(t *testing.T) {
 }
 
 func TestGetActivationsError(t *testing.T) {
+	shittyGlobalVariableNeededForNow()
+
 	assert := assert.New(t)
 
 	setRootToTmp()
@@ -118,6 +131,8 @@ func TestGetActivationsError(t *testing.T) {
 }
 
 func TestUpToDateOkay(t *testing.T) {
+	shittyGlobalVariableNeededForNow()
+
 	assert := assert.New(t)
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -130,6 +145,8 @@ func TestUpToDateOkay(t *testing.T) {
 }
 
 func TestGetProduct(t *testing.T) {
+	shittyGlobalVariableNeededForNow()
+
 	assert := assert.New(t)
 	productQuery := Product{Name: "SLES", Version: "15.2", Arch: "x86_64"}
 
@@ -150,6 +167,8 @@ func TestGetProduct(t *testing.T) {
 }
 
 func TestGetProductError(t *testing.T) {
+	shittyGlobalVariableNeededForNow()
+
 	assert := assert.New(t)
 	productQuery := Product{Name: "Dummy"}
 
@@ -168,6 +187,8 @@ func TestGetProductError(t *testing.T) {
 }
 
 func TestUpgradeProduct(t *testing.T) {
+	shittyGlobalVariableNeededForNow()
+
 	assert := assert.New(t)
 	product := Product{Name: "SUSE-MicroOS", Version: "5.0", Arch: "x86_64"}
 	expectedName := "SUSE_Linux_Enterprise_Micro_5.0_x86_64"
@@ -190,6 +211,8 @@ func TestUpgradeProduct(t *testing.T) {
 }
 
 func TestUpgradeProductError(t *testing.T) {
+	shittyGlobalVariableNeededForNow()
+
 	assert := assert.New(t)
 	product := Product{Name: "Dummy"}
 
@@ -208,6 +231,8 @@ func TestUpgradeProductError(t *testing.T) {
 }
 
 func TestDeactivateProduct(t *testing.T) {
+	shittyGlobalVariableNeededForNow()
+
 	assert := assert.New(t)
 	product := Product{Name: "sle-module-basesystem", Version: "15.2", Arch: "x86_64"}
 	expectedName := "Basesystem_Module_15_SP2_x86_64"
@@ -230,6 +255,8 @@ func TestDeactivateProduct(t *testing.T) {
 }
 
 func TestDeactivateProductSMT(t *testing.T) {
+	shittyGlobalVariableNeededForNow()
+
 	assert := assert.New(t)
 	product := Product{Name: "SUSE-MicroOS", Version: "5.0", Arch: "x86_64"}
 	expectedName := "SMT_DUMMY_NOREMOVE_SERVICE"
@@ -251,6 +278,8 @@ func TestDeactivateProductSMT(t *testing.T) {
 }
 
 func TestDeactivateProductError(t *testing.T) {
+	shittyGlobalVariableNeededForNow()
+
 	assert := assert.New(t)
 	product := Product{Name: "Dummy"}
 
@@ -269,6 +298,8 @@ func TestDeactivateProductError(t *testing.T) {
 }
 
 func TestProductMigrations(t *testing.T) {
+	shittyGlobalVariableNeededForNow()
+
 	assert := assert.New(t)
 
 	setRootToTmp()
@@ -286,6 +317,8 @@ func TestProductMigrations(t *testing.T) {
 }
 
 func TestProductMigrationsSMT(t *testing.T) {
+	shittyGlobalVariableNeededForNow()
+
 	assert := assert.New(t)
 	expectedID := 101361
 
@@ -320,6 +353,8 @@ func createTestUptimeLogFileWithContent(content string) (string, error) {
 }
 
 func TestUptimeLogFileDoesNotExist(t *testing.T) {
+	shittyGlobalVariableNeededForNow()
+
 	tempFilePath, err := createTestUptimeLogFileWithContent("")
 	if err != nil {
 		t.Fatalf("Failed to create temp uptime log file for testing")
@@ -332,6 +367,8 @@ func TestUptimeLogFileDoesNotExist(t *testing.T) {
 }
 
 func TestReadUptimeLogFile(t *testing.T) {
+	shittyGlobalVariableNeededForNow()
+
 	uptimeLogFileContent := `2024-01-18:000000000000001000110000
 2024-01-13:000000000000000000010000`
 	tempFilePath, err := createTestUptimeLogFileWithContent(uptimeLogFileContent)
@@ -358,6 +395,8 @@ func mockDetectArchitecture() {
 }
 
 func TestMakeSysInfoBody(t *testing.T) {
+	shittyGlobalVariableNeededForNow()
+
 	assert := assert.New(t)
 	expectedBody := strings.TrimSpace(string(util.ReadTestFile("api/system_information_body.json", t)))
 
@@ -377,6 +416,8 @@ func TestMakeSysInfoBody(t *testing.T) {
 }
 
 func TestSetLabelsOk(t *testing.T) {
+	shittyGlobalVariableNeededForNow()
+
 	assert := assert.New(t)
 
 	testLabels := []Label{
@@ -399,6 +440,8 @@ func TestSetLabelsOk(t *testing.T) {
 }
 
 func TestSetLabelsError(t *testing.T) {
+	shittyGlobalVariableNeededForNow()
+
 	assert := assert.New(t)
 	testLabels := []Label{
 		Label{Name: "label1"},

--- a/internal/util/system.go
+++ b/internal/util/system.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"os/user"
 	"regexp"
+	"runtime"
 	"slices"
 	"strings"
 	"syscall"
@@ -24,6 +25,9 @@ const (
 	// If we ever consider supporting these systems, then we would need to
 	// change this.
 	BTRFS_SUPER_MAGIC = 0x9123683E
+
+	// See: https://cs.opensource.google/go/go/+/master:src/internal/goos/zgoos_linux.go
+	LINUX_IDENTIFIER = "linux"
 )
 
 var systemEcho bool
@@ -199,4 +203,26 @@ func CurrentHomeDir() string {
 		}
 	}
 	return home
+}
+
+// Returns an error if the current platform is not Linux.
+//
+// NOTE: Android is considered a different platform than "Linux".
+func EnsureLinux() error {
+	if platform := runtime.GOOS; platform != LINUX_IDENTIFIER {
+		return fmt.Errorf("platform '%v' is not supported. Use Linux instead", platform)
+	}
+	return nil
+}
+
+// Ensure that this is a Linux box with Zypper installed.
+func EnsureZypper() error {
+	if err := EnsureLinux(); err != nil {
+		return err
+	}
+
+	if !ExecutableExists("zypper") {
+		return fmt.Errorf("'zypper' is not installed. Make sure it's on your PATH")
+	}
+	return nil
 }


### PR DESCRIPTION
## Description

This is the first change from RR4, and it's a matter of removing the main global variable `connect.CFG`. This is not totally true, as this PR "only" removes any frontend involvement of it. As in, the binaries on `cmd` no longer touch `connect.CFG`, and they build a new `Options` object from the API, which is modeled after the one we have in `pkg`. All of that being said, in the end we do `connect.CFG = opts`, just so the code on `internal/connect/api.go` doesn't implode.

The next PR (and the next card on the epic) is about peeling away the `internal/connect/api.go` file in favor of stuff in `pkg`, so all of this will be solved on that stage. For now, we keep the involvement of `connect.CFG` to the minimum, and we use this new `Options` struct.

Moreover, this struct is **not** the definitive thing, as it will evolve as expected from the RFC from this Epic, and it will morph with the different refactorings for this epic.

## How to test

1. Ensure that `make test` continues to work.
2. Ensure that the binaries on `out` continue to work as expected.

## Words of warning

~~I have disabled `libsuseconnect` as that relies on deleted functionality that relied on `connect.CFG`. We should evaluate whether this C interface is actually needed at all, as it's not entirely clear from my side. I'd strongly suggest current users to switch to `pkg`, as I'm not entirely sure that this `libsuseconnect` actually works at all.~~

Nevermind, fixed it.