### PR TITLE
Fix the 'check-format' make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ ci-env:
 	$(CRM) $(MOUNT) --env-file $(ENVFILE) -w $(WORKDIR) $(CONTAINER) bash
 
 check-format:
-	@gofmt -l internal/* cmd/*
+	@test -z $(shell gofmt -l internal/* cmd/* pkg/* | tee /dev/stderr)
 
 build-rpm:
 	$(CRM) $(MOUNT) -w $(WORKDIR) $(CONTAINER) bash -c 'build/ci/build-rpm'

--- a/cmd/suse-uptime-tracker/uptime_tracker.go
+++ b/cmd/suse-uptime-tracker/uptime_tracker.go
@@ -39,21 +39,21 @@ func exitOnError(err error) {
 }
 
 func displayUptimeVersion() {
-        var (
-                version bool
-        )
+	var (
+		version bool
+	)
 
-        flag.Usage = func() {
-                fmt.Print(uptimeTrackerUsageText)
-        }
+	flag.Usage = func() {
+		fmt.Print(uptimeTrackerUsageText)
+	}
 
-        flag.BoolVar(&version, "version", false, "")
+	flag.BoolVar(&version, "version", false, "")
 
-        flag.Parse()
-        if version {
-                fmt.Println(getShortenedVersion())
-                os.Exit(0)
-        }
+	flag.Parse()
+	if version {
+		fmt.Println(getShortenedVersion())
+		os.Exit(0)
+	}
 }
 
 func readUptimeLogFile(uptimeLogsFilePath string) (map[string]string, error) {

--- a/internal/connect/uptime_test.go
+++ b/internal/connect/uptime_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func createTestUptimeLogFileWithContent(content string) (string, error) {
-tempFile, err := os.CreateTemp("", "testUptimeLog")
+	tempFile, err := os.CreateTemp("", "testUptimeLog")
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
The Github Action calling 'check-format' expected this target to return a bad exit code whenever code was not up to standards, but it was not becuase 'check-format' only showed the diff but did nothing on the exit code. Now this target behaves more as it was expected.

As a side-effect, a couple of files have been changed so this new check did not fail.