### PR TITLE
Harden pull request workflows

### DIFF
--- a/.actrc
+++ b/.actrc
@@ -1,4 +1,5 @@
 --artifact-server-path /tmp/act-connect-ng-artifact-server
 --env-file .env
+--secret-file .env
 --platform ubuntu-latest=ghcr.io/catthehacker/ubuntu:go-latest
 

--- a/.github/workflows/agama.yml
+++ b/.github/workflows/agama.yml
@@ -3,6 +3,8 @@ name: agama tests
 
 on: [pull_request]
 
+permissions:
+  contents: read
 env:
   CONNECTNG_SOURCE: /usr/src/connect-ng
   AGAMA_SOURCE: /usr/src/agama

--- a/.github/workflows/agama.yml
+++ b/.github/workflows/agama.yml
@@ -10,8 +10,6 @@ env:
   AGAMA_SOURCE: /usr/src/agama
   CONNECTNG_ARTIFACT: suseconnect-build-out
   CONNECTNG_TARBALL: /usr/src/suseconnect-build-out.tar.gz
-  REGCODE: ${{ secrets.REGCODE }}
-  RMT_HOST: ${{ secrets.RMT_HOST }}
 
 jobs:
 
@@ -28,7 +26,7 @@ jobs:
           zypper --non-interactive in nodejs-default
 
       - name: Checkout SUSE/connect-ng
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           path: connect-ng
 
@@ -67,7 +65,7 @@ jobs:
           zypper --non-interactive in nodejs-default
 
       - name: Checkout SUSE/connect-ng
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           path: connect-ng
 
@@ -86,7 +84,7 @@ jobs:
           tar -C ${CONNECTNG_SOURCE} -xzf ${CONNECTNG_TARBALL}
 
       - name: Checkout agama-project/agama
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           repository: agama-project/agama
           path: agama
@@ -97,5 +95,8 @@ jobs:
 
       - name: Run agama rust tests
         working-directory: ${{ env.CONNECTNG_SOURCE }}
+        env:
+          REGCODE: ${{ secrets.REGCODE }}
+          RMT_HOST: ${{ secrets.RMT_HOST }}
         run: |
           build/ci/run-agama-rust-tests

--- a/.github/workflows/build-rpm.yml
+++ b/.github/workflows/build-rpm.yml
@@ -3,6 +3,8 @@ name: build and install rpm
 
 on: [pull_request]
 
+permissions:
+  contents: read
 env:
   SOURCE: /usr/src/connect-ng
   ARTIFACT_SOURCE: artifacts

--- a/.github/workflows/build-rpm.yml
+++ b/.github/workflows/build-rpm.yml
@@ -8,7 +8,6 @@ permissions:
 env:
   SOURCE: /usr/src/connect-ng
   ARTIFACT_SOURCE: artifacts
-  REGCODE: ${{ secrets.REGCODE }}
 
 jobs:
   build-rpm:
@@ -18,7 +17,7 @@ jobs:
       options: --user root --privileged
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: move source to /usr/src/connect-ng
         run: |

--- a/.github/workflows/features.yml
+++ b/.github/workflows/features.yml
@@ -17,22 +17,23 @@ name: feature tests
 # See: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
 on: [pull_request]
 
+permissions:
+  contents: read
+
 env:
   SOURCE: /usr/src/connect-ng
   ARTIFACT_SOURCE: artifacts
-  REGCODE: ${{ secrets.REGCODE }}
-  HA_REGCODE: ${{ secrets.HA_REGCODE }}
-  EXPIRED_REGCODE: ${{ secrets.EXPIRED_REGCODE }}
 
 jobs:
   feature-tests:
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     container:
       image: registry.suse.com/bci/golang:1.24-openssl
       options: --user root --privileged
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: move source to /usr/src/connect-ng
         run: |
@@ -49,6 +50,10 @@ jobs:
       #     path: ${{ env.SOURCE }}/${{ env.ARTIFACT_SOURCE }}/*.rpm
 
       - name: configure Connect to run feature tests
+        env:
+          REGCODE: ${{ secrets.REGCODE }}
+          HA_REGCODE: ${{ secrets.HA_REGCODE }}
+          EXPIRED_REGCODE: ${{ secrets.EXPIRED_REGCODE }}
         run: bash build/ci/configure
 
       - name: run feature tests

--- a/.github/workflows/features.yml
+++ b/.github/workflows/features.yml
@@ -57,4 +57,8 @@ jobs:
         run: bash build/ci/configure
 
       - name: run feature tests
+        env:
+          REGCODE: ${{ secrets.REGCODE }}
+          HA_REGCODE: ${{ secrets.HA_REGCODE }}
+          EXPIRED_REGCODE: ${{ secrets.EXPIRED_REGCODE }}
         run: bash build/ci/run-feature-tests

--- a/.github/workflows/features.yml
+++ b/.github/workflows/features.yml
@@ -33,7 +33,7 @@ jobs:
       options: --user root --privileged
 
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: move source to /usr/src/connect-ng
         run: |

--- a/.github/workflows/features.yml
+++ b/.github/workflows/features.yml
@@ -20,7 +20,7 @@ jobs:
       options: --user root --privileged
 
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: move source to /usr/src/connect-ng
         run: |

--- a/.github/workflows/features.yml
+++ b/.github/workflows/features.yml
@@ -3,23 +3,24 @@ name: feature tests
 
 on: [pull_request]
 
+permissions:
+  contents: read
+
 env:
   SOURCE: /usr/src/connect-ng
   ARTIFACT_SOURCE: artifacts
   COVERAGE_BIN: true
