### PR TITLE
Do not show none JSON formated output when the JSON flag is set

### DIFF
--- a/cmd/suseconnect/suseconnect.go
+++ b/cmd/suseconnect/suseconnect.go
@@ -204,6 +204,11 @@ func main() {
 		})
 	}
 
+	// Set the JSON output specifier early on so all later usages can access this information
+	if jsonFlag {
+		opts.OutputKind = connect.JSON
+	}
+
 	// Reading the configuration/flags is done, now let's check if the
 	// filesystem can handle operations from SUSEConnect for specific actions
 	// which require filesystem to be read write (aka writing outside of /etc)

--- a/internal/connect/client.go
+++ b/internal/connect/client.go
@@ -52,7 +52,10 @@ func Register(opts *Options) error {
 	out := &RegisterOut{}
 	api := NewWrappedAPI(opts)
 
-	printInformation(fmt.Sprintf("Registering system to %s", opts.ServerName()), opts)
+	if opts.OutputKind != JSON {
+		printInformation(fmt.Sprintf("Registering system to %s", opts.ServerName()), opts)
+	}
+
 	if err := api.RegisterOrKeepAlive(opts.Token); err != nil {
 		return err
 	}

--- a/pkg/connection/api_error.go
+++ b/pkg/connection/api_error.go
@@ -16,9 +16,9 @@ type ApiError struct {
 
 func (ae *ApiError) Error() string {
 	if ae.LocalizedMessage != "" {
-		return fmt.Sprintf("API error: %v (code: %v)", ae.LocalizedMessage, ae.Code)
+		return fmt.Sprintf("Error: Registration server returned '%v' (%d)", ae.LocalizedMessage, ae.Code)
 	}
-	return fmt.Sprintf("API error: %v (code: %v)", ae.Message, ae.Code)
+	return fmt.Sprintf("Error: Registration server returned '%v' (%d)", ae.Message, ae.Code)
 }
 
 // Returns a new ApiError from the given response if it contained an API error


### PR DESCRIPTION
card: https://trello.com/c/QxBSnLYB/3864-rr4-suseconnect-move-away-from-the-internal-package-for-api-related-things

This fixes the JSON output issue showing `Registering system to...` even when the JSON output is specified and thus breaking JSON parsing.

I also aligned the error message formatting with what we currently have in SUSEConnect.
I believe the best way would be to move the whole formatting out of the library and move it into `internal`. This way all applications decide on their own how to display error messages rather we have a fixed message. BUT this is not for today.

**How to review this merge request:**

```
$ cd <connect branch>
$ docker run --rm --privileged  -ti -v $(pwd):/connect registry.suse.com/bci/golang:1.21-openssl
> cd /connect
> git config --global --add safe.directory /connect
> make build

> ./out/suseconnect --json -r IMNOTEXISTINGANDWILLFAIL
# expect pure json output without any none JSON strings in the output.
```