### PR TITLE
Bump default Go version for package builds to 1.24

### DIFF
--- a/.github/workflows/features.yml
+++ b/.github/workflows/features.yml
@@ -28,7 +28,7 @@ jobs:
   feature-tests:
     runs-on: ubuntu-latest
     container:
-      image: registry.suse.com/bci/golang:1.21-openssl
+      image: registry.suse.com/bci/golang:1.24-openssl
       options: --user root --privileged
 
     steps:

--- a/.github/workflows/lint-unit.yml
+++ b/.github/workflows/lint-unit.yml
@@ -23,7 +23,7 @@ jobs:
   unit-tests:
     runs-on: ubuntu-latest
     container:
-      image: registry.suse.com/bci/golang:1.21-openssl
+      image: registry.suse.com/bci/golang:1.24-openssl
 
     steps:
       - uses: actions/checkout@v4

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ GOFLAGS       = -v -mod=vendor
 BINFLAGS      = -buildmode=pie
 SOFLAGS       = -buildmode=c-shared
 
-CONTAINER     = registry.suse.com/bci/golang:1.21-openssl
+CONTAINER     = registry.suse.com/bci/golang:1.24-openssl
 CRM           = docker run --rm -it --privileged
 ENVFILE       = .env
 WORKDIR       = /usr/src/connect-ng

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This will create a `out/suseconnect` binary.
 ### Build in container
 If you don't have a go compiler installed, you can run the build in a container: 
 ```
-docker run --rm -v $(pwd):/connect registry.suse.com/bci/golang:1.21-openssl sh -c "git config --global --add safe.directory /connect; cd /connect; make build"
+docker run --rm -v $(pwd):/connect registry.suse.com/bci/golang:1.24-openssl sh -c "git config --global --add safe.directory /connect; cd /connect; make build"
 ```
 This will create a `out/suseconnect` binary on the host.
 

--- a/build/ci/README.md
+++ b/build/ci/README.md
@@ -40,7 +40,7 @@ BETA_NOT_ACTIVATED_REGCODE=
 We use the official SUSE Golang container, providing all we need to run the tests:
 
 ```
-export IMAGE="registry.suse.com/bci/golang:1.21-openssl"
+export IMAGE="registry.suse.com/bci/golang:1.24-openssl"
 # Run the required container:
 $ docker run --rm -it --env-file .env -v $(pwd):/usr/src/connect-ng $IMAGE
 

--- a/build/packaging/suseconnect-ng.changes
+++ b/build/packaging/suseconnect-ng.changes
@@ -14,7 +14,7 @@ Thu Mar 12 18:53:13 UTC 2026 - Felix Schnizlein <fschnizlein@suse.com>
   - Fix libsuseconnect APIError detection logic (bsc#1257825)
   - Fix nil token handling (bsc#1261155)
   - Switch to using go1.24-openssl as the default Go version to
-    install to support building the package.
+    install to support building the package (jsc#SCC-585).
 
 -------------------------------------------------------------------
 Wed Mar  4 16:48:14 UTC 2026 - Felix Schnizlein <fschnizlein@suse.com>

--- a/build/packaging/suseconnect-ng.changes
+++ b/build/packaging/suseconnect-ng.changes
@@ -13,6 +13,8 @@ Thu Mar 12 18:53:13 UTC 2026 - Felix Schnizlein <fschnizlein@suse.com>
   - Add missing product id to allow yast2-registration to not break (bsc#1257825)
   - Fix libsuseconnect APIError detection logic (bsc#1257825)
   - Fix nil token handling (bsc#1261155)
+  - Switch to using go1.24-openssl as the default Go version to
+    install to support building the package.
 
 -------------------------------------------------------------------
 Wed Mar  4 16:48:14 UTC 2026 - Felix Schnizlein <fschnizlein@suse.com>

--- a/build/packaging/suseconnect-ng.spec
+++ b/build/packaging/suseconnect-ng.spec
@@ -30,7 +30,7 @@ Source1:        %{name}-rpmlintrc
 Source2:        vendor.tar.xz
 
 # Build against latest golang in Tumbleweed and
-# go1.21-openssl on all other distributions
+# go1.24-openssl on all other distributions
 %if 0%{?suse_version} == 1699
 BuildRequires:  golang(API)
 %else

--- a/build/packaging/suseconnect-ng.spec
+++ b/build/packaging/suseconnect-ng.spec
@@ -34,7 +34,7 @@ Source2:        vendor.tar.xz
 %if 0%{?suse_version} == 1699
 BuildRequires:  golang(API)
 %else
-BuildRequires:  go1.21-openssl
+BuildRequires:  go1.24-openssl
 %endif
 
 BuildRequires:  ruby-devel

--- a/features/README.md
+++ b/features/README.md
@@ -18,7 +18,7 @@ If you do not want to run a full RPM build process you can do the following:
 ```
  # Make sure your .env is populated!
  $ cp .env-example .env
