### PR TITLE
Fix a couple of issues as reported by using SUSEConnect `next` on public cloud instances

### DIFF
--- a/internal/connect/client.go
+++ b/internal/connect/client.go
@@ -53,7 +53,7 @@ func Register(api WrappedAPI, opts *Options) error {
 		printInformation(fmt.Sprintf("Registering system to %s", opts.ServerName()), opts)
 	}
 
-	if err := api.RegisterOrKeepAlive(opts.Token); err != nil {
+	if err := api.RegisterOrKeepAlive(opts.Token, opts.InstanceDataFile); err != nil {
 		return err
 	}
 

--- a/pkg/connection/api_error.go
+++ b/pkg/connection/api_error.go
@@ -30,7 +30,11 @@ func ErrorFromResponse(resp *http.Response) *ApiError {
 
 	ae := &ApiError{Code: resp.StatusCode}
 	if err := json.NewDecoder(resp.Body).Decode(ae); err != nil {
-		return nil
+		// In some servers the response is actually not a JSON message, but
+		// rather some NGinx default page. In that case, just set the HTML
+		// status string as the message.
+		ae.Message = resp.Status
+		ae.LocalizedMessage = resp.Status
 	}
 	return ae
 }


### PR DESCRIPTION
1. Instance data should be attached when registering.
2. API errors were being discarded if the server was behind an NGinx instance which returned some automatic default 404 pages.

## How to test

1. Build
2. Try on a public cloud server as provided by the involved team.