### PR TITLE
bundler received a major version bump to 2.2.34 - fix feature tests

### DIFF
--- a/features/Gemfile.lock
+++ b/features/Gemfile.lock
@@ -57,4 +57,4 @@ DEPENDENCIES
   rspec (~> 3.3.0)
 
 BUNDLED WITH
-   1.16.1
+   2.2.34


### PR DESCRIPTION
We use ruby cucumber to test connect and the gem relies on bundler. Since in SUSE bundler received a major version upgrade to `2.2.34` we need to take care CI is not breaking with this change.

**How to review this merge request:**

- CI is green and feature tests are running

**As always, if you think I missed something, please let me know!**:rocket:

thank you, :heart: