### PR TITLE
Fix build for "test-yast"

### DIFF
--- a/.github/workflows/yast.yml
+++ b/.github/workflows/yast.yml
@@ -1,0 +1,14 @@
+name: YaST integration tests
+on: [pull_request]
+
+jobs:
+  yast:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Go
+        run: go mod vendor
+
+      - name: Run test-yast
+        run: make test-yast

--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ build-rpm:
 feature-tests:
 	$(CRM) $(MOUNT) --env-file $(ENVFILE) -w $(WORKDIR) $(CONTAINER) bash -c 'build/ci/build-rpm && build/ci/configure && build/ci/run-feature-tests'
 
-test-yast: build-so
+test-yast: build
 	docker build -t go-connect-test-yast -f third_party/Dockerfile.yast . && docker run -t go-connect-test-yast
 
 clean:

--- a/third_party/Dockerfile.yast
+++ b/third_party/Dockerfile.yast
@@ -10,5 +10,5 @@ WORKDIR /yast-registration
 RUN git clone --depth 1 https://github.com/yast/yast-registration.git /yast-registration
 
 COPY out/libsuseconnect /usr/lib64/libsuseconnect.so
-COPY third_party/yast/lib /usr/lib64/ruby/vendor_ruby/3.3.0
+COPY third_party/yast/lib /usr/lib64/ruby/vendor_ruby/3.4.0
 CMD ["rake", "test:unit"]

--- a/third_party/Dockerfile.yast
+++ b/third_party/Dockerfile.yast
@@ -9,7 +9,6 @@ WORKDIR /yast-registration
 
 RUN git clone --depth 1 https://github.com/yast/yast-registration.git /yast-registration
 
-COPY out/libsuseconnect.so /usr/lib64
+COPY out/libsuseconnect /usr/lib64/libsuseconnect.so
 COPY third_party/yast/lib /usr/lib64/ruby/vendor_ruby/3.3.0
 CMD ["rake", "test:unit"]
-


### PR DESCRIPTION
## Description

The setup for the `test-yast` Make target was utterly broken. This PR brings it back and tests are shown to be green. Moreover I have added a Github action just to be sure that we don't break it in the future.

## How to test

This should suffice:

```
$ make test-yast
```