### PR TITLE
Change pkg/offline_registration_request to match SCC API

### DIFF
--- a/pkg/registration/offline_request.go
+++ b/pkg/registration/offline_request.go
@@ -27,9 +27,6 @@ type OfflineRequest struct {
 	Login    string `json:"login,omitempty"`
 	Password string `json:"password,omitempty"`
 
-	UUID      string `json:"uuid"`
-	ServerURL string `json:"server_url,omitempty"`
-
 	SystemInformation SystemInformation `json:"system_information,omitempty"`
 }
 
@@ -46,11 +43,6 @@ func (req *OfflineRequest) SetCredentials(creds connection.Credentials) error {
 	return nil
 }
 
-// Set optional server URL
-func (req *OfflineRequest) SetServerURL(serverUrl string) {
-	req.ServerURL = serverUrl
-}
-
 // Marshal and encode the offline request into its base64 representation.
 func (req *OfflineRequest) Base64Encoded() (io.Reader, error) {
 	data, jsonErr := json.Marshal(req)
@@ -65,15 +57,14 @@ func (req *OfflineRequest) Base64Encoded() (io.Reader, error) {
 }
 
 // Builds an offline registration request with it respective required attributes.
-// See [OfflineRequest.SetCredentials] and [OfflineRequest.SetServerURL] for optional attributes.
-func BuildOfflineRequest(identifier, version, arch string, uuid string, systemInformation SystemInformation) *OfflineRequest {
+// See [OfflineRequest.SetCredentials] for optional attributes.
+func BuildOfflineRequest(identifier, version, arch string, systemInformation SystemInformation) *OfflineRequest {
 	return &OfflineRequest{
 		Product: OfflineRequestProductTriplet{
 			Identifier: identifier,
 			Version:    version,
 			Arch:       arch,
 		},
-		UUID:              uuid,
 		SystemInformation: systemInformation,
 	}
 }

--- a/pkg/registration/offline_request_test.go
+++ b/pkg/registration/offline_request_test.go
@@ -11,22 +11,19 @@ import (
 
 func TestBuildOfflineRequest(t *testing.T) {
 	assert := assert.New(t)
-	uuid := "0f2fb933-00b8-483f-b63a-47d481c12947"
 
-	request := BuildOfflineRequest("rancher", "2.9.4", "x86_64", uuid, NoSystemInformation)
+	request := BuildOfflineRequest("rancher", "2.9.4", "x86_64", NoSystemInformation)
 
 	assert.Equal("rancher", request.Product.Identifier)
-	assert.Equal(uuid, request.UUID)
 }
 
 func TestOfflineRequestSetCredentials(t *testing.T) {
 	assert := assert.New(t)
 
-	uuid := "0f2fb933-00b8-483f-b63a-47d481c12947"
 	creds := &mockCredentials{}
 	creds.On("Login").Return("login", "password", nil)
 
-	request := BuildOfflineRequest("rancher", "2.9.4", "x86_64", uuid, NoSystemInformation)
+	request := BuildOfflineRequest("rancher", "2.9.4", "x86_64", NoSystemInformation)
 	request.SetCredentials(creds)
 
 	assert.Equal("login", request.Login)
@@ -35,22 +32,10 @@ func TestOfflineRequestSetCredentials(t *testing.T) {
 	creds.AssertExpectations(t)
 }
 
-func TestOfflineRequestSetServerURL(t *testing.T) {
-	assert := assert.New(t)
-
-	uuid := "0f2fb933-00b8-483f-b63a-47d481c12947"
-	expected := "http://server-url.com"
-
-	request := BuildOfflineRequest("rancher", "2.9.4", "x86_64", uuid, NoSystemInformation)
-	request.SetServerURL(expected)
-	assert.Equal(expected, request.ServerURL)
-}
-
 func TestBuildBase64Encoded(t *testing.T) {
 	assert := assert.New(t)
 
-	uuid := "0f2fb933-00b8-483f-b63a-47d481c12947"
-	request := BuildOfflineRequest("rancher", "2.9.4", "x86_64", uuid, NoSystemInformation)
+	request := BuildOfflineRequest("rancher", "2.9.4", "x86_64", NoSystemInformation)
 
 	encoded, encodeErr := request.Base64Encoded()
 	assert.NoError(encodeErr)
@@ -62,7 +47,6 @@ func TestBuildBase64Encoded(t *testing.T) {
 	assert.NoError(unmarshalErr)
 
 	assert.NotNil(result)
-	assert.Equal(uuid, result["uuid"])
 
 	productMap, ok := result["product"].(map[string]any)
 	assert.True(ok)
@@ -73,10 +57,9 @@ func TestBuildBase64Encoded(t *testing.T) {
 func TestRegisterWithOfflineRequest(t *testing.T) {
 	assert := assert.New(t)
 
-	uuid := "0f2fb933-00b8-483f-b63a-47d481c12947"
 	regcode := "some-scc-regcode"
 
-	request := BuildOfflineRequest("rancher", "2.9.4", "x86_64", uuid, NoSystemInformation)
+	request := BuildOfflineRequest("rancher", "2.9.4", "x86_64", NoSystemInformation)
 	conn, _ := mockConnectionWithCredentials()
 
 	body := fixture(t, "pkg/registration/offline_request_request.base64")


### PR DESCRIPTION
card: https://trello.com/c/EDckQKiH/3971-rr5-scc-aggregates-relevant-information-from-rancher-manager-telemetry-metric-payload

This merge request adapts to the updated metrics parsing for Rancher Manager and with this unifies the interface to be less product specific:
  * Removed `ServerURL` and `UUID` since they are both now prodvided within the `systemInformation` which is generated by Rancher.
  * Adapted the test application for the offline registration API

**How to review this merge request:**

- Get a SCC running using this branch: https://github.com/SUSE/happy-customer/pull/8478
-  Build the updated SUSEConnect:

```
$ cd <connect>
$ git checkout adapt-request-generation
$ docker run --rm --privileged --network host -ti -v $(pwd):/connect registry.suse.com/bci/golang:1.21-openssl
> cd /connect; git config --global --add safe.directory /connect
> make build
```

- Run the API test command for automated offline registration requests:

For this you also need the updated metrics to be sent. Save then to a file you have access from within the container:

```
{
  "version": "v2.13-YES-head",
  "subscription": {
    "installuuid": "7ee4c794-0b21-4b14-b29e-b21a5741ef29",
    "clusteruuid": "a78a3462-4731-4b51-982a-89be9058a956",
    "product": "rancher",
    "version": "v2.13-YES-head",
    "arch": "unknown",
    "git": "386841abc10e4b55aabef0cbd4e79ff5f7795a4f",
    "server_url": "https://some-test.rancher.com"
  },
  "feature_flags": [
    "continuous-delivery",
    "embedded-cluster-api",
    "uiextension",
    "rancher-scc-registration-extension",
    "harvester",
    "rke1-ui",
    "rke2",
    "v2prov-etcd-snapshot-backpopulate",
    "oidc-provider",
    "fleet",
    "multi-cluster-management",
    "auth",
    "rke1-custom-node-cleanup",
    "ui-sql-cache"
  ],
  "managedSystems": [
    {
      "arch": "amd64",
      "cpu": 4,
      "memory": 15873,
      "count": 3
    },
    {
      "arch": "amd64",
      "cpu": 2,
      "memory": 3858,
      "count": 28
    }
  ],
  "managedClusters": [
    {
      "count": 1,
      "nodes": 3,
      "upstream": true
    },
    {
      "count": 2,
      "nodes": 8
    },
    {
      "count": 2,
      "nodes": 3
    },
    {
      "count": 2,
      "nodes": 1
    },
    {
      "count": 2,
      "nodes": 2
    }
  ],
  "timestamp": "2025-08-11T21:29:11.337129794Z"
}

```

Then run the registration:

```
# USE: Search for a rancher manager subscription. See the demo section on the card for a hint
> ./out/suseconnect -r <sles regcode> --url http://localhost:3000
# expect: This should work as expected. Check also the values for the system in the admin view

# Run the offline request test application
> SCC_URL=http://localhost:3000 ./out/offline-register-api rancher 2.9.3 unknown <rancher subscription> /tmp/foo.json
# Expect: It should generate the request and sends it to SCC. See the resulting system in glue + the metrics added.
# Expect: Certificate validity is expected to be false since it tries to validate against the development environment with the production public key!
# HINT: You can decode the result with: echo "blob" | base64 -d | jq
```

**As always, if you think I missed something I should change or find any issues, please do not hesitate to reach out to me!** :rocket:

Thank you! :heart: 