### PR TITLE
Add ToTriplet method to Activation and Product.

### DIFF
--- a/pkg/registration/activation.go
+++ b/pkg/registration/activation.go
@@ -21,6 +21,11 @@ type Activation struct {
 	Product  *Product
 }
 
+// Returns the activations triplet identifier.
+func (a *Activation) ToTriplet() string {
+	return a.Product.ToTriplet()
+}
+
 type activationResponse struct {
 	Activation
 	MetadataAndProduct activateResponse `json:"service"`

--- a/pkg/registration/activation_test.go
+++ b/pkg/registration/activation_test.go
@@ -29,6 +29,7 @@ func TestFetchProductActivations(t *testing.T) {
 	}
 	assert.Equal("15.6", sles.Product.Version)
 	assert.Equal("SUSE_Linux_Enterprise_Server_15_SP6_x86_64", sles.Metadata.Name)
+	assert.Equal("SLES/15.6/x86_64", sles.ToTriplet())
 }
 
 func TestFetchProductActivationsEmpty(t *testing.T) {

--- a/pkg/registration/product.go
+++ b/pkg/registration/product.go
@@ -37,9 +37,14 @@ type Product struct {
 // If true is returned, traversal is continued.
 type TraverseFunc func(product Product) (bool, error)
 
+// Returns the products triplet identifier.
+func (p *Product) ToTriplet() string {
+	return p.Identifier + "/" + p.Version + "/" + p.Arch
+}
+
 // TraverseExtensions traverse through the products extensions and theirs extensions.
 // When TraverseFunc returns false, the full product and its extensions are skipped.
-func (pro Product) TraverseExtensions(fn TraverseFunc) error {
+func (pro *Product) TraverseExtensions(fn TraverseFunc) error {
 	for _, extension := range pro.Extensions {
 		doContinue, fnErr := fn(extension)
 

--- a/pkg/registration/product_test.go
+++ b/pkg/registration/product_test.go
@@ -9,6 +9,16 @@ import (
 	"github.com/stretchr/testify/mock"
 )
 
+func TestProductToTriplet(t *testing.T) {
+	assert := assert.New(t)
+
+	productJson := fixture(t, "pkg/registration/product_tree.json")
+	product := Product{}
+
+	assert.NoError(json.Unmarshal(productJson, &product))
+	assert.Equal("SLES/15.5/x86_64", product.ToTriplet())
+}
+
 func TestProductTraverseExtensionsFull(t *testing.T) {
 	assert := assert.New(t)
 


### PR DESCRIPTION
card: https://trello.com/c/QxBSnLYB/3864-rr4-suseconnect-move-away-from-the-internal-package-for-api-related-things

This moves the triplet creation from the `next` branch into the `main` branch and fixes using the `Identifier` rather then `Name` to create triplets on the fly.

**How to test this merge request:**

- Check the code..

**As always, if you think I missed something or you have questions regarding test setup. Please do not hesitate to reach out to me!**:rocket:

Thank you :heart:,