### PR TITLE
Identify systemd unit files and query their properties

### DIFF
--- a/internal/util/system.go
+++ b/internal/util/system.go
@@ -40,8 +40,11 @@ func SetSystemEcho(v bool) bool {
 	return prev
 }
 
+// ExecuteFunc type
+type ExecuteFunc func(cmd []string, validExitCodes []int) ([]byte, error)
+
 // Assign function for running external commands to a variable so it can be mocked by tests.
-var Execute = func(cmd []string, validExitCodes []int) ([]byte, error) {
+var Execute ExecuteFunc = func(cmd []string, validExitCodes []int) ([]byte, error) {
 	Debug.Print("Executing: ", cmd)
 	var stderr, stdout bytes.Buffer
 	comm := exec.Command(cmd[0], cmd[1:]...)

--- a/internal/util/systemctl.go
+++ b/internal/util/systemctl.go
@@ -1,0 +1,34 @@
+package util
+
+var (
+	//
+	// systemctl settings
+	//
+
+	// path to the systemctl command
+	SystemctlBin = "/usr/bin/systemctl"
+
+	// extra options to pass to the
+	SystemctlBaseCmd = []string{
+		SystemctlBin,
+		"--no-pager",
+		"--nolegend",
+	}
+)
+
+func Systemctl(cmd string, args ...string) ([]byte, error) {
+	// construct systemctl command line
+	cmdLine := append([]string{}, SystemctlBaseCmd...)
+	cmdLine = append(cmdLine, cmd)
+	cmdLine = append(cmdLine, args...)
+
+	exitCodes := []int{0}
+
+	// execute systemctl command
+	output, err := Execute(cmdLine, exitCodes)
+	if err != nil {
+		return nil, err
+	}
+
+	return output, nil
+}

--- a/internal/util/systemctl_test.go
+++ b/internal/util/systemctl_test.go
@@ -1,0 +1,99 @@
+package util
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type systemctlTestCfg struct {
+	SubCmd    string
+	Args      []string
+	Output    []byte
+	Error     error
+	ExitCodes []int
+}
+
+func systemctlSimpleTestMockHandler(cmd []string, exitCodes []int, env *MockExecuteEnv) ([]byte, error) {
+	cfg := env.Cfg.(*systemctlTestCfg)
+	return cfg.Output, cfg.Error
+}
+
+func TestSystemctlNormalOperation(t *testing.T) {
+	// general setup
+	assert := assert.New(t)
+	require := require.New(t)
+
+	// test setup
+	testCfg := &systemctlTestCfg{
+		SubCmd:    "testSubCmd",
+		Args:      []string{"testArg1", "testArg2"},
+		Output:    []byte("test output"),
+		Error:     nil,
+		ExitCodes: []int{0},
+	}
+
+	mockEnv := NewExecuteMockEnv(testCfg)
+	mockEnv.Setup(systemctlSimpleTestMockHandler)
+	defer mockEnv.Teardown()
+
+	// construct expected output and call command line and exit codes
+	expectedCmdLine := append([]string{}, SystemctlBaseCmd...)
+	expectedCmdLine = append(expectedCmdLine, testCfg.SubCmd)
+	expectedCmdLine = append(expectedCmdLine, testCfg.Args...)
+	expectedExitCodes := []int{0}
+	expectedOutput := []byte(testCfg.Output)
+
+	// run test case
+	output, err := Systemctl(testCfg.SubCmd, testCfg.Args...)
+
+	// check returned values
+	assert.Equal(expectedOutput, output, "Systemctl() returned unexpected output")
+	assert.NoError(err, "Systemctl() returned unexpected error")
+
+	// check that Execute() was called as expected
+	require.Equal(1, mockEnv.NumCalls, "Systemctl() called Execute() an unexpected number of times")
+	assert.Equal(expectedCmdLine, mockEnv.CmdLinesList[0], "Systemctl() called Execute() with unexpected cmd argument")
+	assert.Equal(expectedExitCodes, mockEnv.ExitCodesList[0], "Systemctl() called Execute() with unexpected exitCodes argument")
+}
+
+func TestSystemctlFailedOperation(t *testing.T) {
+	// general setup
+	assert := assert.New(t)
+	require := require.New(t)
+
+	// test setup
+	testCfg := &systemctlTestCfg{
+		SubCmd:    "testSubCmd",
+		Args:      []string{"testArg1", "testArg2"},
+		Output:    []byte(nil),
+		Error:     fmt.Errorf("test error"),
+		ExitCodes: []int{0},
+	}
+
+	// setup mockingt for Execute
+	mockEnv := NewExecuteMockEnv(testCfg)
+	mockEnv.Setup(systemctlSimpleTestMockHandler)
+	defer mockEnv.Teardown()
+
+	// construct expected output and call command line and exit codes
+	expectedCmdLine := append([]string{}, SystemctlBaseCmd...)
+	expectedCmdLine = append(expectedCmdLine, testCfg.SubCmd)
+	expectedCmdLine = append(expectedCmdLine, testCfg.Args...)
+	expectedExitCodes := []int{0}
+
+	// run test case
+	output, err := Systemctl(testCfg.SubCmd, testCfg.Args...)
+
+	// check returned values
+	assert.Nil(output, "Systemctl() should have returned nil for output")
+	assert.Error(err, "Systemctl() should have returned an error")
+	assert.ErrorIs(err, testCfg.Error, "Systemctl() returned unexpected error")
+
+	// check that Execute() was called as expected
+	require.Equal(1, mockEnv.NumCalls, "Systemctl() called Execute() an unexpected number of times")
+	assert.Equal(expectedCmdLine, mockEnv.CmdLinesList[0], "Systemctl() called Execute() with unexpected cmd argument")
+	assert.Equal(expectedExitCodes, mockEnv.ExitCodesList[0], "Systemctl() called Execute() with unexpected exitCodes argument")
+}

--- a/internal/util/systemd_unit_files.go
+++ b/internal/util/systemd_unit_files.go
@@ -1,0 +1,79 @@
+package util
+
+import (
+	"bytes"
+	"regexp"
+)
+
+//
+// Systemd Unit Files
+//
+
+type SystemdUnitFile struct {
+	Name string
+}
+
+func NewSystemdUnitFile(name string) *SystemdUnitFile {
+	return &SystemdUnitFile{Name: name}
+}
+
+func (uf *SystemdUnitFile) String() string {
+	return uf.Name
+}
+
+func (uf *SystemdUnitFile) Property(property string) ([]byte, error) {
+	output, err := Systemctl(
+		"show", "--property", property, uf.Name,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return output, nil
+}
+
+//
+// List unit files that match specified type and state
+//
+
+var listUnitFilesOutputMatcher = regexp.MustCompile(
+	`^(\S+)` + // match and extract first column, <unit_file_name>
+		`\s+` + `(\S+)` + // match and extract second column, <state>
+		`(?:` + // start a non-extracting group
+		`\s+` + `\S+` + // match 3rd column, <preset> if present
+		`)?$`, // optional as column not reported on older (SLE 12 SP5) systems
+)
+
+func ListMatchingUnitFilesOfTypeAndState(pattern, unitType, state string, nameFilter *regexp.Regexp) ([]*SystemdUnitFile, error) {
+	output, err := Systemctl(
+		"list-unit-files", "--type", unitType, "--state", state, pattern,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	unitFiles := []*SystemdUnitFile{}
+	for _, line := range bytes.Split(output, []byte("\n")) {
+		// filter on lines that match target pattern
+		enabledMatches := listUnitFilesOutputMatcher.FindSubmatch(line)
+
+		// skip line if line doesn't match expected pattern, total line + 2 fields
+		if len(enabledMatches) != 3 {
+			continue
+		}
+
+		// skip line if state field is not desired state
+		if string(enabledMatches[2]) != state {
+			continue
+		}
+
+		// skip unit file name if it doesn't match the expected pattern
+		if !nameFilter.Match(enabledMatches[1]) {
+			continue
+		}
+
+		unitFiles = append(unitFiles, NewSystemdUnitFile(string(enabledMatches[1])))
+	}
+
+	return unitFiles, nil
+}

--- a/internal/util/systemd_unit_files_test.go
+++ b/internal/util/systemd_unit_files_test.go
@@ -1,0 +1,290 @@
+package util
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestListUnitFilesOutputMatcher(t *testing.T) {
+	testUnitFile := "test.unit"
+	enabled := "enabled"
+
+	testCases := []struct {
+		name          string
+		matcher       *regexp.Regexp
+		input         string
+		fieldMatches  [][]byte
+		expectedCount int
+	}{
+		//
+		// systemctl list-unit-files output matcher
+		//
+		{
+			name:          "list-unit-files output matcher for valid output (unitfile state preset)",
+			matcher:       listUnitFilesOutputMatcher,
+			input:         fmt.Sprintf("%s %s %s", testUnitFile, enabled, enabled),
+			fieldMatches:  [][]byte{[]byte(testUnitFile), []byte(enabled)},
+			expectedCount: 3, // line + 2 fields
+		},
+		{
+			name:          "list-unit-files output matcher for valid output on older systemd versions like SLE-12SP5 (unitfile state)",
+			matcher:       listUnitFilesOutputMatcher,
+			input:         fmt.Sprintf("%s %s", testUnitFile, enabled),
+			fieldMatches:  [][]byte{[]byte(testUnitFile), []byte(enabled)},
+			expectedCount: 3, // line + 2 fields
+		},
+		{
+			name:          "list-unit-files output matcher for invalid output (missing unitfile)",
+			matcher:       listUnitFilesOutputMatcher,
+			input:         fmt.Sprintf(" %s", enabled),
+			fieldMatches:  [][]byte{},
+			expectedCount: 0,
+		},
+		{
+			name:          "list-unit-files output matcher for invalid output (missing state)",
+			matcher:       listUnitFilesOutputMatcher,
+			input:         testUnitFile,
+			fieldMatches:  [][]byte{},
+			expectedCount: 0,
+		},
+		{
+			name:          "list-unit-files output matcher for invalid output (empty)",
+			matcher:       listUnitFilesOutputMatcher,
+			input:         "",
+			fieldMatches:  [][]byte{},
+			expectedCount: 0,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			matches := tc.matcher.FindSubmatch([]byte(tc.input))
+			assert.Len(matches, tc.expectedCount, "FindSubMatch(%s) for %q didn't return expected number of matches", tc.matcher, tc.input)
+			if len(matches) == 0 { // skip matched field checks when none expected
+				return
+			}
+			assert.Equal([]byte(tc.input), matches[0], "FindSubmatch(%s) for %q should have matched entire input string", tc.matcher, tc.input)
+			assert.Equal(tc.fieldMatches, matches[1:], "FindSubmatch(%s) for %q should have matched expected fields", tc.matcher, tc.input)
+		})
+	}
+}
+
+func TestListMatchingUnitFilesOfTypeAndStateNormalOperation(t *testing.T) {
+	// general setup
+	assert := assert.New(t)
+	require := require.New(t)
+
+	// test setup
+	testSvc := "test.service"
+	testSvcMatcher := regexp.MustCompile(fmt.Sprintf("^%s$", testSvc))
+	testPattern := "test*"
+	testCfg := &systemctlTestCfg{
+		SubCmd: "list-unit-files",
+		Args:   []string{"--type", "service", "--state", "enabled", testPattern},
+		Output: []byte(strings.Join(
+			[]string{
+				fmt.Sprintf("%s enabled enabled", testSvc),
+			},
+			"\n",
+		)),
+		Error:     nil,
+		ExitCodes: []int{0},
+	}
+
+	mockEnv := NewExecuteMockEnv(testCfg)
+	mockEnv.Setup(systemctlSimpleTestMockHandler)
+	defer mockEnv.Teardown()
+
+	// construct expected output, systemctl call command line and exit codes
+	expectedCmdLine := append([]string{}, SystemctlBaseCmd...)
+	expectedCmdLine = append(expectedCmdLine, testCfg.SubCmd)
+	expectedCmdLine = append(expectedCmdLine, testCfg.Args...)
+	expectedExitCodes := []int{0}
+	expectedUnitFiles := []*SystemdUnitFile{
+		NewSystemdUnitFile(testSvc),
+	}
+
+	// run test case
+	unitFiles, err := ListMatchingUnitFilesOfTypeAndState("test*", "service", "enabled", testSvcMatcher)
+
+	// check returned values
+	assert.NotNil(unitFiles, "ListMatchingUnitFilesOfTypeAndState() returned nil for unitFiles list")
+	assert.NoError(err, "ListMatchingUnitFilesOfTypeAndState() returned unexpected error")
+	assert.Equal(expectedUnitFiles, unitFiles, "ListMatchingUnitFilesOfTypeAndState() returned unexpected output")
+
+	// check Execute() was called as expected
+	require.Equal(1, mockEnv.NumCalls, "Execute() called unexpected number of times")
+	assert.Equal(expectedCmdLine, mockEnv.CmdLinesList[0], "listMatchingUnitFilesOfTypeAndState() called util.Execute() with unexperect cmd argument")
+	assert.Equal(expectedExitCodes, mockEnv.ExitCodesList[0], "Systemctl() called Execute() with unexpected exitCodes argument")
+}
+
+func TestListMatchingUnitFilesOfTypeAndStateNoMatchesOperation(t *testing.T) {
+	// general setup
+	assert := assert.New(t)
+	require := require.New(t)
+
+	// test setup
+	testSvc := "test.service"
+	testSvcMatcher := regexp.MustCompile(fmt.Sprintf("^%s$", testSvc))
+	testPattern := "test*"
+	testCfg := &systemctlTestCfg{
+		SubCmd:    "list-unit-files",
+		Args:      []string{"--type", "service", "--state", "enabled", testPattern},
+		Output:    []byte(strings.Join([]string{}, "\n")),
+		Error:     nil,
+		ExitCodes: []int{0},
+	}
+
+	mockEnv := NewExecuteMockEnv(testCfg)
+	mockEnv.Setup(systemctlSimpleTestMockHandler)
+	defer mockEnv.Teardown()
+
+	// construct expected output, systemctl call command line and exit codes
+	expectedCmdLine := append([]string{}, SystemctlBaseCmd...)
+	expectedCmdLine = append(expectedCmdLine, testCfg.SubCmd)
+	expectedCmdLine = append(expectedCmdLine, testCfg.Args...)
+	expectedExitCodes := []int{0}
+
+	// run test case
+	unitFiles, err := ListMatchingUnitFilesOfTypeAndState("test*", "service", "enabled", testSvcMatcher)
+
+	// check returned values
+	assert.Empty(unitFiles, "ListMatchingUnitFilesOfTypeAndState() should have returned an empty list of unit files")
+	assert.NoError(err, "ListMatchingUnitFilesOfTypeAndState() returned unexpected error")
+
+	// check Execute() was called as expected
+	require.Equal(1, mockEnv.NumCalls, "Execute() called unexpected number of times")
+	assert.Equal(expectedCmdLine, mockEnv.CmdLinesList[0], "listMatchingUnitFilesOfTypeAndState() called util.Execute() with unexperect cmd argument")
+	assert.Equal(expectedExitCodes, mockEnv.ExitCodesList[0], "Systemctl() called Execute() with unexpected exitCodes argument")
+}
+
+func TestListMatchingUnitFilesOfTypeAndStateFailingSystemCtl(t *testing.T) {
+	// general setup
+	assert := assert.New(t)
+	require := require.New(t)
+
+	// test setup
+	testSvc := "test.service"
+	testSvcMatcher := regexp.MustCompile(fmt.Sprintf("^%s$", testSvc))
+	testPattern := "test*"
+	testError := fmt.Errorf("test error")
+	testCfg := &systemctlTestCfg{
+		SubCmd:    "list-unit-files",
+		Args:      []string{"--type", "service", "--state", "enabled", testPattern},
+		Output:    []byte(nil),
+		Error:     testError,
+		ExitCodes: []int{0},
+	}
+
+	mockEnv := NewExecuteMockEnv(testCfg)
+	mockEnv.Setup(systemctlSimpleTestMockHandler)
+	defer mockEnv.Teardown()
+
+	// construct expected output, systemctl call command line and exit codes
+	expectedCmdLine := append([]string{}, SystemctlBaseCmd...)
+	expectedCmdLine = append(expectedCmdLine, testCfg.SubCmd)
+	expectedCmdLine = append(expectedCmdLine, testCfg.Args...)
+	expectedExitCodes := []int{0}
+
+	// run test case
+	unitFiles, err := ListMatchingUnitFilesOfTypeAndState("test*", "service", "enabled", testSvcMatcher)
+
+	// check returned values
+	assert.Nil(unitFiles, "ListMatchingUnitFilesOfTypeAndState() should have returned a null list of unit files")
+	assert.Error(err, "ListMatchingUnitFilesOfTypeAndState() should have returned an error")
+	assert.ErrorIs(err, testError, "ListMatchingUnitFilesOfTypeAndState() should have returned an instance of testError")
+
+	// check Execute() was called as expected
+	require.Equal(1, mockEnv.NumCalls, "Execute() called unexpected number of times")
+	assert.Equal(expectedCmdLine, mockEnv.CmdLinesList[0], "listMatchingUnitFilesOfTypeAndState() called util.Execute() with unexperect cmd argument")
+	assert.Equal(expectedExitCodes, mockEnv.ExitCodesList[0], "Systemctl() called Execute() with unexpected exitCodes argument")
+}
+
+func TestUnitFilePropertyNormalOperation(t *testing.T) {
+	// general setup
+	assert := assert.New(t)
+	require := require.New(t)
+
+	testSvc := "test.service"
+	testCfg := &systemctlTestCfg{
+		SubCmd:    "show",
+		Args:      []string{"--property", "ExecStart", "test.service"},
+		Output:    []byte("test output"),
+		Error:     nil,
+		ExitCodes: []int{0},
+	}
+	mockEnv := NewExecuteMockEnv(testCfg)
+
+	// expected test values
+	expectedCmdLine := append([]string{}, SystemctlBaseCmd...)
+	expectedCmdLine = append(expectedCmdLine, testCfg.SubCmd)
+	expectedCmdLine = append(expectedCmdLine, testCfg.Args...)
+	expectedNumCalls := 1
+
+	// setup util.Execute() mocking
+	mockEnv.Setup(systemctlSimpleTestMockHandler)
+	defer mockEnv.Teardown()
+
+	// run test case
+	uf := NewSystemdUnitFile(testSvc)
+	output, err := uf.Property("ExecStart")
+
+	// check returned values
+	assert.Equal(testCfg.Output, output, "SystemdUnitFile.Property() returned unexpected output")
+	assert.NoError(err, "SystemdUnitFile.Property() returned unexpected error")
+
+	// check Execute() was called as expected
+	require.Equal(expectedNumCalls, mockEnv.NumCalls, "Execute() called unexpected number of times")
+	assert.Equal(expectedCmdLine, mockEnv.CmdLinesList[0], "SystemdUnitFile.Property() triggered Execute() called with unexpected cmd argument")
+	assert.Equal(testCfg.ExitCodes, mockEnv.ExitCodesList[0], "SystemdUnitFile.Property() triggered util.Execute() called with unexpected exit codes")
+
+}
+
+func TestUnitFilePropertyFailedOperation(t *testing.T) {
+	// general setup
+	assert := assert.New(t)
+	require := require.New(t)
+
+	testSvc := "test.service"
+	testError := fmt.Errorf("test error")
+	testCfg := &systemctlTestCfg{
+		SubCmd:    "show",
+		Args:      []string{"--property", "ExecStart", "test.service"},
+		Output:    []byte(nil),
+		Error:     testError,
+		ExitCodes: []int{0},
+	}
+	mockEnv := NewExecuteMockEnv(testCfg)
+
+	// expected test values
+	expectedCmdLine := append([]string{}, SystemctlBaseCmd...)
+	expectedCmdLine = append(expectedCmdLine, testCfg.SubCmd)
+	expectedCmdLine = append(expectedCmdLine, testCfg.Args...)
+	expectedNumCalls := 1
+
+	// setup util.Execute() mocking
+	mockEnv.Setup(systemctlSimpleTestMockHandler)
+	defer mockEnv.Teardown()
+
+	// run test case
+	uf := NewSystemdUnitFile(testSvc)
+	output, err := uf.Property("ExecStart")
+
+	// check returned values
+	assert.Equal(testCfg.Output, output, "SystemdUnitFile.Property() returned unexpected output")
+	assert.Error(err, "SystemdUnitFile.Property() should have returned an error")
+	assert.ErrorIs(err, testError, "SystemdUnitFile.Property() should have returned an instance of testError")
+
+	// check Execute() was called as expected
+	require.Equal(expectedNumCalls, mockEnv.NumCalls, "Execute() called unexpected number of times")
+	assert.Equal(expectedCmdLine, mockEnv.CmdLinesList[0], "SystemdUnitFile.Property() triggered Execute() called with unexpected cmd argument")
+	assert.Equal(testCfg.ExitCodes, mockEnv.ExitCodesList[0], "SystemdUnitFile.Property() triggered util.Execute() called with unexpected exit codes")
+
+}

--- a/internal/util/test_helpers.go
+++ b/internal/util/test_helpers.go
@@ -29,3 +29,55 @@ func TestContentMatches(t *testing.T, expected string, got string) {
 		t.Errorf(strings.Join(message, "\n"), expected, got)
 	}
 }
+
+//
+// Helpers for mocking Execute()
+//
+
+type MockExecuteEnv struct {
+	// Public Attributes
+	NumCalls      int
+	CmdLinesList  [][]string
+	ExitCodesList [][]int
+	Cfg           any
+
+	// Private Attributes
+	origExecute ExecuteFunc
+}
+
+func NewExecuteMockEnv(cfg any) *MockExecuteEnv {
+	return &MockExecuteEnv{
+		NumCalls:      0,
+		CmdLinesList:  [][]string{},
+		ExitCodesList: [][]int{},
+		Cfg:           cfg,
+		origExecute:   nil,
+	}
+}
+
+type MockExecuteFunc func(cmd []string, exitCodes []int, env *MockExecuteEnv) ([]byte, error)
+
+func (m *MockExecuteEnv) Setup(handler MockExecuteFunc) {
+	// save the original Execute
+	m.origExecute = Execute
+	Execute = func(cmd []string, exitCodes []int) ([]byte, error) {
+		// the mocked execute was called so update tracking settings
+		m.NumCalls++
+		m.CmdLinesList = append(m.CmdLinesList, cmd)
+		m.ExitCodesList = append(m.ExitCodesList, exitCodes)
+
+		// call the handler, passing in the cmd, exitCodes and mock env
+		// and return the results
+		return handler(cmd, exitCodes, m)
+	}
+}
+
+func (m *MockExecuteEnv) OriginalExecute() ExecuteFunc {
+	return m.origExecute
+}
+
+func (m *MockExecuteEnv) Teardown() {
+	// restore the original Execute
+	Execute = m.origExecute
+	m.origExecute = nil
+}

--- a/internal/util/test_helpers_test.go
+++ b/internal/util/test_helpers_test.go
@@ -1,0 +1,132 @@
+package util
+
+import (
+	"fmt"
+	"reflect"
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Test the MockExecute helper functionality
+
+func TestMockExecuteEnv(t *testing.T) {
+	// remember the original Execute
+	originalExecute := Execute
+
+	// define a test config that will be used by test handler
+	type testCfg struct {
+		name      string
+		cmd       []string
+		exitCodes []int
+		status    int
+		output    []byte
+		err       error
+		numCalls  int
+	}
+
+	// define a test error
+	testError := fmt.Errorf("test error")
+
+	// define a handler that uses the defined config and returns specific values
+	var handler MockExecuteFunc = func(cmd []string, exitCodes []int, env *MockExecuteEnv) ([]byte, error) {
+		cfg := env.Cfg.(*testCfg)
+
+		var output []byte
+		var err error
+
+		switch cmd[0] {
+		case "success":
+			output = []byte("successful command execution")
+		case "failure":
+			if slices.Contains(exitCodes, cfg.status) {
+				output = []byte("permitted failing command execution")
+			} else {
+				err = testError
+			}
+		}
+
+		return output, err
+	}
+
+	// setup a table of subtests to run
+	for _, tc := range []testCfg{
+		{
+			name:      "verify successful command handling",
+			cmd:       []string{"success"},
+			exitCodes: []int{0},
+			status:    0,
+			output:    []byte("successful command execution"),
+			err:       nil,
+			numCalls:  1,
+		},
+		{
+			name:      "verify unpermitted failed command handling",
+			cmd:       []string{"failure"},
+			exitCodes: []int{0},
+			status:    1,
+			output:    []byte(nil),
+			err:       testError,
+			numCalls:  1,
+		},
+		{
+			name:      "verify permitted failing command handling",
+			cmd:       []string{"failure"},
+			exitCodes: []int{0, 1},
+			status:    1,
+			output:    []byte("permitted failing command execution"),
+			err:       nil,
+			numCalls:  1,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			// general setup
+			assert := assert.New(t)
+			require := require.New(t)
+
+			// use the provided test config
+			cfg := &tc
+
+			// create the MockEnv and verify that cfg was setup correctly
+			mockEnv := NewExecuteMockEnv(cfg)
+			assert.Equal(cfg, mockEnv.Cfg, "MockExecuteEnv.Cfg not setup correctly")
+
+			// setup mocking of Execute
+			mockEnv.Setup(handler)
+
+			// verify that Execute was replaced by a mock Execute
+			require.NotNil(Execute, "MockExecuteEnv.Setup() did not correctly mock the Execute routine")
+			if reflect.ValueOf(Execute).Pointer() == reflect.ValueOf(originalExecute).Pointer() {
+				t.Fatal("MockExecuteEnv.Setup() did not replace the original Execute function properly")
+			}
+
+			// verify that the original Execute was saved when mocking was setup
+			require.NotNil(mockEnv.OriginalExecute(), "MockExecuteEnv.Setup() did not correctly save the original Execute routine")
+			if reflect.ValueOf(mockEnv.OriginalExecute()).Pointer() != reflect.ValueOf(originalExecute).Pointer() {
+				t.Fatal("MockExecuteEnv.Setup() did not save the original Execute function properly")
+			}
+
+			// perform the mocked call
+			output, err := Execute(cfg.cmd, cfg.exitCodes)
+
+			// verify that after teardown the original Execute is restored
+			mockEnv.Teardown()
+			require.NotNil(Execute, "MockExecuteEnv.Teardown() did not correctly restore the Execute routine")
+			if reflect.ValueOf(Execute).Pointer() != reflect.ValueOf(originalExecute).Pointer() {
+				t.Fatal("MockExecuteEnv.Teardown() did not restore the original Execute function properly")
+			}
+
+			// verify that expected mocked output and error were returned
+			assert.Equal(cfg.output, output, "Mocked Execute() returned unexpected output")
+			assert.Equal(cfg.err, err, "Mocked Execute() returned unexpected error")
+
+			// verify that Execute() was called as expected
+			require.Equal(cfg.numCalls, mockEnv.NumCalls, "Execute() called unexpected number of times")
+			assert.Equal(cfg.cmd, mockEnv.CmdLinesList[0], "Execute() called with unexpected cmd argument")
+			assert.Equal(cfg.exitCodes, mockEnv.ExitCodesList[0], "Execute() called with unexpected exitCodes argument")
+
+		})
+	}
+}


### PR DESCRIPTION
Add a helper routine, Systemctl(), to the util package that leverages the Execute() helper to run systemctl commands.

Add a new type SystemdUnitFiles that supports querying properties of systemd unit files.

Add ListMatchingUnitFilesOfTypeAndState() helper routine, leveraging Systemctl(), returning a slice of SystemdUnitFiles, representing the set of systemd unit files of both the specified type and state that match the provided wildcard naming patern.

Add testing helper routines and associated types to simplify mocking Execute() for the various new scenarios that need to be tested in the util package. These new routines and types can be leveraged by other packages that leverage Execute() to potentially simplify any mocking needs their tests may have.

Add unit tests for the new Execute() mocking features. Additionally leverage these new mocking features to verify correct operation of the new Systemctl(), ListMatchingUnitFilesOfTypeAndState() routines and the SystemdUnitFile.Property() method.

Implements: TEL-358