### PR TITLE
Remove link to extensions documentation

### DIFF
--- a/build/packaging/suseconnect-ng.changes
+++ b/build/packaging/suseconnect-ng.changes
@@ -7,6 +7,7 @@
    only /usr/sap but no installation exists (bsc#1241002)
  - Fixed modules and extension link to point to version less documentation. (bsc#1239439)
  - Fixed SAP instance detection (bsc#1244550)
+ - Remove link to extensions documentation (bsc#1239439)
 
 -------------------------------------------------------------------
 Thu Nov 14 11:01:05 UTC 2024 - Miquel Sabaté Solà <msabate@suse.com>

--- a/features/extension_activation.feature
+++ b/features/extension_activation.feature
@@ -12,7 +12,6 @@ Feature: Test extension/module activation
     And the output should contain "Legacy Module"
     And the output should contain "Public Cloud Module"
     And the output should contain "SUSE Linux Enterprise High Availability Extension"
-    And the output should contain "https://documentation.suse.com/sles/html/SLES-all/article-modules.html"
 
   # Skip in SLES15 for now, since there's no paid extensions that can be activated
   # directly on the root product. Once SUSEConnect automatically activates recommended

--- a/internal/connect/extension-list.tmpl
+++ b/internal/connect/extension-list.tmpl
@@ -7,8 +7,3 @@
 
 {{"\x1b[31m"}}(Not available){{"\x1b[0m"}} The module/extension is {{"\x1b[1m"}}not{{"\x1b[0m"}} enabled on your RMT/SMT
 {{"\x1b[33m"}}(Activated){{"\x1b[0m"}}     The module/extension is activated on your system
-
-{{"\x1b[1m"}}MORE INFORMATION{{"\x1b[0m"}}
-
-You can find more information about available modules here:
-https://documentation.suse.com/sles/html/SLES-all/article-modules.html

--- a/internal/connect/extensions_test.go
+++ b/internal/connect/extensions_test.go
@@ -91,7 +91,6 @@ func TestPrintExtensionsAsText(t *testing.T) {
 	expectNoError(t, err)
 	expectStringMatches(t, result, "AVAILABLE EXTENSIONS AND MODULES")
 	expectStringMatches(t, result, "Python 3 Module 15 SP4 x86_64")
-	expectStringMatches(t, result, "You can find more information about available modules here:")
 }
 
 func TestPrintExtensionsAsJSON(t *testing.T) {


### PR DESCRIPTION
Currently, the `--list-extensions` command prints out a message linking to the SLE documentation, where modules and extensions are described.

For this link to really make sense, it should point to the documentation page that corresponds to the underlying SLES version. The modules/extensions of 15 SP6 are not necessarily the same as 15 SP7 (and are definitely not the same as 16). Having the link always point to the “latest” version of this document, no matter which version of SLES the server is running, means that when the user clicks on it, they may or may not get accurate information that applies to their system.

It’s also worth mentioning: until recently, the link was actually broken, as it took the user to the documentation home page rather than to the intended page. No one reported this issue, which suggests that our customers are not actually clicking on it.

Given that making this a properly versioned link is more effort, and that the link itself brings little value, we are removing it from the output in an upcoming SUSEConnect release.