### PR TITLE
Fix 2 occurrences of a module pseudo-constant being modified

### DIFF
--- a/cmd/offline-register-api/main.go
+++ b/cmd/offline-register-api/main.go
@@ -29,7 +29,7 @@ func main() {
 	arch := os.Args[3]
 	regcode := os.Args[4]
 
-	information := registration.NoSystemInformation
+	information := registration.SystemInformation{}
 
 	if len(os.Args) == 6 {
 		file := os.Args[5]

--- a/internal/connect/wrapper.go
+++ b/internal/connect/wrapper.go
@@ -128,7 +128,7 @@ func (w Wrapper) Register(regcode, instanceDataFile string) error {
 	// If an instance-data file was provided, try to read it and attach it as
 	// "extra" data. This will be used inside of the `registration.Register`
 	// code.
-	extraData := registration.NoExtraData
+	extraData := registration.ExtraData{}
 	if instanceDataFile != "" {
 		data, err := os.ReadFile(instanceDataFile)
 		if err != nil {


### PR DESCRIPTION
In Golang you can't define constants for certain types, such as maps.

However, it can be useful to define name pseudo-constants in modules but care must be taken to ensure that they are not modified by the code that uses them.

In this case registration modules defines two such pseudo-constants, NoExtraData and NoSystemInformation, but in a couple of places the code is copying those references and then modifying them which could lead to potential side effects.

Switching the problem code to just initialising an empty instance of the associated type resolves the issue.