- $ docker run --rm --privileged --env-file .env -ti -v $(pwd):/connect registry.suse.com/bci/golang:1.21-openssl
+ $ docker run --rm --privileged --env-file .env -ti -v $(pwd):/connect registry.suse.com/bci/golang:1.24-openssl
  > git config --global --add safe.directory /connect
  > cd /connect
  > make build

--- a/features/suseconnect/extensions_test.go
+++ b/features/suseconnect/extensions_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/SUSE/connect-ng/features/helpers"
 	"github.com/SUSE/connect-ng/pkg/registration"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestExtensions(t *testing.T) {
@@ -161,17 +162,49 @@ func testActivateAndDeactivateExtensionWithRegcode(t *testing.T) {
 
 func testActivateLeafModule(t *testing.T) {
 	assert := assert.New(t)
+	require := require.New(t)
 
 	zypp := helpers.NewZypper(t)
-	_, version, arch := zypp.BaseProduct()
+	identifier, version, arch := zypp.BaseProduct()
+	api := helpers.NewValidationAPI(t)
+	// Assume we are already registered
+	api.FetchCredentials()
 
 	// Pick a module which is depended on another module which is not yet activated
-	// HPC requires Web and Scripting module
-	extension := fmt.Sprintf("%s/%s/%s", "sle-module-hpc", version, arch)
+	// HPC requires Web and Scripting module in SLE 15
+	// NOTE: This test may not be viable in a SLE 16 based test environment
+	targetModule := "sle-module-hpc"
+	dependentModule := "sle-module-web-scripting"
+	extension := fmt.Sprintf("%s/%s/%s", targetModule, version, arch)
+
+	// determine friendly names for the target and dependent modules
+	targetFriendlyName := ""
+	dependentFriendlyName := ""
+	tree := api.ProductTree(identifier, version, arch)
+	tree.TraverseExtensions(func(ext registration.Product) (bool, error) {
+		switch ext.Identifier {
+		case targetModule:
+			targetFriendlyName = ext.FriendlyName
+		case dependentModule:
+			dependentFriendlyName = ext.FriendlyName
+		}
+		if targetFriendlyName != "" && dependentFriendlyName != "" {
+			return false, nil
+		}
+		return true, nil
+	})
+
+	// ensure test fails immediately if unable to determine the friendly names of
+	// the target and dependent modules
+	require.NotEmpty(targetFriendlyName, "Failed to determine friendly name for %q extension", targetModule)
+	require.NotEmpty(dependentFriendlyName, "Failed to determine friendly name for %q extension", targetModule)
+
+	// construct expected error message for failure using discovered friendly names
+	expectedError := fmt.Sprintf("Error: Registration server returned 'The product you are attempting to activate (%s) requires one of these products to be activated first: %s'", targetFriendlyName, dependentFriendlyName)
 
 	cli := helpers.NewRunner(t, "suseconnect -p %s", extension)
 	cli.Run()
 
-	assert.Contains(cli.Stdout(), "Error: Registration server returned 'The product you are attempting to activate (HPC Module 15 SP6 x86_64) requires one of these products to be activated first: Web and Scripting Module 15 SP6 x86_64'")
+	assert.Contains(cli.Stdout(), expectedError)
 	assert.Equal(67, cli.ExitCode())
 }


### PR DESCRIPTION
Switch the default Go package installed to support package builds to g1.24-openssl. This should be available on all currently supported release streams.