### PR TITLE
Address minor issues identified by vet and staticheck

### DIFF
--- a/internal/connect/product_test.go
+++ b/internal/connect/product_test.go
@@ -124,7 +124,7 @@ func TestSplitTriplet(t *testing.T) {
 	if p.ToTriplet() != expected.ToTriplet() {
 		t.Errorf("Expected: %v, got: %v", expected, p)
 	}
-	p, err = SplitTriplet("SLES")
+	_, err = SplitTriplet("SLES")
 	if err == nil {
 		t.Fatal("Expected error, got nil")
 	}

--- a/internal/connect/registry_auth_test.go
+++ b/internal/connect/registry_auth_test.go
@@ -55,7 +55,7 @@ func mockWriteFile(t *testing.T, matcherfile string) {
 func mockMkDirAll(t *testing.T) {
 	mkDirAll = func(_ string, perm os.FileMode) error {
 		if perm != 0755 {
-			t.Log(fmt.Sprintf("mkdir: %s is unlikely the right directory permission. Are you sure?", perm))
+			t.Logf("mkdir: %s is unlikely the right directory permission. Are you sure?", perm)
 		}
 		return nil
 	}
@@ -128,7 +128,7 @@ func TestRegistryAuthRemoveReadFailed(t *testing.T) {
 	}
 
 	writeFile = func(_ string, _ []byte, _ os.FileMode) error {
-		fmt.Errorf("Expected writeFile to never be called")
+		t.Errorf("Expected writeFile to never be called")
 		return nil
 	}
 


### PR DESCRIPTION
Loading the code in VSCode reported a number of minor issues that include the ones addressed here:
  * A call to fmt.Errorf() that doesn't store the returned error. Changed to a t.Errorf() which will trigger a test failure if called, as appears to have been the intent. This showed up in a go vet ./... check.
  * Converted a t.Log() wrapping of an fmt.Sprintf() into a t.Logf()
  * Changed an unused return variable p to an _ per Go standards; this didn't flag an error in other checks because p was used previously in the same code context.

Note that there are many occurrences of error messages staring with capitals and/or ending in punctuation that are also flagged by the Go staticcheck tooling that VSCode uses.