### PR TITLE
Attach the uptime log if requested on keepalive

### DIFF
--- a/cmd/suseconnect/suseconnect.go
+++ b/cmd/suseconnect/suseconnect.go
@@ -254,7 +254,7 @@ func main() {
 			exitOnError(errors.New("cannot use the json option with the 'keepalive' command"), api, opts)
 		}
 		api := connect.NewWrappedAPI(opts)
-		err = api.KeepAlive()
+		err = api.KeepAlive(opts.EnableSystemUptimeTracking)
 		exitOnError(err, api, opts)
 		util.Info.Print(util.Bold(util.GreenText("\nSuccessfully updated system")))
 	} else if listExtensions {

--- a/internal/connect/client.go
+++ b/internal/connect/client.go
@@ -53,7 +53,7 @@ func Register(api WrappedAPI, opts *Options) error {
 		printInformation(fmt.Sprintf("Registering system to %s", opts.ServerName()), opts)
 	}
 
-	if err := api.RegisterOrKeepAlive(opts.Token, opts.InstanceDataFile); err != nil {
+	if err := api.RegisterOrKeepAlive(opts.Token, opts.InstanceDataFile, opts.EnableSystemUptimeTracking); err != nil {
 		return err
 	}
 

--- a/pkg/registration/status.go
+++ b/pkg/registration/status.go
@@ -1,6 +1,8 @@
 package registration
 
-import "github.com/SUSE/connect-ng/pkg/connection"
+import (
+	"github.com/SUSE/connect-ng/pkg/connection"
+)
 
 // Enum being used to report on the different status scenarios for a given
 // connection.

--- a/third_party/libsuseconnect/libsuseconnect.go
+++ b/third_party/libsuseconnect/libsuseconnect.go
@@ -86,7 +86,7 @@ func update_system(clientParams, distroTarget *C.char) *C.char {
 	opts := loadConfig(C.GoString(clientParams))
 
 	api := connect.NewWrappedAPI(opts)
-	if err := api.KeepAlive(); err != nil {
+	if err := api.KeepAlive(opts.EnableSystemUptimeTracking); err != nil {
 		return C.CString(errorToJSON(err))
 	}
 	return C.CString("{}")


### PR DESCRIPTION
Fixes #331

## How to test

1. Start a container and build the thing 😄 
2. Register your system as usual.
3. Enable uptime on the system's configuration:

```
> cp /etc/SUSEConnect.example /etc/SUSEConnect
> vim /etc/SUSEConnect
# enable uptime log
```

4. Create the log file `/etc/zypp/suse-uptime.log` and put the following contents:

```
2024-01-18:000000000000001000110000
2024-01-13:000000000000000000010000
```

5. Run keepalive: `./out/suseconnect --keepalive`. It should **succeed**.
6. Check your system in scc.suse.com. I did not know how to pick up this information from the UI, so just go to the Rails console and:

```
> System.find(<id-of-your-system>).system_uptimes
```

The data should **match** to what you wrote on the log file.