### PR TITLE
Add missing pkg/ directory bundling directive

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ all: clean build test
 dist: clean internal/connect/version.txt vendor
 	@mkdir -p $(DIST)/build/packaging
 	@cp -r internal $(DIST)
+	@cp -r pkg $(DIST)
 	@cp -r third_party $(DIST)
 	@cp -r cmd $(DIST)
 	@cp -r docs $(DIST)


### PR DESCRIPTION
Its now needed when we want to build against the library when building rpms