### PR TITLE
Add label support to the library

### DIFF
--- a/cmd/public-api-demo/credentials.go
+++ b/cmd/public-api-demo/credentials.go
@@ -6,6 +6,7 @@ type SccCredentials struct {
 	SystemLogin string
 	Password    string
 	SystemToken string
+	ShowTraces  bool
 }
 
 func (SccCredentials) HasAuthentication() bool {
@@ -13,12 +14,16 @@ func (SccCredentials) HasAuthentication() bool {
 }
 
 func (creds *SccCredentials) Token() (string, error) {
-	fmt.Printf("<- fetch token %s\n", creds.SystemToken)
+	if creds.ShowTraces {
+		fmt.Printf("<- fetch token %s\n", creds.SystemToken)
+	}
 	return creds.SystemToken, nil
 }
 
 func (creds *SccCredentials) UpdateToken(token string) error {
-	fmt.Printf("-> update token %s\n", token)
+	if creds.ShowTraces {
+		fmt.Printf("-> update token %s\n", token)
+	}
 	creds.SystemToken = token
 	return nil
 }
@@ -27,12 +32,17 @@ func (creds *SccCredentials) Login() (string, string, error) {
 	if creds.SystemLogin == "" || creds.Password == "" {
 		return "", "", fmt.Errorf("login credentials not set")
 	}
-	fmt.Printf("<- fetch login %s\n", creds.SystemLogin)
+
+	if creds.ShowTraces {
+		fmt.Printf("<- fetch login %s\n", creds.SystemLogin)
+	}
 	return creds.SystemLogin, creds.Password, nil
 }
 
 func (creds *SccCredentials) SetLogin(login, password string) error {
-	fmt.Printf("-> set login %s\n", login)
+	if creds.ShowTraces {
+		fmt.Printf("-> set login %s\n", login)
+	}
 	creds.SystemLogin = login
 	creds.Password = password
 	return nil

--- a/internal/testutil/connection_mock.go
+++ b/internal/testutil/connection_mock.go
@@ -1,0 +1,56 @@
+package testutil
+
+import (
+	"net/http"
+
+	"github.com/SUSE/connect-ng/pkg/connection"
+	"github.com/stretchr/testify/mock"
+)
+
+type MockConnection struct {
+	mock.Mock
+	real connection.Connection
+}
+
+func MockConnectionWithCredentials() (*MockConnection, *MockCredentials) {
+	creds := &MockCredentials{}
+	conn := NewMockConnection(creds, "testing")
+
+	creds.On("Token").Return("sample-token", nil)
+	creds.On("Login").Return("sample-login", "sample-password", nil)
+
+	creds.On("UpdateToken", mock.Anything).Return(nil)
+
+	conn.On("GetCredentials").Return(creds)
+
+	return conn, creds
+}
+
+func NewMockConnection(creds connection.Credentials, hostname string) *MockConnection {
+	opts := connection.DefaultOptions("testing", "---", "---")
+	opts.URL = "http://local-testing/"
+
+	conn := connection.New(opts, creds)
+
+	return &MockConnection{
+		real: conn,
+	}
+}
+
+func (m *MockConnection) BuildRequest(verb, path string, body any) (*http.Request, error) {
+
+	request, err := m.real.BuildRequest(verb, path, body)
+	return request, err
+}
+
+func (m *MockConnection) Do(request *http.Request) ([]byte, error) {
+	args := m.Called(request)
+
+	return args.Get(0).([]byte), args.Error(1)
+}
+
+func (m *MockConnection) GetCredentials() connection.Credentials {
+	args := m.Called()
+
+	return args.Get(0).(connection.Credentials)
+}

--- a/internal/testutil/credential_mock.go
+++ b/internal/testutil/credential_mock.go
@@ -1,0 +1,32 @@
+package testutil
+
+import "github.com/stretchr/testify/mock"
+
+type MockCredentials struct {
+	mock.Mock
+}
+
+func (m *MockCredentials) HasAuthentication() bool {
+	args := m.Called()
+	return args.Bool(0)
+}
+
+func (m *MockCredentials) Login() (string, string, error) {
+	args := m.Called()
+	return args.String(0), args.String(1), args.Error(2)
+}
+
+func (m *MockCredentials) SetLogin(login, password string) error {
+	args := m.Called(login, password)
+	return args.Error(0)
+}
+
+func (m *MockCredentials) Token() (string, error) {
+	args := m.Called()
+	return args.String(0), args.Error(1)
+}
+
+func (m *MockCredentials) UpdateToken(token string) error {
+	args := m.Called(token)
+	return args.Error(0)
+}

--- a/internal/testutil/helpers.go
+++ b/internal/testutil/helpers.go
@@ -1,0 +1,78 @@
+package testutil
+
+import (
+	"encoding/base64"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func Fixture(t *testing.T, path string) []byte {
+	t.Helper()
+
+	absolut, pathErr := filepath.Abs(filepath.Join("../../testdata", path))
+	if pathErr != nil {
+		t.Fatalf("Could not build fixture path from %s", path)
+	}
+
+	data, err := os.ReadFile(absolut)
+	if err != nil {
+		t.Fatalf("Could not read fixture: %s", err)
+	}
+	return data
+
+}
+
+func MatchEmptyBody(t *testing.T) func(mock.Arguments) {
+	assert := assert.New(t)
+
+	return func(args mock.Arguments) {
+		request := args.Get(0).(*http.Request)
+		assert.Equal(nil, request.Body, "request.Body is not empty")
+	}
+
+}
+
+func MatchBody(t *testing.T, expected string) func(mock.Arguments) {
+	assert := assert.New(t)
+
+	return func(args mock.Arguments) {
+		request := args.Get(0).(*http.Request)
+		body, readErr := io.ReadAll(request.Body)
+
+		assert.NoError(readErr)
+		assert.Equal(strings.TrimSpace(string(expected)), strings.TrimSpace(string(body)), "request.Body does not match")
+	}
+}
+
+func CheckAuthByRegcode(t *testing.T, regcode string) func(mock.Arguments) {
+	assert := assert.New(t)
+
+	return func(args mock.Arguments) {
+		request := args.Get(0).(*http.Request)
+		token := request.Header.Get("Authorization")
+
+		expected := fmt.Sprintf("Token token=%s", regcode)
+		assert.Equal(expected, token, "regcode is not set as authorization header")
+	}
+}
+
+func CheckAuthBySystemCredentials(t *testing.T, login, password string) func(mock.Arguments) {
+	assert := assert.New(t)
+	encoded := base64.StdEncoding.EncodeToString([]byte(login + ":" + password))
+
+	return func(args mock.Arguments) {
+		request := args.Get(0).(*http.Request)
+		token := request.Header.Get("Authorization")
+
+		expected := fmt.Sprintf("Basic %s", encoded)
+		assert.Equal(expected, token, "system credentials are not set as authorization header")
+	}
+}

--- a/pkg/connection/connection.go
+++ b/pkg/connection/connection.go
@@ -43,19 +43,23 @@ func New(opts Options, creds Credentials) *ApiConnection {
 }
 
 func (conn ApiConnection) BuildRequest(verb string, path string, body any) (*http.Request, error) {
+	var reader io.Reader
 	buffer := bytes.Buffer{}
 
-	// Make sure we do not encode HTML data which might interfere with instance_data which can be valid
-	// XML.
-	encoder := json.NewEncoder(&buffer)
-	encoder.SetEscapeHTML(false)
+	if body != nil {
+		// Make sure we do not encode HTML data which might interfere with instance_data which can be valid
+		// XML.
+		encoder := json.NewEncoder(&buffer)
+		encoder.SetEscapeHTML(false)
 
-	err := encoder.Encode(body)
-	if err != nil {
-		return nil, err
+		err := encoder.Encode(body)
+		if err != nil {
+			return nil, err
+		}
+		reader = bytes.NewReader(buffer.Bytes())
 	}
 
-	request, err := http.NewRequest(verb, conn.Options.URL, bytes.NewReader(buffer.Bytes()))
+	request, err := http.NewRequest(verb, conn.Options.URL, reader)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/labels/assign.go
+++ b/pkg/labels/assign.go
@@ -1,0 +1,44 @@
+package labels
+
+import (
+	"encoding/json"
+
+	"github.com/SUSE/connect-ng/pkg/connection"
+)
+
+type assignLabelsRequestResponse struct {
+	Labels []Label `json:"labels"`
+}
+
+// Assign manages labels in SCC. It is possible to set labels and alter them.
+// Supplying already existing labels will not recreate them. Labels not
+// existing in SCC will get created automatically.
+func AssignLabels(conn connection.Connection, labels []Label) ([]Label, error) {
+	updated := []Label{}
+	payload := assignLabelsRequestResponse{
+		Labels: labels,
+	}
+
+	request, buildErr := conn.BuildRequest("POST", "/connect/systems/labels", payload)
+	if buildErr != nil {
+		return []Label{}, buildErr
+	}
+
+	login, password, credErr := conn.GetCredentials().Login()
+	if credErr != nil {
+		return []Label{}, credErr
+	}
+
+	connection.AddSystemAuth(request, login, password)
+
+	response, doErr := conn.Do(request)
+	if doErr != nil {
+		return []Label{}, doErr
+	}
+
+	if err := json.Unmarshal(response, &updated); err != nil {
+		return []Label{}, err
+	}
+
+	return updated, nil
+}

--- a/pkg/labels/assign_test.go
+++ b/pkg/labels/assign_test.go
@@ -1,0 +1,34 @@
+package labels
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	"github.com/SUSE/connect-ng/internal/testutil"
+)
+
+func TestAssignLabelSuccess(t *testing.T) {
+	assert := assert.New(t)
+
+	conn, _ := testutil.MockConnectionWithCredentials()
+
+	labels := []Label{
+		Label{Name: "label1", Description: "label1 description"},
+		Label{Name: "label2"},
+	}
+
+	// 204 No Content
+	response := testutil.Fixture(t, "pkg/labels/assign_labels_success.json")
+	body := testutil.Fixture(t, "pkg/labels/assign_labels_body.json")
+
+	conn.On("Do", mock.Anything).Return(response, nil).Run(testutil.MatchBody(t, string(body)))
+
+	fetchedLabels, err := AssignLabels(conn, labels)
+	assert.NoError(err)
+	assert.Len(fetchedLabels, 2)
+	assert.Equal("label2", fetchedLabels[1].Name)
+
+	conn.AssertExpectations(t)
+}

--- a/pkg/labels/label.go
+++ b/pkg/labels/label.go
@@ -1,0 +1,8 @@
+package labels
+
+// A label represents a system label in SCC which can be assigned and unassigned from a system using the library
+type Label struct {
+	Id          int    `json:"id,omitempty"`
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+}

--- a/pkg/labels/list.go
+++ b/pkg/labels/list.go
@@ -1,0 +1,35 @@
+package labels
+
+import (
+	"encoding/json"
+
+	"github.com/SUSE/connect-ng/pkg/connection"
+)
+
+// ListLabels fetches the currently assigned labels for this system in SCC.
+func ListLabels(conn connection.Connection) ([]Label, error) {
+	labels := []Label{}
+
+	request, buildErr := conn.BuildRequest("GET", "/connect/systems/labels", nil)
+	if buildErr != nil {
+		return []Label{}, buildErr
+	}
+
+	login, password, credErr := conn.GetCredentials().Login()
+	if credErr != nil {
+		return []Label{}, credErr
+	}
+
+	connection.AddSystemAuth(request, login, password)
+
+	response, doErr := conn.Do(request)
+	if doErr != nil {
+		return []Label{}, doErr
+	}
+
+	if err := json.Unmarshal(response, &labels); err != nil {
+		return []Label{}, err
+	}
+
+	return labels, nil
+}

--- a/pkg/labels/list_test.go
+++ b/pkg/labels/list_test.go
@@ -1,0 +1,27 @@
+package labels
+
+import (
+	"testing"
+
+	"github.com/SUSE/connect-ng/internal/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestListLabels(t *testing.T) {
+	assert := assert.New(t)
+
+	conn, _ := testutil.MockConnectionWithCredentials()
+
+	// 204 No Content
+	response := testutil.Fixture(t, "pkg/labels/list_labels_success.json")
+
+	conn.On("Do", mock.Anything).Return(response, nil).Run(testutil.MatchEmptyBody(t))
+
+	labels, err := ListLabels(conn)
+	assert.NoError(err)
+	assert.Len(labels, 3)
+	assert.Equal("label2", labels[1].Name)
+
+	conn.AssertExpectations(t)
+}

--- a/pkg/labels/unassign.go
+++ b/pkg/labels/unassign.go
@@ -1,0 +1,40 @@
+package labels
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/SUSE/connect-ng/pkg/connection"
+)
+
+// UnassignLabel removes a label from a system in SCC. The label itself will not get
+// deleted from the account.
+// If the label should be deleted, have a look into the organization API of SCC.
+// see: https://scc.suse.com/connect/v4/documentation#/organizations/delete_organizations_labels__id_
+func UnassignLabel(conn connection.Connection, labelId int) ([]Label, error) {
+	labels := []Label{}
+	url := fmt.Sprintf("/connect/systems/labels/%d", labelId)
+
+	request, buildErr := conn.BuildRequest("DELETE", url, nil)
+	if buildErr != nil {
+		return []Label{}, buildErr
+	}
+
+	login, password, credErr := conn.GetCredentials().Login()
+	if credErr != nil {
+		return []Label{}, credErr
+	}
+
+	connection.AddSystemAuth(request, login, password)
+
+	response, doErr := conn.Do(request)
+	if doErr != nil {
+		return []Label{}, doErr
+	}
+
+	if err := json.Unmarshal(response, &labels); err != nil {
+		return []Label{}, err
+	}
+
+	return labels, nil
+}

--- a/pkg/labels/unassign_test.go
+++ b/pkg/labels/unassign_test.go
@@ -1,0 +1,43 @@
+package labels
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	"github.com/SUSE/connect-ng/internal/testutil"
+)
+
+func TestUnassignLabelSuccess(t *testing.T) {
+	assert := assert.New(t)
+
+	conn, _ := testutil.MockConnectionWithCredentials()
+
+	// 204 No Content
+	response := testutil.Fixture(t, "pkg/labels/unassign_label_success.json")
+	conn.On("Do", mock.Anything).Return(response, nil).Run(testutil.MatchEmptyBody(t))
+
+	remainingLabels, err := UnassignLabel(conn, 2)
+	assert.NoError(err)
+	assert.Len(remainingLabels, 1)
+	assert.Equal("label1", remainingLabels[0].Name)
+
+	conn.AssertExpectations(t)
+}
+
+func TestUnassignLabelUnknownId(t *testing.T) {
+	assert := assert.New(t)
+
+	conn, _ := testutil.MockConnectionWithCredentials()
+
+	// 204 No Content
+	response := testutil.Fixture(t, "pkg/labels/unassign_label_failed.json")
+	conn.On("Do", mock.Anything).Return(response, fmt.Errorf("Couldn't find Label with 'id'=1337"))
+
+	_, err := UnassignLabel(conn, 1337)
+	assert.ErrorContains(err, "Couldn't find Label")
+
+	conn.AssertExpectations(t)
+}

--- a/testdata/pkg/labels/assign_labels_body.json
+++ b/testdata/pkg/labels/assign_labels_body.json
@@ -1,0 +1,1 @@
+{"labels":[{"name":"label1","description":"label1 description"},{"name":"label2"}]}

--- a/testdata/pkg/labels/assign_labels_success.json
+++ b/testdata/pkg/labels/assign_labels_success.json
@@ -1,0 +1,11 @@
+[
+  {
+    "id": 1,
+    "name": "label1",
+    "description": "label1 description"
+  },
+  {
+    "id": 2,
+    "name": "label2"
+  }
+]

--- a/testdata/pkg/labels/list_labels_success.json
+++ b/testdata/pkg/labels/list_labels_success.json
@@ -1,0 +1,15 @@
+[
+  {
+    "id": 3,
+    "name": "label1",
+    "description": "label1 description"
+  },
+  {
+    "id": 8,
+    "name": "label2"
+  },
+  {
+    "id": 12,
+    "name": "label3"
+  }
+]

--- a/testdata/pkg/labels/unassign_label_failed.json
+++ b/testdata/pkg/labels/unassign_label_failed.json
@@ -1,0 +1,5 @@
+{
+  "type": "error",
+  "error": "Couldn't find Label with 'id'=10000000000000",
+  "localized_error": "Couldn't find Label with 'id'=10000000000000"
+}

--- a/testdata/pkg/labels/unassign_label_success.json
+++ b/testdata/pkg/labels/unassign_label_success.json
@@ -1,0 +1,7 @@
+[
+  {
+    "id": 1,
+    "name": "label1",
+    "description": "label1 description"
+  }
+]


### PR DESCRIPTION
card: https://trello.com/c/FiOiNbBa/3918-rr4-add-label-support-to-the-library

This merge request adds labeling support to the public library. This further enhances the library but is mainly required to successfully port SUSEConnect to consume the library.

**How to review this merge request:***

```
$ docker run --rm --privileged --network host -ti -v $(pwd):/connect registry.suse.com/bci/golang:1.21-openssl
> cd /connect
> git config --global --add safe.directory /connect
> make build

> REGCODE=<regcode> ./out/public-api-demo SLES 16.0 x86_64
# enter and more enter until you reach step 7 which show cases the labeling feature.
# expect: Labels to be set in SCC
# enter to unassign labels
# expect: One label to be removed

```

Note: I added `internal/testutil` where I moved all the test helpers. In a follow up PR I move all helpers into this place and update tests accordingly. I did not want to pollute this PR even more!

**As always, if you have any question, feedback or anything else. Please, do not hesitate to reach out to me!**:rocket:

Thank you! :heart: