### PR TITLE
Add missing tar dependency for zypper migration

### DIFF
--- a/build/packaging/suseconnect-ng.spec
+++ b/build/packaging/suseconnect-ng.spec
@@ -55,6 +55,8 @@ Requires:       ca-certificates-mozilla
 Requires:       ca-certificates
 %endif
 
+Requires:       gzip
+Requires:       tar
 Requires:       coreutils
 Requires:       zypper
 Requires:       util-linux


### PR DESCRIPTION
Noticed that `zypper migration` requires `tar` as dependency which is missing in our spec file. I added it.

**How to test this merge request:**

- Check CI and building rpm is fine. After that you are done!

cheers,

Felix