### PR TITLE
Add extra data option to register and status

### DIFF
--- a/pkg/connection/connection.go
+++ b/pkg/connection/connection.go
@@ -43,12 +43,19 @@ func New(opts Options, creds Credentials) *ApiConnection {
 }
 
 func (conn ApiConnection) BuildRequest(verb string, path string, body any) (*http.Request, error) {
-	bodyData, err := json.Marshal(body)
+	buffer := bytes.Buffer{}
+
+	// Make sure we do not encode HTML data which might interfere with instance_data which can be valid
+	// XML.
+	encoder := json.NewEncoder(&buffer)
+	encoder.SetEscapeHTML(false)
+
+	err := encoder.Encode(body)
 	if err != nil {
 		return nil, err
 	}
 
-	request, err := http.NewRequest(verb, conn.Options.URL, bytes.NewReader(bodyData))
+	request, err := http.NewRequest(verb, conn.Options.URL, bytes.NewReader(buffer.Bytes()))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/registration/helpers_test.go
+++ b/pkg/registration/helpers_test.go
@@ -30,7 +30,7 @@ func fixture(t *testing.T, path string) []byte {
 
 }
 
-func matchBody(t *testing.T, body string) func(mock.Arguments) {
+func matchBody(t *testing.T, testBody string) func(mock.Arguments) {
 	assert := assert.New(t)
 
 	return func(args mock.Arguments) {
@@ -38,7 +38,7 @@ func matchBody(t *testing.T, body string) func(mock.Arguments) {
 		body, readErr := io.ReadAll(request.Body)
 
 		assert.NoError(readErr)
-		assert.Equal(strings.TrimSpace(string(body)), string(body), "request.Body matches")
+		assert.Equal(strings.TrimSpace(string(body)), strings.TrimSpace(testBody), "request.Body does not match")
 	}
 }
 
@@ -50,7 +50,7 @@ func checkAuthByRegcode(t *testing.T, regcode string) func(mock.Arguments) {
 		token := request.Header.Get("Authorization")
 
 		expected := fmt.Sprintf("Token token=%s", regcode)
-		assert.Equal(expected, token, "regcode is set as authorization header")
+		assert.Equal(expected, token, "regcode is not set as authorization header")
 	}
 }
 
@@ -63,6 +63,6 @@ func checkAuthBySystemCredentials(t *testing.T, login, password string) func(moc
 		token := request.Header.Get("Authorization")
 
 		expected := fmt.Sprintf("Basic %s", encoded)
-		assert.Equal(expected, token, "system credentials are set as authorization header")
+		assert.Equal(expected, token, "system credentials are not set as authorization header")
 	}
 }

--- a/pkg/registration/status.go
+++ b/pkg/registration/status.go
@@ -18,16 +18,22 @@ const (
 )
 
 type statusRequest struct {
-	Hostname string            `json:"hostname"`
-	Info     SystemInformation `json:"hwinfo"`
+	Hostname string `json:"hostname"`
+
+	requestWithInformation
 }
 
 // Returns the registration status for the system pointed by the authorized
 // connection.
-func Status(conn connection.Connection, hostname string, info SystemInformation) (StatusCode, error) {
+func Status(conn connection.Connection, hostname string, systemInformation SystemInformation, extraData ExtraData) (StatusCode, error) {
 	payload := statusRequest{
 		Hostname: hostname,
-		Info:     info,
+	}
+
+	enrichWithSystemInformation(&payload.requestWithInformation, systemInformation)
+	enrichErr := enrichWithExtraData(&payload.requestWithInformation, extraData)
+	if enrichErr != nil {
+		return 0, enrichErr
 	}
 
 	request, buildErr := conn.BuildRequest("PUT", "/connect/systems", payload)

--- a/pkg/registration/system_information.go
+++ b/pkg/registration/system_information.go
@@ -1,5 +1,61 @@
 package registration
 
+import "fmt"
+
 // SystemInformation encapsulates any data which should be stored as system meta information.
 // This can be sockets, vCPUs, memory or any other useful information.
 type SystemInformation = map[string]any
+
+// Indicates there is no system information available when registering.
+// Example:
+//
+//	registration.Register(conn, "hostname", "regcode", NoSystemInformation, NoExtraData)
+//
+// Note: If possible make sure to include system information whenever possible
+var NoSystemInformation = map[string]any{}
+
+// ExtraData encapsulates additional data which might be required to be sent along with the
+// request. This can be cloud instance data or online times of the system, depending on the
+// requirements.
+// Available ExtraData keys are:
+//   - instance data (string): Information provided by a cloud instance (Cloud)
+//   - namespace (string): Namespace in which the API operates (SMT)
+//   - online_at ([]string): OnlineAt definition which records hourly usage time of the system (Cloud)
+type ExtraData = map[string]any
+
+// Use NoExtraData when no extra information is used by the registration or status method.
+// Example:
+//
+//	registration.Register(conn, "regcode", "hostname", NoSystemInformation, NoExtraData)
+var NoExtraData = map[string]any{}
+
+type requestWithInformation struct {
+	SystemInformation any      `json:"hwinfo"`
+	InstanceData      string   `json:"instance_data,omitempty"`
+	Namespace         string   `json:"namespace,omitempty"`
+	OnlineAt          []string `json:"online_at,omitempty"`
+}
+
+func enrichWithSystemInformation(payload *requestWithInformation, info SystemInformation) {
+	payload.SystemInformation = info
+}
+
+func enrichWithExtraData(payload *requestWithInformation, extraData ExtraData) error {
+	for key, value := range extraData {
+		converted := false
+
+		switch key {
+		case "instance_data":
+			payload.InstanceData, converted = value.(string)
+		case "namespace":
+			payload.Namespace, converted = value.(string)
+		case "online_at":
+			payload.OnlineAt, converted = value.([]string)
+		}
+
+		if !converted {
+			return fmt.Errorf("Could not parse extra data attribute `%s`. This is a bug.", key)
+		}
+	}
+	return nil
+}

--- a/testdata/pkg/registration/register_with_extra_data.json
+++ b/testdata/pkg/registration/register_with_extra_data.json
@@ -1,0 +1,1 @@
+{"hostname":"hostname","hwinfo":{},"instance_data":"<document>{\"instanceId\": \"dummy_instance_data\"}</document>","namespace":"staging-sles","online_at":["12122025:000000000000000000000000","11122025:000000000000000000000000","10122025:000000000000000000000000"]}

--- a/testdata/pkg/registration/register_with_system_information.json
+++ b/testdata/pkg/registration/register_with_system_information.json
@@ -1,0 +1,1 @@
+{"hostname":"hostname","hwinfo":{"cpus":3,"sap":[{"instance_types":["ASCS"],"system_id":"DEV"}],"sockets":3}}

--- a/testdata/pkg/registration/status_with_extra_data.json
+++ b/testdata/pkg/registration/status_with_extra_data.json
@@ -1,0 +1,1 @@
+{"hostname":"test-hostname","hwinfo":{},"instance_data":"<document>{\"instanceId\": \"dummy_instance_data\"}</document>","namespace":"staging-sles","online_at":["12122025:000000000000000000000000","11122025:000000000000000000000000","10122025:000000000000000000000000"]}


### PR DESCRIPTION
card: https://trello.com/c/obMObgvt/3899-rr4-instance-data-support-is-in-the-public-library

This merge requests, add support for `instanceData` and all the other optional attributes we might want to send along with a registration or status request.

**How to test changes:**

You need to test this:
 * connect code base with branch checked out
 * mitmproxy (HINT: If you use mise `mise use mitmproxy`)
 * A regcode

```
$ docker run --rm --privileged --network host -ti -v $(pwd):/connect registry.suse.com/bci/golang:1.21-openssl
> cd /connect
> git config --global --add safe.directory /connect
> make build

# In another console
$ mitmdump --mode reverse:https://scc.suse.com -p 7000 --set flow_detail=3

# Run with a regcode
> SCC_URL="http://localhost:7000" REGCODE="<regcode>" ./out/public-api-demo SLES 15.6 x86_64
# Hit enter until you reach step 5 completed.

# expect: See that the request `PUT https://scc.suse.com/connect/systems` includes `instance_data`

127.0.0.1:41462: PUT https://scc.suse.com/connect/systems
    Host: scc.suse.com
    User-Agent: public-api-demo/1.0
    Content-Length: 117
    Accept: application/json,application/vnd.scc.suse.com.v4+json
    Accept-Language: DE
    Content-Type: application/json
    System-Token: 003ff9ee-6b4d-46a7-bdd7-aa90dc7bad63
    Accept-Encoding: gzip

    {
        "hostname": "public-api-demo",
        "hwinfo": {
            "uname": "public api demo - ping"
        },
        "instance_data": "<document>{}</document>"
    }

```

**As always, do not hesitate to reach out,  if you have questions, feedback or anything else**:rocket:

Thank you! :heart: