### PR TITLE
Enhance the SAP collector

### DIFF
--- a/build/packaging/suseconnect-ng.changes
+++ b/build/packaging/suseconnect-ng.changes
@@ -3,6 +3,8 @@
  - Update error message for Public Cloud instances with registercloudguest
    installed. SUSEConnect -d is disabled on PYAG and BYOS when the
    registercloudguest command is available. (bsc#1230861)
+ - Enhanced SAP detected. Take TREX into account and remove empty values when
+   only /usr/sap but no installation exists (bsc#1241002)
 
 -------------------------------------------------------------------
 Thu Nov 14 11:01:05 UTC 2024 - Miquel Sabaté Solà <msabate@suse.com>

--- a/internal/collectors/sap_test.go
+++ b/internal/collectors/sap_test.go
@@ -110,6 +110,28 @@ func TestSAPDetectSingleWorkload(t *testing.T) {
 
 }
 
+func TestSAPRunWithLowercaseWorkload(t *testing.T) {
+	assert := assert.New(t)
+	sap := SAP{}
+
+	expected := Result{"sap": []map[string]interface{}{
+		{
+			"system_id":      "DEV",
+			"instance_types": []string{"trex", "J"},
+		},
+	}}
+
+	mockUtilFileExists(true)
+	mockLocalOsReaddir(map[string][]string{
+		"/usr/sap":     []string{"DEV", ".config"},
+		"/usr/sap/DEV": []string{"trex01", "J01"},
+	})
+
+	res, err := sap.run(ARCHITECTURE_X86_64)
+	assert.NoError(err)
+	assert.Equal(expected, res, "Result mismatch when there are workloads")
+}
+
 func TestSAPRunWithMultipleWorkloads(t *testing.T) {
 	assert := assert.New(t)
 	sap := SAP{}
@@ -129,4 +151,18 @@ func TestSAPRunWithMultipleWorkloads(t *testing.T) {
 	res, err := sap.run(ARCHITECTURE_X86_64)
 	assert.NoError(err)
 	assert.Equal(expected, res, "Result mismatch when there are workloads")
+}
+
+func TestSAPRunWithNoWorkloadDetected(t *testing.T) {
+	assert := assert.New(t)
+	sap := SAP{}
+
+	mockUtilFileExists(true)
+	mockLocalOsReaddir(map[string][]string{
+		"/usr/sap": []string{".config"},
+	})
+
+	res, err := sap.run(ARCHITECTURE_X86_64)
+	assert.NoError(err)
+	assert.Equal(NoResult, res, "Should not detect SAP")
 }


### PR DESCRIPTION
card: https://trello.com/c/tix412X1/3879-investigate-explain-and-fix-strange-sap-workload-data

- Allow lowercase directories to be checked too, since TREX is creating a lower case directory and breaking SAP own scheme
- Do not submit sap data attribute when only the directory `/usr/sap` exists.

**How to test this changes:**

```
$ docker run --rm --privileged -ti -v $(pwd):/connect registry.suse.com/bci/golang:1.21-openssl
> zypper in -y suseconnect-ng
> git config --global --add safe.directory /connect
> cd /connect && make build

# test TREX is detected
> mkdir -p /usr/sap/DEV/trex01
> ./out/suseconnect -i
# expect: trex is shown in the `sap` section

# do not send empty SAP installs
> rm -r /usr/sap/DEV
> ./out/suseconnect -i
# expect: no sap section is shown

```

**As always if you have questions, do not hesitate to reach out to me**:rocket:

**Thank you** :heart: 