### PR TITLE
Fix broken documentation links in --list-extensions

### DIFF
--- a/build/packaging/suseconnect-ng.changes
+++ b/build/packaging/suseconnect-ng.changes
@@ -5,6 +5,7 @@
    registercloudguest command is available. (bsc#1230861)
  - Enhanced SAP detected. Take TREX into account and remove empty values when
    only /usr/sap but no installation exists (bsc#1241002)
+ - Fixed modules and extension link to point to version less documentation. (bsc#1239439)
 
 -------------------------------------------------------------------
 Thu Nov 14 11:01:05 UTC 2024 - Miquel Sabaté Solà <msabate@suse.com>

--- a/features/extension_activation.feature
+++ b/features/extension_activation.feature
@@ -12,7 +12,7 @@ Feature: Test extension/module activation
     And the output should contain "Legacy Module"
     And the output should contain "Public Cloud Module"
     And the output should contain "SUSE Linux Enterprise High Availability Extension"
-    And the output should contain "https://www.suse.com/documentation/sles-15/singlehtml/art_modules/art_modules.html"
+    And the output should contain "https://documentation.suse.com/sles/html/SLES-all/article-modules.html"
 
   # Skip in SLES15 for now, since there's no paid extensions that can be activated
   # directly on the root product. Once SUSEConnect automatically activates recommended

--- a/internal/connect/extension-list.tmpl
+++ b/internal/connect/extension-list.tmpl
@@ -11,4 +11,4 @@
 {{"\x1b[1m"}}MORE INFORMATION{{"\x1b[0m"}}
 
 You can find more information about available modules here:
-https://www.suse.com/documentation/sles-15/singlehtml/art_modules/art_modules.html
+https://documentation.suse.com/sles/html/SLES-all/article-modules.html


### PR DESCRIPTION
card: https://trello.com/c/FTnm1OZN/5517-connect-sles-16-show-correct-link-to-documentation-depending-on-the-base-system

Fixed the link to point to the versionless documentation page regarding modules and extensions.

part of: bsc#1239439

**How to review this merge request:**

```
$ docker run --rm --privileged -ti -v $(pwd):/connect registry.suse.com/bci/golang:1.21-openssl
> cd /connect
> git config --global --add safe.directory /connect
> make build
> ./out/suseconnect -r <regcode>
> ./out/suseconnect --list-extensions
# expect: To see the link https://documentation.suse.com/sles/html/SLES-all/article-modules.html at the bottom
```

**As always, if you have questions about anything in the merge request, do not hesitate to reach out to me!**:rocket:

Thank you :heart: