### PR TITLE
Temporary fix proxy detection

### DIFF
--- a/internal/connect/connection.go
+++ b/internal/connect/connection.go
@@ -159,6 +159,8 @@ func callHTTP(verb, path string, body []byte, query map[string]string, auth auth
 	// configuration, we can actually further inspect it via some of the headers
 	// that are returned by Glue vs RMT. Hence, if the server type is unknown,
 	// make an educated guess now.
+	// FIXME: or remove this. This fails when the request was not successful (none 2xx)
+	//        since SCC does not return the Scc-Api-Version on error cases.
 	if CFG.ServerType == UnknownProvider {
 		if api := resp.Header.Get("Scc-Api-Version"); api == sccAPIVersion {
 			CFG.ServerType = SccProvider


### PR DESCRIPTION
card: https://trello.com/c/QxBSnLYB/3864-rr4-suseconnect-move-away-from-the-internal-package-for-api-related-things

This change makes sure the logic is kept for the `IsOutdatedRegProxy`. Before the implementation was `IsUpToDate` which is semantically the inverse of `IsOutdated`. The return values need to be inverted now as well.

**How to test this merge request:**

```
$ cd <connect branch>
$ docker run --rm --privileged  -ti -v $(pwd):/connect registry.suse.com/bci/golang:1.21-openssl
> cd /connect
> git config --global --add safe.directory /connect
> make build

# run suseconnect to make sure it is working as expected:
> ./out/suseconnect -r <regcode>
# expect: Working as usually
# Now trying to activate a product which requires an additional registration code
> ./out/suseconnect -p sle-ha/15.6/x86_64
# expect no to see:
# `Your Registration Proxy server doesn't support this function.`
# but expect to see:
# `Error: Registration server returned 'Please provide a Registration Code for this product'`

# cleanup
> ./out/suseconnect -d

```

**As always, if you think I missed something or anything is unclear. Please do not hesitate to reach out to me!**:rocket:

Thank you! :heart: