### PR TITLE
Fix system leak in feature tests

### DIFF
--- a/build/ci/run-feature-tests
+++ b/build/ci/run-feature-tests
@@ -7,6 +7,8 @@ SOURCE=${SOURCE:-/usr/src/connect-ng}
 # exported variables we expect to exist to run the tests
 KEYS_TO_CHECK=(REGCODE EXPIRED_REGCODE HA_REGCODE)
 
+REMOVE_PRODUCTS="sle-module-python3 sle-module-server-applications sle-module-basesystem"
+
 group() { echo "::group::$1"; }
 groupend() { echo "::groupend::"; }
 fail() { echo "::error::$1"; exit 1; }
@@ -24,8 +26,17 @@ group "cleanup test system"
   [ -f /etc/SUSEConnect ] && rm /etc/SUSEConnect
 groupend
 
+# Remove products so container in a clean state
+group "Clean Container"
+for product in ${REMOVE_PRODUCTS}; do
+    if zypper --no-refresh se --installed-only -t product ${product} | grep -q ${product}; then
+	   zypper --no-refresh --non-interactive remove -t product ${product}
+    fi
+done
+groupend
+
 group "run feature tests"
 pushd "$SOURCE"
- go test -timeout 15m -v features/suseconnect/*
+go test -timeout 15m -v features/suseconnect/*.go
 popd
 groupend

--- a/features/suseconnect/changed_root_test.go
+++ b/features/suseconnect/changed_root_test.go
@@ -14,13 +14,19 @@ func TestChangedRoot(t *testing.T) {
 	assert := assert.New(t)
 	env := helpers.NewEnv(t)
 
+	// cleanup any cruft left from container creation 
+	cli := helpers.NewRunner(t, "suseconnect -r %s", env.REGCODE)
+	cli.Run()
+	cli = helpers.NewRunner(t, "suseconnect -d")
+	cli.Run()
+
 	root := setupCustomRoot(t)
 	namespace := "test-namespace"
 
 	// No need to install rpm packages just registration
 	t.Setenv("SKIP_SERVICE_INSTALL", "true")
 
-	cli := helpers.NewRunner(t, "suseconnect --root %s --namespace %s -r %s", root, namespace, env.REGCODE)
+	cli = helpers.NewRunner(t, "suseconnect --root %s --namespace %s -r %s", root, namespace, env.REGCODE)
 	cli.Run()
 
 	assert.Equal(0, cli.ExitCode())
@@ -33,6 +39,9 @@ func TestChangedRoot(t *testing.T) {
 	t.Run("check credentials location", func(t *testing.T) {
 		testChangedRootCredentialsLocation(t, root)
 	})
+	// dereg to remove created system from SCC
+	cli = helpers.NewRunner(t, "suseconnect --root %s -d", root)
+	cli.Run()
 }
 
 func setupCustomRoot(t *testing.T) string {

--- a/features/suseconnect/changed_root_test.go
+++ b/features/suseconnect/changed_root_test.go
@@ -14,7 +14,10 @@ func TestChangedRoot(t *testing.T) {
 	assert := assert.New(t)
 	env := helpers.NewEnv(t)
 
-	// cleanup any cruft left from container creation 
+	// cleanup any stale state left from container creation by registering and
+	// then cleanly deregistering which removes any related zypper repo services
+	// and associated release packages
+	
 	cli := helpers.NewRunner(t, "suseconnect -r %s", env.REGCODE)
 	cli.Run()
 	cli = helpers.NewRunner(t, "suseconnect -d")


### PR DESCRIPTION
   The feature test can fail to deregister systems because
    when suseconnect deactivates it gets a list of the release packages installed
    on the system and attempts to deactivate those on the SCC.
    
    But SCC may have activated extensions where the system does not have
    release packages installed. If the SCC has an active extension that
    depends on an release package installed on the system, the de-reg will fail.
    
    This is the situation in the current test setup. The current reg leak issue
    can be addressed by making sure the test container is in a clean state
    before starting the tests.
    
    This done by removing the unregistered products before starting the tests.

    Limit the go test to .go files, while not needed to address the
    registration leak, it keeps local testing from failing if stray files
    are in the test directory.
