### PR TITLE
Convert library based errors into internal connect based errors

### DIFF
--- a/internal/connect/errors.go
+++ b/internal/connect/errors.go
@@ -3,6 +3,8 @@ package connect
 import (
 	"errors"
 	"fmt"
+
+	"github.com/SUSE/connect-ng/pkg/connection"
 )
 
 // export errors that package main needs
@@ -21,6 +23,26 @@ type APIError struct {
 
 func (ae APIError) Error() string {
 	return fmt.Sprintf("Error: Registration server returned '%s' (%d)", ae.Message, ae.Code)
+}
+
+// This method converts connection.ApiError into connect.APIError to not have to deal
+// with the same error classes with different namespaces.
+func ToAPIError(in error) error {
+	if in == nil {
+		return nil
+	}
+
+	if err, ok := in.(*connection.ApiError); ok {
+		return APIError{
+			Message: err.Error(),
+			Code:    err.Code,
+		}
+	}
+
+	return APIError{
+		Message: in.Error(),
+		Code:    -1,
+	}
 }
 
 // JSONError is returned on failed JSON decoding

--- a/internal/connect/wrapper.go
+++ b/internal/connect/wrapper.go
@@ -77,7 +77,7 @@ func (w Wrapper) KeepAlive() error {
 	if code != registration.Registered {
 		return fmt.Errorf("trying to send a keepalive from a system not yet registered. Register this system first")
 	}
-	return err
+	return ToAPIError(err)
 }
 
 func (w Wrapper) Register(regcode string) error {
@@ -89,7 +89,7 @@ func (w Wrapper) Register(regcode string) error {
 
 	// TODO: do something with the code
 	_, err = registration.Register(w.Connection, regcode, hostname, hwinfo, registration.NoExtraData)
-	return err
+	return ToAPIError(err)
 }
 
 // RegisterOrKeepAlive calls either `Register` or `KeepAlive` depending on


### PR DESCRIPTION
card: https://trello.com/c/QxBSnLYB/3864-rr4-suseconnect-move-away-from-the-internal-package-for-api-related-things

Wrapper should take care of converting `connection.ApiError` into `connect.APIError` to only have to deal with one type of error class within the whole SUSEConnect implementation.

This fixes issues with wrong exitcodes since error handling defaulted to `exitcode = 1` on unknown error types.

**How to test this merge request:**

```
$ cd <connect branch>
$ docker run --rm --privileged  -ti -v $(pwd):/connect registry.suse.com/bci/golang:1.21-openssl
> cd /connect
> git config --global --add safe.directory /connect
> make build

> ./out/suseconnect -r IMNOTEXISTINGANDWILLFAIL; echo $?
# expect exit code to be 67

```

**As always, if you think I missed something or you have questions regarding the changes, please do not hesitate to comment or reach out**:rocket:

Thank you :heart:,