### PR TITLE
Add collector to get pci device data

### DIFF
--- a/build/packaging/suseconnect-ng.spec
+++ b/build/packaging/suseconnect-ng.spec
@@ -56,6 +56,7 @@ Requires:       ca-certificates
 %endif
 
 Requires:       coreutils
+Requires:       pciutils
 Requires:       zypper
 Requires:       util-linux
 Recommends:     systemd

--- a/internal/collectors/pci.go
+++ b/internal/collectors/pci.go
@@ -1,0 +1,19 @@
+package collectors
+
+import (
+	"github.com/SUSE/connect-ng/internal/util"
+)
+
+type PCI struct{}
+
+func (pci PCI) run(arch string) (Result, error) {
+        output, err := util.Execute([]string{"lspci", "-vmmDk", "-s", ".0"}, nil)
+	// Some systems may not have lspci command, so
+	// if the execute fails, 
+	// send nil to SCC to indicate that PCI data was unavailable.
+	if err != nil {
+		return Result{"PCIData": nil}, nil
+	}
+	
+	return Result{"PCIData": string(output)}, nil
+}

--- a/internal/collectors/pci_test.go
+++ b/internal/collectors/pci_test.go
@@ -1,0 +1,34 @@
+package collectors
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+
+func TestPCIRun(t *testing.T) {
+	assert := assert.New(t)
+
+        expectedPCI := `
+Slot:   0000:05:00.0
+Class:  VGA compatible controller
+Vendor: Advanced Micro Devices, Inc. [AMD/ATI]
+Device: Rembrandt [Radeon 680M]
+SVendor:        Advanced Micro Devices, Inc. [AMD/ATI]
+SDevice:        Rembrandt [Radeon 680M]
+Rev:    c7
+ProgIf: 00
+Driver: amdgpu
+Module: amdgpu
+IOMMUGroup:     17
+`
+        mockUtilExecute(expectedPCI, nil)
+	expected := Result{"PCIData": expectedPCI}
+
+	collector := PCI{}
+	result, err := collector.run(ARCHITECTURE_X86_64)
+        
+	assert.Equal(expected, result)
+	assert.Nil(err)
+}

--- a/internal/connect/api.go
+++ b/internal/connect/api.go
@@ -271,6 +271,7 @@ var mandatoryCollectors = []collectors.Collector{
 	collectors.CloudProvider{},
 	collectors.Architecture{},
 	collectors.ContainerRuntime{},
+	collectors.PCI{},
 
 	// Optional collectors
 	collectors.Uname{},


### PR DESCRIPTION
Add collection of PCI data to the heartbeat

This done by adding a collector that will invoke
lspci -vmmDk  -s .0

Requires adding pciutils to required package for suseconnect

The size of the additional payload in the heartbeat depends on how many pci devices are on the system.
Each PCI device on the system generated ~290 bytes of information.

Testing on large AWS systems and couple of other systems I have access to gave the following
approximate payload sizes.

AWS g6.48xlarge          8.2KB
AWS i7ie.metal-24xl    14.0KB
HP Z840                          1.9KB
HP DL360                        3.5KB