### PR TITLE
Add SystemID and ProductName to the OfflinePayload

### DIFF
--- a/cmd/offline-register-api/main.go
+++ b/cmd/offline-register-api/main.go
@@ -93,4 +93,13 @@ func main() {
 	fmt.Printf("Certificate validity: %v\n", valid)
 	fmt.Printf("Expires at: %v\n", expires)
 	fmt.Printf("RegcodeMatches: %v\n", matches)
+
+	if os.Getenv("DEBUG") == "1" {
+		fmt.Printf("Encoded payload: %v\n", certificate.EncodedPayload)
+
+		// NOTE: ExtractPayload is called by previous calls like
+		// `ExpiresAt`. Hence, the OfflinePayload has already been filled by
+		// this point.
+		fmt.Printf("Payload: %#v\n", certificate.OfflinePayload)
+	}
 }

--- a/pkg/registration/offline_certificate.go
+++ b/pkg/registration/offline_certificate.go
@@ -36,6 +36,8 @@ type OfflinePayload struct {
 	HashedRegcode    string           `json:"hashed_regcode"`
 	HashedUUID       string           `json:"hashed_uuid"`
 	Information      map[string]any   `json:"information"`
+	SystemID         int              `json:"system_id"`
+	ProductName      string           `json:"product_name"`
 }
 
 // Reads and offline registration certificate from the given reader object.


### PR DESCRIPTION
## How to test

As usual on offline shenanigans, create the request from a file (see [trello card](https://trello.com/c/V2hexaZO/4006-rr5-add-id-and-subscription-info-to-offlinecertificate-to-match-online-registration))

Then on a docker container:

1. Build the thing
2. Register as usual.
3. DEBUG=1 SCC_URL=http://localhost:3000 ./out/offline-register-api rancher 2.9.3 unknown <rancher subscription> <awesome-request.json>

Note the `DEBUG=1`, which will print both the encoded and the parsed payload from the server. You should see something like:

```
<lotta data> ...  SystemID:19087464, ProductName:"SUSE Rancher 2.9.3"}
```