-  REGCODE: ${{ secrets.REGCODE }}
-  HA_REGCODE: ${{ secrets.HA_REGCODE }}
-  EXPIRED_REGCODE: ${{ secrets.EXPIRED_REGCODE }}
 
 jobs:
   feature-tests:
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     container:
       image: registry.suse.com/bci/golang:1.26-openssl
       options: --user root --privileged
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: move source to /usr/src/connect-ng
         run: |

--- a/.github/workflows/features.yml
+++ b/.github/workflows/features.yml
@@ -35,6 +35,10 @@ jobs:
           make build
 
       - name: run feature tests
+        env:
+          REGCODE: ${{ secrets.REGCODE }}
+          HA_REGCODE: ${{ secrets.HA_REGCODE }}
+          EXPIRED_REGCODE: ${{ secrets.EXPIRED_REGCODE }}
         run: |
           set -e
           cd $SOURCE

--- a/.github/workflows/features.yml
+++ b/.github/workflows/features.yml
@@ -20,7 +20,7 @@ jobs:
       options: --user root --privileged
 
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: move source to /usr/src/connect-ng
         run: |

--- a/.github/workflows/features.yml
+++ b/.github/workflows/features.yml
@@ -13,14 +13,13 @@ env:
 
 jobs:
   feature-tests:
-    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     container:
       image: registry.suse.com/bci/golang:1.26-openssl
       options: --user root --privileged
 
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@v7
 
       - name: move source to /usr/src/connect-ng
         run: |

--- a/.github/workflows/lint-unit.yml
+++ b/.github/workflows/lint-unit.yml
@@ -16,6 +16,9 @@ name: lint + unit tests
 # See: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
 on: [pull_request]
 
+permissions:
+  contents: read
+
 env:
   SOURCE: /usr/src/connect-ng
 
@@ -26,7 +29,7 @@ jobs:
       image: registry.suse.com/bci/golang:1.24-openssl
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: move source to /usr/src/connect-ng
         run: |

--- a/.github/workflows/lint-unit.yml
+++ b/.github/workflows/lint-unit.yml
@@ -29,7 +29,7 @@ jobs:
       image: registry.suse.com/bci/golang:1.24-openssl
 
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: move source to /usr/src/connect-ng
         run: |

--- a/.github/workflows/lint-unit.yml
+++ b/.github/workflows/lint-unit.yml
@@ -12,7 +12,7 @@ jobs:
       image: registry.suse.com/bci/golang:1.26-openssl
 
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: run golang linting
         run: make check-format

--- a/.github/workflows/lint-unit.yml
+++ b/.github/workflows/lint-unit.yml
@@ -2,6 +2,9 @@ name: lint + unit tests
 
 on: [pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   unit-tests:
     runs-on: ubuntu-latest
@@ -9,7 +12,7 @@ jobs:
       image: registry.suse.com/bci/golang:1.26-openssl
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: run golang linting
         run: make check-format

--- a/.github/workflows/lint-unit.yml
+++ b/.github/workflows/lint-unit.yml
@@ -12,7 +12,7 @@ jobs:
       image: registry.suse.com/bci/golang:1.26-openssl
 
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: run golang linting
         run: make check-format

--- a/.github/workflows/lint-unit.yml
+++ b/.github/workflows/lint-unit.yml
@@ -12,7 +12,7 @@ jobs:
       image: registry.suse.com/bci/golang:1.26-openssl
 
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@v7
 
       - name: run golang linting
         run: make check-format

--- a/.github/workflows/yast.yml
+++ b/.github/workflows/yast.yml
@@ -1,11 +1,14 @@
 name: YaST integration tests
 on: [pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   yast:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Setup Go
         run: go mod vendor

--- a/.github/workflows/yast.yml
+++ b/.github/workflows/yast.yml
@@ -8,7 +8,7 @@ jobs:
   yast:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Setup Go
         run: go mod vendor

--- a/.github/workflows/yast.yml
+++ b/.github/workflows/yast.yml
@@ -8,7 +8,7 @@ jobs:
   yast:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Run test-yast
         run: make test-yast

--- a/.github/workflows/yast.yml
+++ b/.github/workflows/yast.yml
@@ -8,7 +8,7 @@ jobs:
   yast:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Run test-yast
         run: make test-yast

--- a/.github/workflows/yast.yml
+++ b/.github/workflows/yast.yml
@@ -1,11 +1,14 @@
 name: YaST integration tests
 on: [pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   yast:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Run test-yast
         run: make test-yast

--- a/.github/workflows/yast.yml
+++ b/.github/workflows/yast.yml
@@ -8,7 +8,7 @@ jobs:
   yast:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@v7
 
       - name: Run test-yast
         run: make test-yast

--- a/README.md
+++ b/README.md
@@ -311,8 +311,9 @@ specify alternate platform images via the `--platform` option.
 Additionally, enabling the emulation of the v4 artifact upload/download support
 also requires appropriate command line options to be set.
 
-Similarly, to ensure that `act` sets up the appropriate environment settings for
-jobs that run, the `--env-file .env` option should be set.
+Similarly, to ensure that `act` sets up the appropriate environment settings and
+secrets for jobs that run, the `--env-file .env` and `--secret-file .env`
+options should be set.
 
 The [.actrc](.actrc) file in the repo specifies appropriate values for these
 options.


### PR DESCRIPTION
This updates the pull request workflows to tighten permissions and reduce secret exposure.

- Set `contents: read` explicitly for all active PR workflows.
- Scope registration secrets to the steps that actually need them.
- Remove the unused `REGCODE` from the RPM workflow.
- Update all `actions/checkout` references to `v7`.
- Add `.env` as an `act` secret file and document the local setup.