### PR TITLE
Add system ID and Product name to the output of offline registration certificate

### DIFF
--- a/cmd/offline-register-api/main.go
+++ b/cmd/offline-register-api/main.go
@@ -90,6 +90,8 @@ func main() {
 		os.Exit(1)
 	}
 
+	fmt.Printf("certificate blob:\n===\n%s\n===\n", certificate.EncodedPayload)
+	fmt.Printf("Payload: %#v\n", certificate.OfflinePayload)
 	fmt.Printf("Certificate validity: %v\n", valid)
 	fmt.Printf("Expires at: %v\n", expires)
 	fmt.Printf("RegcodeMatches: %v\n", matches)

--- a/pkg/registration/offline_certificate.go
+++ b/pkg/registration/offline_certificate.go
@@ -19,6 +19,8 @@ type OfflineCertificate struct {
 	Hash             string `json:"hash"`
 	EncodedPayload   string `json:"payload"`
 	EncodedSignature string `json:"signature"`
+	SystemID         int    `json:"system_id"`
+	ProductName      string `json:"product_name"`
 
 	*OfflinePayload
 }


### PR DESCRIPTION
rebase to `main` from `next`.
Check: https://github.com/SUSE/connect-ng/pull/327 & https://trello.com/c/V2hexaZO/4006-rr5-add-id-and-subscription-info-to-offlinecertificate-to-match-online-registration

We do not yet merge next into main and this change would force it from the original branch. I more or less just imported the changes here to have it against `main`.