### PR TITLE
Add a new RKE2 & K3s detection collector

### DIFF
--- a/build/packaging/suseconnect-ng.changes
+++ b/build/packaging/suseconnect-ng.changes
@@ -6,7 +6,9 @@ Mon Apr  6 15:40:58 UTC 2026 - Fergal Mc Carthy <fmccarthy@suse.com>
     (jsc#SCC-630).
   - Restore exit code 71 handling when attempting keepalive and not
     registered (bsc#1263772)
-  
+  - Add collector support for gathering RKE2 & K3s kubernetes provider
+    info if enabled on a system (jsc#TEL-317)
+
 -------------------------------------------------------------------
 Wed Apr  1 16:43:26 UTC 2026 - Fergal Mc Carthy <fmccarthy@suse.com>
 

--- a/features/README.md
+++ b/features/README.md
@@ -40,3 +40,67 @@ Also, feature tests modify the existing filesystem by adding/removing certain
 configuration files. Hence, make sure to run this into a containerized scenario
 if you don't want unexpected surprises. That's why `make feature-tests` runs in
 a container, and why the above example does it too.
+
+### Special Notes for Kubernetes Provider Info Feature Tests
+
+The kubernetes provider info feature tests require a valid functional systemd
+environment to work and customise that environment to add sumulated kubernetes
+provider services.
+
+As such they will not work inside the normal containerised feature testing
+environment, and require either a VM or customised container image with
+systemd installed and started. See below for details on how to do that.
+
+#### Environment variables used to manage kubernetes provider info tests
+
+As such these feasture tests will be skipped by default unless the required
+environment variable `KUBERNETES_PROVIDER_TESTS_ENABLED` is set in the
+environment.
+
+Additionally setting the `KUBERNETES_PROVIDER_TESTS_NO_CLEANUP` environment
+variable will disable the cleanup of the system modifications which can be
+helpful for adhoc testings and debugging.
+
+#### Starting a container with systemd enabled
+
+The recommended approach for this is to use `podman` rather than `docker` as
+`podman` is more friendly to systemd.
+
+You will need a customised container image which has systemd installed which
+can be accomplished using a Dockerfile like the following:
+
+```dockerfile
+FROM registry.suse.com/bci/golang:1.24-openssl
+
+# Install systemd and make
+RUN zypper -n install \
+    systemd \
+    dmidecode \
+    make \
+    jq \
+    && \
+    zypper clean --all
+
+# Set up systemd as the default entrypoint
+# Note: Requires running with privileged mode or specific systemd volumes in podman
+CMD ["/usr/lib/systemd/systemd"]
+```
+
+The kubernetes provider info tests can now be run as follows:
+
+* build a testing image using the above Dockerfile
+* start a named background container using that image with systemd enabled and repo dir mounted as /connect
+* exec into the container to run a bash shell
+* build the suseconnect and symlink it into the accessible path
+* run the kubernetes provider tests with K8S_PROVIDER_TESTS_ENABLED=true set in the environment
+
+```bash
+$ podman build -t k8s-provider-tester -F /tmp/Dockerfile.k8s-tester
+$ podman run -d --name k8s-testing --systemd=true --env-file .env -v $(pwd):/connect k8s-provider-tester
+$ podman exec -it k8s-testing /bin/bash
+> git config --global --add safe.directory /connect
+> cd /connect
+> make build
+> ln -s /connect/out/suseconnect /usr/local/bin/suseconnect
+> env K8S_PROVIDER_TESTS_ENABLED=true go test -v features/suseconnect/kubernetes_provider_info_test.go
+```

--- a/features/suseconnect/kubernetes_provider_info_test.go
+++ b/features/suseconnect/kubernetes_provider_info_test.go
@@ -1,0 +1,280 @@
+package features
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/SUSE/connect-ng/features/helpers"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func getKubernetesProviderInfo(t *testing.T) map[string]any {
+	cli := helpers.NewRunner(t, "suseconnect --info")
+	cli.Run()
+	require.Equal(t, 0, cli.ExitCode(), "suseconnect --info failed")
+
+	hwinfo := helpers.AssertValidJSON[map[string]any](t, cli.Stdout())
+	if kp, ok := hwinfo["kubernetes_provider"].(map[string]any); ok {
+		return kp
+	}
+	return nil
+}
+
+var (
+	// path under which simulated k8s provider scripts will be created
+	simulatedK8sDir = "/usr/local/bin"
+
+	// directory for simulated systemd services
+	etcSystemdDir = "/etc/systemd/system"
+
+	// k8s provider versions - must match values in embedded script
+	rke2Version = "v1.33.6+rke2r1"
+	k3sVersion  = "v1.33.6+k3s1"
+
+	// environment variables used to manage running these tests
+	k8sProviderTestsEnabled   = "K8S_PROVIDER_TESTS_ENABLED"
+	k8sProviderTestsNoCleanup = "K8S_PROVIDER_TESTS_NO_CLEANUP"
+)
+
+func generateSimulatedK8sScript() string {
+	return `#!/bin/bash
+
+# ensure unassigned variables are treated as errors and fail immediately
+set -eu
+
+# determine the script name, which is the k8s provider to simulate
+k8s="$(basename "${BASH_SOURCE[0]}")"
+
+declare -A is_simulated
+is_simulated[k3s]=true
+is_simulated[rke2]=true
+
+if [[ "${is_simulated[${k8s}]:-false}" != "true" ]]; then
+    echo "ERROR: k8s provider not simulated: '${k8s}'"
+    exit 1
+fi
+
+declare -A k8s_version_info
+# simulated k3s version string - keep in sync with values in test file
+k8s_version_info[k3s]="k3s version ` + k3sVersion + ` (b5847677)
+go version go1.24.9"
+# simulated rke2 version string
+k8s_version_info[rke2]="rke2 version ` + rke2Version + ` (2c2298232b55a94bd16b059f893c76a950811489)
+go version go1.24.9 X:boringcrypto"
+
+# simulate a running service by sleeping forever until
+# terminated by a signal
+simulate_service_running()
+{
+    local role="${1-server}"
+
+    # trap signals to exit cleanly when systemd stops the service
+    trap "echo Exiting...; exit 0" SIGINT SIGTERM
+
+    # sleep forever so systemd maintains an 'active' state
+    echo "Simulated ${k8s} sleeping forever simulating role '${role}'"
+    sleep infinity & wait
+}
+
+# determine the action to perform
+action="${1:-}"
+case "${action}" in
+    (--version)
+        echo "${k8s_version_info[${k8s}]}"
+        ;;
+
+    (agent|server|dummy|"")
+        simulate_service_running "${action:-no_role_specified}"
+        ;;
+
+    (*)
+        echo "ERROR: Action '${action}' not implemented for simulated provider '${k8s}'"
+        exit 1
+        ;;
+esac
+
+# clean exit if we get here
+exit 0
+`
+}
+
+func setupSimulatedK8sEnv(t *testing.T) []string {
+	err := os.MkdirAll(simulatedK8sDir, 0755)
+	require.NoError(t, err, "Failed to create simulatedK8sDir %s directory", simulatedK8sDir)
+
+	// write simulated provider script for currently simulated providers
+	simulatedK8sScript := generateSimulatedK8sScript()
+	k3sScriptPath := filepath.Join(simulatedK8sDir, "k3s")
+	rke2ScriptPath := filepath.Join(simulatedK8sDir, "rke2")
+	for _, k8sScript := range []string{k3sScriptPath, rke2ScriptPath} {
+		err := os.WriteFile(k8sScript, []byte(simulatedK8sScript), 0755)
+		require.NoError(t, err, "Failed to write simulated %s script", k8sScript)
+	}
+
+	services := map[string]string{
+		// valid k3s services
+		"k3s.service":        k3sScriptPath + " server",
+		"k3s-agent.service":  k3sScriptPath + " agent",
+		"k3s-custom.service": k3sScriptPath + " server",
+
+		// valid rke2 services
+		"rke2-server.service": rke2ScriptPath + " server",
+		"rke2-agent.service":  rke2ScriptPath + " agent",
+
+		// dummy services
+		"k3s-dummy.service":  k3sScriptPath + " dummy",
+		"rke2-dummy.service": rke2ScriptPath + " dummy",
+
+		// invalid services
+		"k3snodash.service":    k3sScriptPath,
+		"k3s-invalid.service":  k3sScriptPath,
+		"rke2-invalid.service": rke2ScriptPath,
+	}
+
+	etcSystemdDir := "/etc/systemd/system"
+	var svcNames []string
+	for name, execStart := range services {
+		content := fmt.Sprintf("[Unit]\nDescription=Simulated %s\n\n[Service]\nExecStart=%s\n\n[Install]\nWantedBy=multi-user.target\n", name, execStart)
+		err := os.WriteFile(filepath.Join(etcSystemdDir, name), []byte(content), 0644)
+		require.NoError(t, err, "Failed to write simulated service %s", name)
+		svcNames = append(svcNames, name)
+	}
+
+	systemdDaemonReload(t)
+
+	return svcNames
+}
+
+func cleanupSimulatedK8sEnv(t *testing.T, services []string) {
+	// skip test env cleanup if no cleanup env var exists
+	if _, ok := os.LookupEnv(k8sProviderTestsNoCleanup); ok {
+		return
+	}
+
+	for _, name := range services {
+		// disable the service
+		systemdServiceAction(t, name, "disable")
+
+		// remove the simulated service
+		os.Remove(filepath.Join(etcSystemdDir, name))
+	}
+
+	k3sScript := filepath.Join(simulatedK8sDir, "k3s")
+	rke2Script := filepath.Join(simulatedK8sDir, "rke2")
+	for _, k8sScript := range []string{k3sScript, rke2Script} {
+		os.Remove(k8sScript)
+	}
+
+	systemdDaemonReload(t)
+}
+
+func systemdServiceAction(t *testing.T, name, action string) {
+	// Enable/disable service immediately
+	cli := helpers.NewRunner(t, "systemctl %s --now %s", action, name)
+	cli.Run()
+}
+
+func systemdDaemonReload(t *testing.T) {
+	// Enable/disable service immediately
+	cli := helpers.NewRunner(t, "systemctl daemon-reload")
+	cli.Run()
+}
+
+func TestKubernetesProviderInfo(t *testing.T) {
+	assert := assert.New(t)
+
+	// skip if systemctl not available
+	if _, err := exec.LookPath("systemctl"); err != nil {
+		t.Skip("Skipping feature test: systemctl not available in this environment")
+	}
+
+	// skip if provider tests enabled env var is not set
+	if _, ok := os.LookupEnv(k8sProviderTestsEnabled); !ok {
+		t.Skipf("Skipping feature test: env var %q not set", k8sProviderTestsEnabled)
+	}
+
+	services := setupSimulatedK8sEnv(t)
+	defer cleanupSimulatedK8sEnv(t, services)
+
+	targetServices := []struct {
+		name     string
+		role     string
+		provider string
+		version  string
+		service  string
+	}{
+		{"RKE2 Server", "server", "rke2", rke2Version, "rke2-server.service"},
+		{"RKE2 Agent", "agent", "rke2", rke2Version, "rke2-agent.service"},
+		{"K3s Server", "server", "k3s", k3sVersion, "k3s.service"},
+		{"K3s Agent", "agent", "k3s", k3sVersion, "k3s-agent.service"},
+		{"K3s Custom Server", "server", "k3s", k3sVersion, "k3s-custom.service"},
+	}
+	for _, tt := range targetServices {
+		t.Run(fmt.Sprintf("Detects %s", tt.name), func(t *testing.T) {
+			systemdServiceAction(t, tt.service, "enable")
+			defer systemdServiceAction(t, tt.service, "disable")
+
+			expected := map[string]any{
+				"type":    tt.provider,
+				"role":    tt.role,
+				"version": tt.version,
+			}
+			kp := getKubernetesProviderInfo(t)
+			assert.NotNil(kp, "suseconnect --info should have returned a valid kubernetes_provider entry")
+			assert.Equal(expected, kp, "suseconnect --info should have returned the expected kubernetes provider entry")
+		})
+	}
+
+	t.Run("Ignores dummy roles", func(t *testing.T) {
+		for _, svcName := range []string{"k3s-dummy.service", "rke2-dummy.service"} {
+			systemdServiceAction(t, svcName, "enable")
+			defer systemdServiceAction(t, svcName, "disable")
+		}
+
+		kp := getKubernetesProviderInfo(t)
+		assert.Nil(kp, "Expected no valid kubernetes provider due to dummy roles")
+	})
+
+	t.Run("Ignores invalid execStart arguments", func(t *testing.T) {
+		for _, svcName := range []string{"k3snodash.service", "k3s-invalid.service", "rke2-invalid.service"} {
+			systemdServiceAction(t, svcName, "enable")
+			defer systemdServiceAction(t, svcName, "disable")
+		}
+
+		kp := getKubernetesProviderInfo(t)
+		assert.Nil(kp, "Expected no valid kubernetes provider due to invalid execStart arguments")
+	})
+
+	t.Run("Logs expected debug message when no providers detected", func(t *testing.T) {
+		cli := helpers.NewRunner(t, "suseconnect --info --debug")
+		cli.Run()
+		assert.Equal(0, cli.ExitCode(), "suseconnect should not fail when multiple providers are enabled")
+		assert.Contains(cli.Stderr(), "No kubernetes providers found", "suseconnect should log the expected debug message")
+	})
+
+	t.Run("Logs expected debug message when multiple providers detected", func(t *testing.T) {
+		systemdServiceAction(t, "k3s.service", "enable")
+		systemdServiceAction(t, "rke2-server.service", "enable")
+		defer systemdServiceAction(t, "k3s.service", "disable")
+		defer systemdServiceAction(t, "rke2-server.service", "disable")
+
+		cli := helpers.NewRunner(t, "suseconnect --info --debug")
+		cli.Run()
+		assert.Equal(0, cli.ExitCode(), "suseconnect should not fail when multiple providers are enabled")
+		assert.Contains(cli.Stderr(), "too many kubernetes providers enabled", "suseconnect should log the expected debug message")
+	})
+
+	t.Run("Successfully Skips Disabled Services", func(t *testing.T) {
+		systemdServiceAction(t, "k3s-agent.service", "enable")
+		kp := getKubernetesProviderInfo(t)
+		assert.NotNil(kp)
+
+		systemdServiceAction(t, "k3s-agent.service", "disable")
+		kp = getKubernetesProviderInfo(t)
+		assert.Nil(kp, "Disabled service was not correctly skipped")
+	})
+}

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/SUSE/connect-ng
 go 1.24
 
 require (
+	github.com/godbus/dbus/v5 v5.2.2
 	github.com/google/uuid v1.6.0
 	github.com/stretchr/testify v1.9.0
 )
@@ -11,5 +12,6 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
+	golang.org/x/sys v0.27.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/godbus/dbus/v5 v5.2.2 h1:TUR3TgtSVDmjiXOgAAyaZbYmIeP3DPkld3jgKGV8mXQ=
+github.com/godbus/dbus/v5 v5.2.2/go.mod h1:3AAv2+hPq5rdnr5txxxRwiGjPXamgoIHgz9FPBfOp3c=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
@@ -8,6 +10,8 @@ github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
 github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+golang.org/x/sys v0.27.0 h1:wBqf8DvsY9Y/2P8gAfPDEYNuS30J4lPHJxXSb/nJZ+s=
+golang.org/x/sys v0.27.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/internal/collectors/kubernetes_provider.go
+++ b/internal/collectors/kubernetes_provider.go
@@ -1,0 +1,254 @@
+package collectors
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"regexp"
+	"slices"
+
+	"github.com/SUSE/connect-ng/internal/util"
+)
+
+const (
+	// recognised kubernetes providers
+	RKE2_PROVIDER = "rke2"
+	K3S_PROVIDER  = "k3s"
+
+	// recognised kubernetes provider node roles
+	KUBERNETES_SERVER = "server"
+	KUBERNETES_AGENT  = "agent"
+)
+
+// Custom Errors
+var (
+	KubernetesProviderNotRecognised    = errors.New("kubernetes provider not recognised")
+	KubernetesRoleNotRecognised        = errors.New("kubernetes role not recognised")
+	KubernetesMultipleProvidersEnabled = errors.New("multiple kubernetes providers enabled")
+)
+
+var (
+	//
+	// regexp matchers
+	//
+
+	// match lines with the format "<app> version <version> (<hash>)" and extract
+	// <version> and <hash> fields
+	versionMatcher = regexp.MustCompile(`^\S+\s+version\s+(\S+)\s+\(([[:xdigit:]]+)\)$`)
+
+	//
+	// kubernetes providers and roles that this collector recognises and reports
+	//
+	recognisedKubernetesProviders = []string{
+		RKE2_PROVIDER,
+		K3S_PROVIDER,
+	}
+	recognisedKubernetesRoles = []string{
+		KUBERNETES_SERVER,
+		KUBERNETES_AGENT,
+	}
+)
+
+type K8S struct{}
+
+func (K8S) run(arch string) (Result, error) {
+	systemdClient, err := util.NewDbusSystemdClient()
+	if err != nil {
+		return nil, err
+	}
+	defer systemdClient.Close()
+
+	return generateKubernetesProvider(systemdClient)
+}
+
+func generateKubernetesProvider(systemdClient util.SystemdClient) (Result, error) {
+	provider, err := getKubernetesProviderData(systemdClient)
+	if err != nil {
+		util.Debug.Printf("Failed to get kubernetes provider: %s", err)
+		return Result{}, err
+	}
+
+	// nothing to report
+	if provider == nil {
+		return Result{}, nil
+	}
+
+	res := Result{"kubernetes_provider": provider}
+	return res, nil
+}
+
+func getKubernetesProviderData(systemdClient util.SystemdClient) (map[string]any, error) {
+	kSvcs, err := getKubernetesServices(systemdClient)
+	if err != nil {
+		return nil, err
+	}
+
+	// return nil without error if no services found
+	if len(kSvcs) == 0 {
+		util.Debug.Println("No kubernetes providers found")
+		return nil, nil
+	}
+
+	// only one kubernetes provider should be enabled on a system
+	if len(kSvcs) > 1 {
+		err := fmt.Errorf(
+			"too many kubernetes providers enabled (%d): %w",
+			len(kSvcs), KubernetesMultipleProvidersEnabled,
+		)
+		return nil, err
+	}
+
+	provider := map[string]any{
+		"type":    kSvcs[0].Type,
+		"role":    kSvcs[0].Role,
+		"version": kSvcs[0].Version,
+	}
+
+	return provider, nil
+}
+
+func getKubernetesServices(systemdClient util.SystemdClient) ([]*KubernetesService, error) {
+	kSvcs := []*KubernetesService{}
+
+	// first try to use ListUnitsByPatterns, failing back to ListUnits if not available
+	svcPatterns := []string{"rke2-*.service", "k3s.service", "k3s-*.service*"}
+	filterNames := false // expecting ListUnitsByPatterns to handle name filtering for us
+	units, err := systemdClient.ListUnitsByPatterns(svcPatterns...)
+	if err != nil {
+		if !errors.Is(err, util.SystemdMethodNotAvailable) {
+			util.Debug.Printf("systemdClient.ListUnitsByPatterns() failed: %s\n", err)
+			return nil, err
+		}
+
+		// fail back to ListUnits, and ensure name filtering is completed below
+		filterNames = true
+		units, err = systemdClient.ListUnits()
+		if err != nil {
+			util.Debug.Printf("systemdClient.ListUnits() failed: %s\n", err)
+			return nil, err
+		}
+	}
+
+	for _, unit := range units {
+		// skip if names don't match, if not already filtered by ListUnitsByPatterns
+		if filterNames && !unit.Name.Match(svcPatterns...) {
+			util.Debug.Printf("Skipping non-matching unit %q\n", unit.Name)
+			continue
+		}
+
+		state, err := systemdClient.GetUnitFileState(unit.Name)
+		if err != nil {
+			util.Debug.Printf("systemdClient.GetUnitFileState(%q) failed: %s\n", unit.Name, err)
+			// skip on failure
+			continue
+		}
+
+		// skip if not enabled
+		if state != "enabled" {
+			util.Debug.Printf("Skipping disabled unit %q\n", unit.Name)
+			continue
+		}
+
+		ks, err := NewKubernetesService(systemdClient, unit)
+		if err != nil {
+			util.Debug.Printf("NewKubernetesService(%q) failed: %s\n", unit.Name, err)
+			// skip on failure
+			continue
+		}
+		kSvcs = append(kSvcs, ks)
+	}
+
+	return kSvcs, nil
+}
+
+type KubernetesService struct {
+	Name        string
+	Type        string
+	Binary      string
+	Role        string
+	Version     string
+	VersionHash string
+}
+
+func NewKubernetesService(systemdClient util.SystemdClient, unit *util.SystemdUnit) (*KubernetesService, error) {
+	ks := new(KubernetesService)
+
+	// retrieve the ExecStart property value for the specified unit file
+	execStarts, err := systemdClient.GetExecStart(unit.ObjectPath)
+	if err != nil {
+		return nil, err
+	}
+
+	// proceed only if a single exec start was retrieved
+	if len(execStarts) != 1 {
+		err = fmt.Errorf("Multiple (%d) ExecStarts found for unit %q", len(execStarts), unit.Name)
+		return nil, err
+	}
+	execStart := execStarts[0]
+
+	// ensure that there are at least 2 arguments, binary path and role, in the args list
+	if len(execStart.Args) < 2 {
+		err = fmt.Errorf("Missing second argument in ExecStart for unit %q", unit.Name)
+		return nil, err
+	}
+
+	// store retrieved values
+	ks.Name = string(unit.Name)
+	ks.Binary = execStart.Path
+	ks.Role = execStart.Args[1]
+	ks.Type = filepath.Base(ks.Binary)
+
+	// validate type is recognised
+	if !slices.Contains(recognisedKubernetesProviders, ks.Type) {
+		err = fmt.Errorf(
+			"type %q not in recognised providers list %v: %w",
+			ks.Type, recognisedKubernetesProviders,
+			KubernetesProviderNotRecognised,
+		)
+		return nil, err
+	}
+
+	// validate role is recognised
+	if !slices.Contains(recognisedKubernetesRoles, ks.Role) {
+		err = fmt.Errorf(
+			"role %q not in recognised roles list %v: %w",
+			ks.Role, recognisedKubernetesRoles,
+			KubernetesRoleNotRecognised,
+		)
+		return nil, err
+	}
+
+	// retrieve the version using the binary
+	if err = ks.setVersion(); err != nil {
+		return nil, err
+	}
+
+	return ks, nil
+}
+
+func (ks *KubernetesService) setVersion() error {
+	output, err := util.Execute(
+		[]string{ks.Binary, "--version"},
+		[]int{0},
+	)
+	if err != nil {
+		// report failure if unable to retrieve version
+		err := fmt.Errorf("failed to run %s --version: %w", ks.Binary, err)
+		return err
+	}
+
+	// split into lines and extract version info from first line
+	outputLines := bytes.Split(output, []byte("\n"))
+	matches := versionMatcher.FindSubmatch(outputLines[0])
+	if len(matches) != 3 {
+		// report an error if version output doesn't match expected format
+		err = fmt.Errorf("failed to parse %s --version output", ks.Binary)
+		return err
+	}
+
+	ks.Version = string(matches[1])
+	ks.VersionHash = string(matches[2])
+
+	return nil
+}

--- a/internal/collectors/kubernetes_provider_test.go
+++ b/internal/collectors/kubernetes_provider_test.go
@@ -1,0 +1,914 @@
+package collectors
+
+import (
+	"fmt"
+	"path/filepath"
+	"regexp"
+	"testing"
+
+	"github.com/SUSE/connect-ng/internal/util"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	// RKE2 consts
+	rke2BinPath       = "/opt/rke2/bin/rke2"
+	rke2ListPattern   = "rke2-*"
+	rke2Version       = "v1.33.6+rke2r1"
+	rke2VersionHash   = "2c2298232b55a94bd16b059f893c76a950811489"
+	rke2VersionGolang = "go version go1.24.9 X:boringcrypto"
+
+	// K3s consts
+	k3sBinPath       = "/usr/local/bin/k3s"
+	k3sListPattern   = "k3s*"
+	k3sVersion       = "v1.33.6+k3s1"
+	k3sVersionHash   = "b5847677"
+	k3sVersionGolang = "go version go1.24.9"
+
+	// Dummy consts
+	dummyBinPath = "/usr/local/bin/dummy"
+)
+
+func TestMatchers(t *testing.T) {
+	testVersion := "testVersion"
+	testVerHash := "deadbeef"
+
+	testCases := []struct {
+		name          string
+		matcher       *regexp.Regexp
+		input         string
+		fieldMatches  [][]byte
+		expectedCount int
+	}{
+		//
+		// version matcher
+		//
+		{
+			name:          "version matcher for valid version output",
+			matcher:       versionMatcher,
+			input:         fmt.Sprintf("test version %s (%s)", testVersion, testVerHash),
+			fieldMatches:  [][]byte{[]byte(testVersion), []byte(testVerHash)},
+			expectedCount: 3,
+		},
+		{
+			name:          "version matcher for invalid version output (invalid hash)",
+			matcher:       versionMatcher,
+			input:         fmt.Sprintf("test version %s (%s)", testVersion, testVersion),
+			fieldMatches:  [][]byte{},
+			expectedCount: 0,
+		},
+		{
+			name:          "version matcher for invalid version output (missing hash)",
+			matcher:       versionMatcher,
+			input:         fmt.Sprintf("test version %s", testVersion),
+			fieldMatches:  [][]byte{},
+			expectedCount: 0,
+		},
+		{
+			name:          "version matcher for invalid version output (empty)",
+			matcher:       versionMatcher,
+			input:         fmt.Sprintf("test version %s", testVersion),
+			fieldMatches:  [][]byte{},
+			expectedCount: 0,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert := assert.New(t)
+			matches := tc.matcher.FindSubmatch([]byte(tc.input))
+			assert.Len(matches, tc.expectedCount, "FindSubMatch(%s) for %q didn't return expected number of matches", tc.matcher, tc.input)
+			if len(matches) == 0 { // skip matched field checks not none expected
+				return
+			}
+			assert.Equal([]byte(tc.input), matches[0], "FindSubmatch(%s) for %q should have matched entire input string", tc.matcher, tc.input)
+			assert.Equal(tc.fieldMatches, matches[1:], "FindSubmatch(%s) for %q should have matched expected fields", tc.matcher, tc.input)
+		})
+	}
+}
+
+func generatek8sProviderVersionOutput(binary, version, hash, golang string) string {
+	return fmt.Sprintf(
+		"%s version %s (%s)\n%s\n",
+		filepath.Base(binary),
+		version,
+		hash,
+		golang,
+	)
+}
+
+// helper code for testing systemd client operations
+type systemdTestEnv struct {
+	// forced errors
+	closeError                   error
+	listUnitsError               error
+	listUnitsByPatternsError     error
+	listUnitFilesError           error
+	listUnitFilesByPatternsError error
+	getExecStartError            error
+	getSystemdVersionError       error
+	getUnitFileStateError        error
+	executeError                 error
+
+	// systemd client response objects
+	units          []*util.SystemdUnit
+	unitFiles      []*util.SystemdUnitFile
+	execStarts     map[string]*util.SystemdServiceExecStart
+	systemdVersion string
+	unitFileStates map[util.SystemdUnitName]string
+	versionOutputs map[string]string
+
+	// saved util.Execute
+	savedUtilExecute func(cmd []string, validExitCodes []int) ([]byte, error)
+
+	// mock util.Execute call state tracking
+	numCalls      int
+	cmdLinesList  [][]string
+	exitCodesList [][]int
+}
+
+func NewSystemdTestEnv() *systemdTestEnv {
+	testEnv := new(systemdTestEnv)
+	testEnv.Init(util.MOCK_SYSTEMD_SLE15SP3_VERSION)
+	return testEnv
+}
+
+func (env *systemdTestEnv) Init(systemVersion string) {
+	env.units = []*util.SystemdUnit{}
+	env.unitFiles = []*util.SystemdUnitFile{}
+	env.execStarts = map[string]*util.SystemdServiceExecStart{}
+	env.unitFileStates = map[util.SystemdUnitName]string{}
+	env.versionOutputs = map[string]string{}
+	env.SetSystemdVersion(systemVersion)
+}
+
+func (env *systemdTestEnv) SetSystemdVersion(systemdVersion string) {
+	env.systemdVersion = systemdVersion
+}
+
+func (env *systemdTestEnv) AddK8sUnit(svcName, k8sType, k8sRole, svcState string) {
+	// derived values
+	unitName := util.SystemdUnitName(svcName)
+	objectPath := fmt.Sprintf("/org/freedesktop/systemd1/unit/%s", svcName)
+
+	// determine unit state settings
+	var activeState string
+	var subState string
+	switch svcState {
+	case "enabled":
+		activeState = "inactive"
+		subState = "dead"
+	case "disabled":
+		activeState = "active"
+		subState = "running"
+	default:
+		activeState = "unknown"
+		subState = "unknown"
+	}
+
+	// determine version string
+	var binPath string
+	var versionOutput string
+	switch k8sType {
+	case "rke2":
+		binPath = rke2BinPath
+		versionOutput = generatek8sProviderVersionOutput(binPath, rke2Version, rke2VersionHash, rke2VersionGolang)
+	case "k3s":
+		binPath = k3sBinPath
+		versionOutput = generatek8sProviderVersionOutput(binPath, k3sVersion, k3sVersionHash, k3sVersionGolang)
+	default:
+		binPath = dummyBinPath
+		versionOutput = "unknown"
+	}
+
+	// create a SystemdUnit
+	unit := util.NewSystemdUnit(
+		unitName,
+		fmt.Sprintf("%s %s service", k8sType, k8sRole),
+		"loaded",
+		activeState,
+		subState,
+		"",
+		objectPath,
+		0,
+		"",
+		"/",
+	)
+
+	// create a SystemdUnitFile
+	unitFile := util.NewSystemdUnitFile(
+		fmt.Sprintf("/etc/systemd/system/%s", unitName),
+		svcState,
+	)
+
+	// create a SystemdServiceExecStart
+	execStart := util.NewSystemdServiceExecStart(
+		binPath,
+		[]string{
+			binPath,
+			k8sRole,
+		},
+		false,
+		0,
+		0,
+		0,
+		0,
+		0,
+		0,
+		0,
+	)
+
+	// add unit entry
+	env.units = append(env.units, unit)
+
+	// add unitFile entry
+	env.unitFiles = append(env.unitFiles, unitFile)
+
+	// add execStart entry
+	env.execStarts[objectPath] = execStart
+
+	// add state entry
+	env.unitFileStates[unitName] = svcState
+
+	// add version output
+	env.versionOutputs[binPath] = versionOutput
+}
+
+func (env *systemdTestEnv) NewClient() util.SystemdClient {
+	mockClient := util.NewMockSystemdClient(env.systemdVersion)
+
+	mockClient.CloseFunc = func() error {
+		if env.closeError != nil {
+			return env.closeError
+		}
+
+		return nil
+	}
+
+	mockClient.ListUnitsFunc = func() ([]*util.SystemdUnit, error) {
+		if env.listUnitsError != nil {
+			return nil, env.listUnitsError
+		}
+
+		return env.units, nil
+	}
+
+	mockClient.ListUnitsByPatternsFunc = func(patterns ...string) ([]*util.SystemdUnit, error) {
+		if env.listUnitsByPatternsError != nil {
+			return nil, env.listUnitsByPatternsError
+		}
+
+		return env.units, nil
+	}
+
+	mockClient.ListUnitFilesFunc = func() ([]*util.SystemdUnitFile, error) {
+		if env.listUnitFilesError != nil {
+			return nil, env.listUnitFilesError
+		}
+
+		return env.unitFiles, nil
+	}
+
+	mockClient.ListUnitFilesByPatternsFunc = func(patterns ...string) ([]*util.SystemdUnitFile, error) {
+		if env.listUnitFilesByPatternsError != nil {
+			return nil, env.listUnitFilesByPatternsError
+		}
+
+		return env.unitFiles, nil
+	}
+
+	mockClient.GetExecStartFunc = func(unitObjectPath string) ([]*util.SystemdServiceExecStart, error) {
+		execStarts := []*util.SystemdServiceExecStart{}
+
+		if env.getExecStartError != nil {
+			return nil, env.getExecStartError
+		}
+
+		execStart, ok := env.execStarts[unitObjectPath]
+		if ok {
+			execStarts = append(execStarts, execStart)
+		}
+
+		return execStarts, nil
+	}
+
+	mockClient.GetSystemdVersionFunc = func() (string, error) {
+		if env.getSystemdVersionError != nil {
+			return "", env.getSystemdVersionError
+		}
+
+		return env.systemdVersion, nil
+	}
+
+	mockClient.GetUnitFileStateFunc = func(unitName util.SystemdUnitName) (string, error) {
+		state := "unknown"
+
+		if env.getUnitFileStateError != nil {
+			return "", env.getUnitFileStateError
+		}
+		if unitState, ok := env.unitFileStates[unitName]; ok {
+			state = unitState
+		}
+
+		return state, nil
+	}
+
+	env.savedUtilExecute = util.Execute
+	util.Execute = func(cmd []string, validExitCodes []int) ([]byte, error) {
+		env.numCalls++
+		env.cmdLinesList = append(env.cmdLinesList, cmd)
+		env.exitCodesList = append(env.exitCodesList, validExitCodes)
+
+		var output []byte
+		var err error
+
+		// return immediately an error has been specified
+		if env.executeError != nil {
+			return nil, env.executeError
+		}
+
+		switch cmd[0] {
+		case rke2BinPath:
+			fallthrough
+		case k3sBinPath:
+			switch cmd[1] {
+			case "--version":
+				output = []byte(env.versionOutputs[cmd[0]])
+			default:
+				output = []byte("some version output")
+			}
+		default:
+			output = []byte("some command output")
+		}
+
+		return output, err
+	}
+
+	return mockClient
+}
+
+func (env *systemdTestEnv) Cleanup() {
+	util.Execute = env.savedUtilExecute
+}
+
+func TestKubernetesServiceInitNormalOperation(t *testing.T) {
+	// general setup
+	assert := assert.New(t)
+	require := require.New(t)
+
+	// test settings
+	testEnv := NewSystemdTestEnv()
+	k8sSvc := "rke2-server.service"
+	k8sType := RKE2_PROVIDER
+	k8sRole := "server"
+	k8sVersion := rke2Version
+	k8sVersionHash := rke2VersionHash
+	versionCmdLine := []string{rke2BinPath, "--version"}
+	testEnv.AddK8sUnit(k8sSvc, k8sType, k8sRole, "enabled")
+
+	// create a mock systemd client
+	systemdClient := testEnv.NewClient()
+	defer testEnv.Cleanup()
+
+	// run test case
+	uf := testEnv.units[0]
+	ks, err := NewKubernetesService(systemdClient, uf)
+
+	// check returned values
+	assert.NotNil(ks, "KubernetesService.Init() returned nil")
+	assert.NoError(err, "KubernetesService.Init() returned unexpected error")
+
+	// check KubernetesService.Init() extracted binary and role correctly
+	assert.Equal(k8sSvc, ks.Name, "KubernetesService.Init() extracted binary incorrectly")
+	assert.Equal(k8sType, ks.Type, "KubernetesService.Init() extracted type incorrectly")
+	assert.Equal(k8sRole, ks.Role, "KubernetesService.Init() extracted role incorrectly")
+	assert.Equal(rke2BinPath, ks.Binary, "KubernetesService.Init() extracted binary incorrectly")
+	assert.Equal(k8sVersion, ks.Version, "KubernetesService.setVersion() extracted version incorrectly")
+	assert.Equal(k8sVersionHash, ks.VersionHash, "KubernetesService.setVersion() extracted version hash incorrectly")
+
+	// check util.Execute() called expected number of times and skip remaining tests if not
+	require.Equal(1, testEnv.numCalls, "util.Execute() called unexpected number of times")
+
+	// check util.Execute() was called as expected for KubernetesService.setVersion()
+	assert.Equal(versionCmdLine, testEnv.cmdLinesList[0], "UnitFile.Property() triggered util.Execute() with unexperect cmd argument")
+
+	// check all util.Execute() permitted exit codes are as expected
+	for i, exitCodes := range testEnv.exitCodesList {
+		assert.Equal([]int{0}, exitCodes, "util.Execute() returned unexpected exitCodes for call %d", i)
+	}
+}
+
+func TestKubernetesServiceInitFailedExecStartPropertyOperation(t *testing.T) {
+	// general setup
+	assert := assert.New(t)
+
+	// test settings
+	testEnv := NewSystemdTestEnv()
+	testEnv.AddK8sUnit("rke2-server.service", RKE2_PROVIDER, "server", "enabled")
+	testEnv.getExecStartError = fmt.Errorf("test error")
+
+	// create a mock systemd client
+	systemdClient := testEnv.NewClient()
+	defer testEnv.Cleanup()
+
+	// run test case
+	uf := testEnv.units[0]
+	ks, err := NewKubernetesService(systemdClient, uf)
+
+	// check returned values
+	assert.Nil(ks, "KubernetesService.Init() returned non-nil object")
+	assert.ErrorIs(err, testEnv.getExecStartError, "KubernetesService.Init() returned unexpected error")
+}
+
+func TestKubernetesServiceInitFailedSetVersionOperation(t *testing.T) {
+	// general setup
+	assert := assert.New(t)
+	require := require.New(t)
+
+	// test settings
+	testEnv := NewSystemdTestEnv()
+	testEnv.AddK8sUnit("rke2-server.service", RKE2_PROVIDER, "server", "enabled")
+	testEnv.executeError = fmt.Errorf("test error")
+
+	// expected values
+	versionCmdLine := []string{rke2BinPath, "--version"}
+
+	// create a mock systemd client
+	systemdClient := testEnv.NewClient()
+	defer testEnv.Cleanup()
+
+	// run test case
+	uf := testEnv.units[0]
+	ks, err := NewKubernetesService(systemdClient, uf)
+
+	// check returned values
+	assert.Nil(ks, "KubernetesService.Init() returned non-nil object")
+	assert.ErrorIs(err, testEnv.executeError, "KubernetesService.Init() returned unexpected error")
+
+	// check util.Execute() called expected number of times and skip remaining tests if not
+	require.Equal(1, testEnv.numCalls, "util.Execute() called unexpected number of times")
+
+	// check util.Execute() was called as expected for KubernetesService.setVersion()
+	assert.Equal(versionCmdLine, testEnv.cmdLinesList[0], "KubernetesService.setVersion() triggered util.Execute() with unexperect cmd argument")
+
+	// check all util.Execute() permitted exit codes are as expected
+	for i, exitCodes := range testEnv.exitCodesList {
+		assert.Equal([]int{0}, exitCodes, "util.Execute() returned unexpected exitCodes for call %d", i)
+	}
+}
+
+func TestGetKubernetesServicesNormalOperation(t *testing.T) {
+	// general setup
+	assert := assert.New(t)
+	require := require.New(t)
+
+	// test settings
+	testEnv := NewSystemdTestEnv()
+	testEnv.AddK8sUnit("rke2-server.service", RKE2_PROVIDER, "server", "enabled")
+	testEnv.AddK8sUnit("rke2-agent.service", RKE2_PROVIDER, "agent", "enabled")
+	testEnv.AddK8sUnit("rke2-dummy.service", RKE2_PROVIDER, "dummy", "enabled")
+	testEnv.AddK8sUnit("k3s.service", K3S_PROVIDER, "server", "enabled")
+	testEnv.AddK8sUnit("k3s-agent.service", K3S_PROVIDER, "agent", "enabled")
+	testEnv.AddK8sUnit("k3s-custom.service", K3S_PROVIDER, "server", "enabled")
+	testEnv.AddK8sUnit("k3s-dummy.service", K3S_PROVIDER, "dummy", "enabled")
+	testEnv.AddK8sUnit("k3snodash.service", K3S_PROVIDER, "nodash", "enabled")
+
+	// expected values
+	rke2VersionCmdLine := []string{rke2BinPath, "--version"}
+	k3sVersionCmdLine := []string{k3sBinPath, "--version"}
+
+	// create a mock systemd client
+	systemdClient := testEnv.NewClient()
+	defer testEnv.Cleanup()
+
+	// run test case
+	ksList, err := getKubernetesServices(systemdClient)
+
+	// check returned values and fail immediatedly if less than expected services found
+	assert.NotNil(ksList, "getKubernetesServices() returned nil")
+	assert.NoError(err, "getKubernetesServices() returned unexpected error")
+	require.Len(ksList, 5, "getKubernetesServices() returned unexpected number of services")
+
+	// expect util.Execute() to have been called 5 times to retrieve version info
+	require.Equal(5, testEnv.numCalls, "util.Execute() called unexpected number of times")
+
+	// check discovered services
+	for i, tks := range []struct {
+		svcName, k8sType, k8sRole, binPath, version, hash string
+		versionCmdLine                                    []string
+	}{
+		{
+			"rke2-server.service",
+			RKE2_PROVIDER,
+			"server",
+			rke2BinPath,
+			rke2Version,
+			rke2VersionHash,
+			rke2VersionCmdLine,
+		},
+		{
+			"rke2-agent.service",
+			RKE2_PROVIDER,
+			"agent",
+			rke2BinPath,
+			rke2Version,
+			rke2VersionHash,
+			rke2VersionCmdLine,
+		},
+		{
+			"k3s.service",
+			K3S_PROVIDER,
+			"server",
+			k3sBinPath,
+			k3sVersion,
+			k3sVersionHash,
+			k3sVersionCmdLine,
+		},
+		{
+			"k3s-agent.service",
+			K3S_PROVIDER,
+			"agent",
+			k3sBinPath,
+			k3sVersion,
+			k3sVersionHash,
+			k3sVersionCmdLine,
+		},
+		{
+			"k3s-custom.service",
+			K3S_PROVIDER,
+			"server",
+			k3sBinPath,
+			k3sVersion,
+			k3sVersionHash,
+			k3sVersionCmdLine,
+		},
+	} {
+		assert.Equal(tks.svcName, ksList[i].Name, "getKubernetesServices() returned unexpected service name for service %d", i)
+		assert.Equal(tks.k8sType, ksList[i].Type, "getKubernetesServices() returned unexpected type for service [%d]%s", i, ksList[i].Name)
+		assert.Equal(tks.k8sRole, ksList[i].Role, "getKubernetesServices() returned unexpected role for service [%d]%s", i, ksList[i].Name)
+		assert.Equal(tks.binPath, ksList[i].Binary, "getKubernetesServices() returned unexpected binary path for service [%d]%s", i, ksList[i].Name)
+		assert.Equal(tks.version, ksList[i].Version, "getKubernetesServices() returned unexpected version for service [%d]%s", i, ksList[i].Name)
+		assert.Equal(tks.hash, ksList[i].VersionHash, "getKubernetesServices() returned unexpected version hash for service [%d]%s", i, ksList[i].Name)
+		assert.Equal(tks.versionCmdLine, testEnv.cmdLinesList[i], "util.Execute() called with unexpected version command line for service [%d]%s", i, ksList[i].Name)
+	}
+
+	// check all util.Execute() exit codes are as expected
+	for i, exitCodes := range testEnv.exitCodesList {
+		assert.Equal([]int{0}, exitCodes, "util.Execute() returned unexpected exitCodes for call %d", i)
+	}
+}
+
+func TestGetKubernetesServicesFallbackOperation(t *testing.T) {
+	// general setup
+	assert := assert.New(t)
+	require := require.New(t)
+
+	// test settings
+	testEnv := NewSystemdTestEnv()
+	testEnv.AddK8sUnit("rke2-server.service", RKE2_PROVIDER, "server", "enabled")
+	testEnv.AddK8sUnit("k3s.service", K3S_PROVIDER, "server", "enabled")
+	// Add a non-matching service to ensure filtering works via unit.Name.Match() in fallback
+	testEnv.AddK8sUnit("unrelated.service", "dummy", "dummy", "enabled")
+
+	// force fallback by simulating ListUnitsByPatterns not available
+	testEnv.listUnitsByPatternsError = util.SystemdMethodNotAvailable
+
+	// create a mock systemd client
+	systemdClient := testEnv.NewClient()
+	defer testEnv.Cleanup()
+
+	// run test case
+	ksList, err := getKubernetesServices(systemdClient)
+
+	// check returned values
+	assert.NotNil(ksList, "getKubernetesServices() returned nil")
+	assert.NoError(err, "getKubernetesServices() returned unexpected error")
+	require.Len(ksList, 2, "getKubernetesServices() returned unexpected number of services")
+
+	// check discovered services
+	assert.Equal("rke2-server.service", ksList[0].Name)
+	assert.Equal("k3s.service", ksList[1].Name)
+}
+
+func TestGetKubernetesServicesGetUnitFileStateError(t *testing.T) {
+	// general setup
+	assert := assert.New(t)
+	require := require.New(t)
+
+	testEnv := NewSystemdTestEnv()
+	testEnv.AddK8sUnit("rke2-server.service", RKE2_PROVIDER, "server", "enabled")
+
+	// force state fetch to fail
+	testEnv.getUnitFileStateError = fmt.Errorf("test state error")
+
+	systemdClient := testEnv.NewClient()
+	defer testEnv.Cleanup()
+
+	ksList, err := getKubernetesServices(systemdClient)
+
+	assert.NotNil(ksList, "getKubernetesServices() returned nil")
+	assert.NoError(err, "getKubernetesServices() returned unexpected error")
+	require.Len(ksList, 0, "getKubernetesServices() should skip units with state errors")
+}
+
+func TestGetKubernetesProviderNormalOperation(t *testing.T) {
+	// general setup
+	assert := assert.New(t)
+	require := require.New(t)
+
+	// test settings
+	testEnv := NewSystemdTestEnv()
+	testEnv.AddK8sUnit("rke2-server.service", RKE2_PROVIDER, "server", "enabled")
+	testEnv.AddK8sUnit("rke2-agent.service", RKE2_PROVIDER, "agent", "disabled")
+
+	// expeected values
+	versionCmdLine := []string{rke2BinPath, "--version"}
+
+	// expected kubernetes provider info
+	expectedKpInfo := map[string]any{
+		"type":    RKE2_PROVIDER,
+		"role":    "server",
+		"version": rke2Version,
+	}
+
+	// create a mock systemd client
+	systemdClient := testEnv.NewClient()
+	defer testEnv.Cleanup()
+
+	// run test case
+	kpInfo, err := getKubernetesProviderData(systemdClient)
+
+	// check returned values
+	assert.NotNil(kpInfo, "getKubernetesProvider() returned nil")
+	assert.NoError(err, "getKubernetesProvider() returned unexpected error")
+	assert.Len(kpInfo, 3, "getKubernetesProvider() returned map with unexpected number of fields")
+	assert.Equal(expectedKpInfo, kpInfo, "getKubernetesProvider() returned unexpected provider info")
+
+	// check util.Execute() called expected number of times and skip remaining tests if not
+	require.Equal(1, testEnv.numCalls, "util.Execute() called unexpected number of times")
+
+	// check util.Execute() was called as expected for KubernetesService.setVersion()
+	assert.Equal(versionCmdLine, testEnv.cmdLinesList[0], "KubernetesService.setVersion() triggered util.Execute() with unexperect cmd argument")
+
+	// check all util.Execute() permitted exit codes are as expected
+	for i, exitCodes := range testEnv.exitCodesList {
+		assert.Equal([]int{0}, exitCodes, "util.Execute() returned unexpected exitCodes for call %d", i)
+	}
+}
+
+func TestGetKubernetesProviderNoServicesOperation(t *testing.T) {
+	// general setup
+	assert := assert.New(t)
+	require := require.New(t)
+
+	// test settings
+	testEnv := NewSystemdTestEnv()
+	testEnv.AddK8sUnit("rke2-server.service", RKE2_PROVIDER, "server", "disabled")
+	testEnv.AddK8sUnit("rke2-agent.service", RKE2_PROVIDER, "agent", "disabled")
+
+	// create a mock systemd client
+	systemdClient := testEnv.NewClient()
+	defer testEnv.Cleanup()
+
+	// run test case
+	kpInfo, err := getKubernetesProviderData(systemdClient)
+
+	// check returned values
+	assert.Nil(kpInfo, "getKubernetesProvider() should have returned nil for provider info")
+	assert.NoError(err, "getKubernetesProvider() returned unexpected error")
+
+	// check util.Execute() called expected number of times and skip remaining tests if not
+	require.Equal(0, testEnv.numCalls, "util.Execute() called unexpected number of times")
+}
+
+func TestGetKubernetesProviderTooManyServicesOperation(t *testing.T) {
+	// general setup
+	assert := assert.New(t)
+	require := require.New(t)
+
+	// test settings
+	testEnv := NewSystemdTestEnv()
+	testEnv.AddK8sUnit("rke2-server.service", RKE2_PROVIDER, "server", "enabled")
+	testEnv.AddK8sUnit("k3s.service", K3S_PROVIDER, "server", "enabled")
+
+	// expeected values
+	rke2VersionCmdLine := []string{rke2BinPath, "--version"}
+	k3sVersionCmdLine := []string{k3sBinPath, "--version"}
+
+	// create a mock systemd client
+	systemdClient := testEnv.NewClient()
+	defer testEnv.Cleanup()
+
+	// run test case
+	kpInfo, err := getKubernetesProviderData(systemdClient)
+
+	// check returned values
+	assert.Nil(kpInfo, "getKubernetesProvider() should have returned nil for provider info")
+	assert.ErrorIs(err, KubernetesMultipleProvidersEnabled, "getKubernetesProvider() returned unexpected error")
+
+	// check util.Execute() called expected number of times and skip remaining tests if not
+	require.Equal(2, testEnv.numCalls, "util.Execute() called unexpected number of times")
+
+	// check util.Execute() was called as expected for KubernetesService.setVersion()
+	assert.Equal(rke2VersionCmdLine, testEnv.cmdLinesList[0], "KubernetesService.setVersion() triggered util.Execute() with unexperect cmd argument")
+	assert.Equal(k3sVersionCmdLine, testEnv.cmdLinesList[1], "KubernetesService.setVersion() triggered util.Execute() with unexperect cmd argument")
+
+	// check all util.Execute() permitted exit codes are as expected
+	for i, exitCodes := range testEnv.exitCodesList {
+		assert.Equal([]int{0}, exitCodes, "util.Execute() returned unexpected exitCodes for call %d", i)
+	}
+}
+
+func TestGetKubernetesProviderFailedOperation(t *testing.T) {
+	// general setup
+	assert := assert.New(t)
+	require := require.New(t)
+
+	// test settings
+	testEnv := NewSystemdTestEnv()
+	testEnv.listUnitsByPatternsError = fmt.Errorf("test error")
+
+	// create a mock systemd client
+	systemdClient := testEnv.NewClient()
+	defer testEnv.Cleanup()
+
+	// run test case
+	kpInfo, err := getKubernetesProviderData(systemdClient)
+
+	// check returned values
+	assert.Nil(kpInfo, "getKubernetesProvider() should have returned nil for provider info")
+	assert.ErrorIs(err, testEnv.listUnitsByPatternsError, "getKubernetesProvider() returned unexpected error")
+
+	// check util.Execute() called expected number of times and skip remaining tests if not
+	require.Equal(0, testEnv.numCalls, "util.Execute() called unexpected number of times")
+}
+
+func TestGenerateKubernetesProviderNormalOperation(t *testing.T) {
+	// general setup
+	assert := assert.New(t)
+	require := require.New(t)
+
+	// test settings
+	testEnv := NewSystemdTestEnv()
+	testEnv.AddK8sUnit("rke2-server.service", RKE2_PROVIDER, "server", "enabled")
+	testEnv.AddK8sUnit("rke2-agent.service", RKE2_PROVIDER, "agent", "disabled")
+
+	// expected values
+	versionCmdLine := []string{rke2BinPath, "--version"}
+
+	// expected result info
+	expectedKpInfo := map[string]any{
+		"type":    RKE2_PROVIDER,
+		"role":    "server",
+		"version": rke2Version,
+	}
+	expectedResult := Result{"kubernetes_provider": expectedKpInfo}
+
+	// create a mock systemd client
+	systemdClient := testEnv.NewClient()
+	defer testEnv.Cleanup()
+
+	// run test case
+	res, err := generateKubernetesProvider(systemdClient)
+
+	// check returned values
+	assert.NotNil(res, "generateKubernetesProvider() returned nil")
+	assert.NoError(err, "generateKubernetesProvider() returned unexpected error")
+	assert.Equal(expectedResult, res, "generateKubernetesProvider() returned unexpected result")
+
+	// check util.Execute() called expected number of times and skip remaining tests if not
+	require.Equal(1, testEnv.numCalls, "util.Execute() called unexpected number of times")
+
+	// check util.Execute() was called as expected for KubernetesService.setVersion()
+	assert.Equal(versionCmdLine, testEnv.cmdLinesList[0], "KubernetesService.setVersion() triggered util.Execute() with unexperect cmd argument")
+
+	// check all util.Execute() permitted exit codes are as expected
+	for i, exitCodes := range testEnv.exitCodesList {
+		assert.Equal([]int{0}, exitCodes, "util.Execute() returned unexpected exitCodes for call %d", i)
+	}
+}
+
+func TestGenerateKubernetesProviderLegacyNormalOperation(t *testing.T) {
+	// general setup
+	assert := assert.New(t)
+	require := require.New(t)
+
+	// test settings
+	testEnv := NewSystemdTestEnv()
+	testEnv.SetSystemdVersion(util.MOCK_SYSTEMD_SLE12SP5_VERSION)
+	testEnv.AddK8sUnit("rke2-server.service", RKE2_PROVIDER, "server", "enabled")
+	testEnv.AddK8sUnit("rke2-agent.service", RKE2_PROVIDER, "agent", "disabled")
+	testEnv.AddK8sUnit("rke2-dummy.service", RKE2_PROVIDER, "dummy", "enabled")
+	testEnv.AddK8sUnit("k3s.service", K3S_PROVIDER, "server", "disabled")
+	testEnv.AddK8sUnit("k3s-agent.service", K3S_PROVIDER, "agent", "disabled")
+	testEnv.AddK8sUnit("k3s-dummy.service", K3S_PROVIDER, "dummy", "disabled")
+	testEnv.AddK8sUnit("k3snodash.service", K3S_PROVIDER, "dummy", "disabled")
+
+	// expected values
+	versionCmdLine := []string{rke2BinPath, "--version"}
+
+	// expected result info
+	expectedKpInfo := map[string]any{
+		"type":    RKE2_PROVIDER,
+		"role":    "server",
+		"version": rke2Version,
+	}
+	expectedResult := Result{"kubernetes_provider": expectedKpInfo}
+
+	// create a mock systemd client
+	systemdClient := testEnv.NewClient()
+	defer testEnv.Cleanup()
+
+	// run test case
+	res, err := generateKubernetesProvider(systemdClient)
+
+	// check returned values
+	assert.NotNil(res, "generateKubernetesProvider() returned nil")
+	assert.NoError(err, "generateKubernetesProvider() returned unexpected error")
+	assert.Equal(expectedResult, res, "generateKubernetesProvider() returned unexpected result")
+
+	// check util.Execute() called expected number of times and skip remaining tests if not
+	require.Equal(1, testEnv.numCalls, "util.Execute() called unexpected number of times")
+
+	// check util.Execute() was called as expected for KubernetesService.setVersion()
+	assert.Equal(versionCmdLine, testEnv.cmdLinesList[0], "KubernetesService.setVersion() triggered util.Execute() with unexperect cmd argument")
+
+	// check all util.Execute() permitted exit codes are as expected
+	for i, exitCodes := range testEnv.exitCodesList {
+		assert.Equal([]int{0}, exitCodes, "util.Execute() returned unexpected exitCodes for call %d", i)
+	}
+}
+
+func TestGenerateKubernetesProviderNoServicesOperation(t *testing.T) {
+	// general setup
+	assert := assert.New(t)
+	require := require.New(t)
+
+	// test settings
+	testEnv := NewSystemdTestEnv()
+	testEnv.AddK8sUnit("rke2-server.service", RKE2_PROVIDER, "server", "disabled")
+	testEnv.AddK8sUnit("rke2-agent.service", RKE2_PROVIDER, "agent", "disabled")
+
+	// create a mock systemd client
+	systemdClient := testEnv.NewClient()
+	defer testEnv.Cleanup()
+
+	// run test case
+	res, err := generateKubernetesProvider(systemdClient)
+
+	// check returned values
+	assert.Equal(Result{}, res, "generateKubernetesProvider() should have returned an empty result")
+	assert.NoError(err, "generateKubernetesProvider() returned unexpected error")
+
+	// check util.Execute() called expected number of times and skip remaining tests if not
+	require.Equal(0, testEnv.numCalls, "util.Execute() called unexpected number of times")
+}
+
+func TestGenerateKubernetesProviderTooManyServicesOperation(t *testing.T) {
+	// general setup
+	assert := assert.New(t)
+	require := require.New(t)
+
+	// test settings
+	testEnv := NewSystemdTestEnv()
+	testEnv.AddK8sUnit("rke2-server.service", RKE2_PROVIDER, "server", "enabled")
+	testEnv.AddK8sUnit("k3s.service", K3S_PROVIDER, "server", "enabled")
+
+	// create a mock systemd client
+	systemdClient := testEnv.NewClient()
+	defer testEnv.Cleanup()
+
+	// run test case
+	res, err := generateKubernetesProvider(systemdClient)
+
+	// check returned values
+	assert.Equal(Result{}, res, "generateKubernetesProvider() should have returned an empty result")
+	assert.ErrorIs(err, KubernetesMultipleProvidersEnabled, "generateKubernetesProvider() returned unexpected error")
+
+	// check util.Execute() called expected number of times and skip remaining tests if not
+	require.Equal(2, testEnv.numCalls, "util.Execute() called unexpected number of times")
+}
+func TestGenerateKubernetesProviderFailedOperation(t *testing.T) {
+	// general setup
+	assert := assert.New(t)
+	require := require.New(t)
+
+	// test settings
+	testEnv := NewSystemdTestEnv()
+	testEnv.listUnitsByPatternsError = fmt.Errorf("test error")
+
+	// create a mock systemd client
+	systemdClient := testEnv.NewClient()
+	defer testEnv.Cleanup()
+
+	// run test case
+	res, err := generateKubernetesProvider(systemdClient)
+
+	// check returned values
+	assert.Equal(Result{}, res, "generateKubernetesProvider() should have returned an empty result")
+	assert.ErrorIs(err, testEnv.listUnitsByPatternsError, "generateKubernetesProvider() returned unexpected error")
+
+	// check util.Execute() called expected number of times and skip remaining tests if not
+	require.Equal(0, testEnv.numCalls, "util.Execute() called unexpected number of times")
+}

--- a/internal/collectors/kubernetes_provider_test.go
+++ b/internal/collectors/kubernetes_provider_test.go
@@ -156,10 +156,10 @@ func (env *systemdTestEnv) AddK8sUnit(svcName, k8sType, k8sRole, svcState string
 	var activeState string
 	var subState string
 	switch svcState {
-	case "enabled":
+	case "disabled":
 		activeState = "inactive"
 		subState = "dead"
-	case "disabled":
+	case "ensabled":
 		activeState = "active"
 		subState = "running"
 	default:

--- a/internal/connect/collectors.go
+++ b/internal/connect/collectors.go
@@ -21,6 +21,7 @@ func FetchSystemInformation(arch string) (collectors.Result, error) {
 		collectors.Uname{},
 		collectors.SAP{},
 		collectors.Vendor{},
+		collectors.K8S{},
 	}
 
 	var err error

--- a/internal/util/systemd.go
+++ b/internal/util/systemd.go
@@ -1,0 +1,155 @@
+package util
+
+import (
+	"fmt"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+const (
+	SYSTEMD_BYPATTERNS_VERSION = 230
+)
+
+var (
+	// error returned when a method is not available
+	SystemdMethodNotAvailable = fmt.Errorf("method not available")
+)
+
+func availableMethodCheck(methodName string, tgtVersion, reqVersion uint64) error {
+	// check if method is available from the target systemd
+	if tgtVersion < reqVersion {
+		return fmt.Errorf(
+			"Systemd version %d required for method %s: %w",
+			reqVersion, methodName, SystemdMethodNotAvailable,
+		)
+	}
+
+	return nil
+}
+
+// parse the systemd version string to extract the initial "major"
+// version value by striping off any trailing details leaving just
+// the base integer version
+func parseSystemdVersion(version string) (uint64, error) {
+	major, _, _ := strings.Cut(version, ".")
+	return strconv.ParseUint(major, 10, 64)
+}
+
+// SystemdUnitName represents a systemd unit name
+type SystemdUnitName string
+
+func (name SystemdUnitName) UnitType() string {
+	ext := filepath.Ext(string(name))
+	if ext == "" {
+		return ""
+	}
+	return ext[1:]
+}
+
+func (name SystemdUnitName) UnitName() string {
+	return filepath.Base(string(name))
+}
+
+func (name SystemdUnitName) Match(patterns ...string) bool {
+	unitName := name.UnitName()
+	for _, pattern := range patterns {
+		if matched, _ := filepath.Match(pattern, unitName); matched {
+			return true
+		}
+	}
+
+	return false
+}
+
+// SystemdUnitFile represents the systemd unit file as reported by Manager.ListUnitFiles* methods
+type SystemdUnitFile struct {
+	Name  SystemdUnitName
+	State string
+}
+
+func NewSystemdUnitFile(name, state string) *SystemdUnitFile {
+	unitFile := SystemdUnitFile{
+		Name:  SystemdUnitName(name),
+		State: state,
+	}
+
+	return &unitFile
+}
+
+// SystemdUnit represents the systemd unit as reported by Manager.ListUnits* methods
+type SystemdUnit struct {
+	Name        SystemdUnitName
+	Description string
+	LoadState   string
+	ActiveState string
+	SubState    string
+	Following   string
+	ObjectPath  string
+	JobId       uint32
+	JobType     string
+	JobPath     string
+}
+
+func NewSystemdUnit(name SystemdUnitName, description, loadState, activeState, subState, following, objectPath string, jobId uint32, jobType, jobPath string) *SystemdUnit {
+	unit := SystemdUnit{
+		Name:        name,
+		Description: description,
+		LoadState:   loadState,
+		ActiveState: activeState,
+		SubState:    subState,
+		Following:   following,
+		ObjectPath:  objectPath,
+		JobId:       jobId,
+		JobType:     jobType,
+		JobPath:     jobPath,
+	}
+
+	return &unit
+}
+
+// the expected number of fields per ExecStart entry
+const SYSTEMD_EXEC_START_NUM_FIELDS = 10
+
+// SystemdServiceExecStart represents the ExecStart property of a systemd service
+type SystemdServiceExecStart struct {
+	Path                    string
+	Args                    []string
+	IgnoreErrors            bool
+	StartTimestamp          uint64
+	StartTimestampMonotonic uint64
+	ExitTimestamp           uint64
+	ExitTimestampMonotonic  uint64
+	Pid                     uint32
+	ExitCode                int32
+	ExitStatus              int32
+}
+
+func NewSystemdServiceExecStart(path string, args []string, ignoreErrors bool, startTimestamp, startTimestampMonotonic, exitTimestamp, exitTimestampMonotonic uint64, pid uint32, exitCode, exitStatus int32) *SystemdServiceExecStart {
+	execStart := SystemdServiceExecStart{
+		Path:                    path,
+		Args:                    args,
+		IgnoreErrors:            ignoreErrors,
+		StartTimestamp:          startTimestamp,
+		StartTimestampMonotonic: startTimestampMonotonic,
+		ExitTimestamp:           exitTimestamp,
+		ExitTimestampMonotonic:  exitTimestampMonotonic,
+		Pid:                     pid,
+		ExitCode:                exitCode,
+		ExitStatus:              exitStatus,
+	}
+
+	return &execStart
+}
+
+// SystemdClient defines the interface we used for our systemd interactions
+type SystemdClient interface {
+	ListUnits() ([]*SystemdUnit, error)
+	ListUnitsByPatterns(patterns ...string) ([]*SystemdUnit, error)
+	ListUnitFiles() ([]*SystemdUnitFile, error)
+	ListUnitFilesByPatterns(patterns ...string) ([]*SystemdUnitFile, error)
+	GetExecStart(unitObjectPath string) ([]*SystemdServiceExecStart, error)
+	GetSystemdVersion() (string, error)
+	GetUnitFileState(unitName SystemdUnitName) (string, error)
+	Close() error
+}

--- a/internal/util/systemd_dbus.go
+++ b/internal/util/systemd_dbus.go
@@ -1,0 +1,268 @@
+package util
+
+import (
+	"fmt"
+
+	"github.com/godbus/dbus/v5"
+)
+
+const (
+	DBUS_SYSTEMD_DEST    = "org.freedesktop.systemd1"
+	DBUS_SYSTEMD_PATH    = "/org/freedesktop/systemd1"
+	DBUS_SYSTEMD_MANAGER = DBUS_SYSTEMD_DEST + ".Manager"
+	DBUS_SYSTEMD_SERVICE = DBUS_SYSTEMD_DEST + ".Service"
+)
+
+// DbusSystemdClient implements a SystemdClient that leverages native
+// D-Bus support to talk to the system bus.
+type DbusSystemdClient struct {
+	conn        *dbus.Conn
+	version     uint64
+	fullVersion string
+}
+
+func (c *DbusSystemdClient) Init(conn *dbus.Conn) error {
+	var err error
+
+	// setup the connection so that GetSustemVersion() can be called
+	c.conn = conn
+
+	// retrieve the Systemd Version string which may have one of these forms
+	//   * 228 (SLE 12 SP 5)
+	//   * 246.16+suse.312.gb540e1826d (SLE 15 SP3)
+	//   * 249.17+suse.247.g8b6ed60a0c (SLE 15 SP4/5)
+	//   * 254.27+suse.192.gc89ea566d9 (SLE 15 SP6/7)
+	//   * 257.13+suse.38.gd349fc5cd4 (SLE 16.0)
+	c.fullVersion, err = c.GetSystemdVersion()
+	if err != nil {
+		return err
+	}
+
+	if c.version, err = parseSystemdVersion(c.fullVersion); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// NewDbusSystemdClient connects to the system bus
+func NewDbusSystemdClient() (*DbusSystemdClient, error) {
+	conn, err := dbus.SystemBus()
+	if err != nil {
+		return nil, err
+	}
+
+	systemdClient := new(DbusSystemdClient)
+	err = systemdClient.Init(conn)
+	if err != nil {
+		_ = conn.Close()
+		return nil, err
+	}
+
+	return systemdClient, nil
+}
+
+func (c *DbusSystemdClient) Close() error {
+	return c.conn.Close()
+}
+
+//
+// Implement ListUnits* methods
+//
+
+// type signature for unit info returned by ListUnits* methods: ssssssouso
+type unitInfo struct {
+	Name, Desc, Load, Active, Sub, Follow string
+	ObjectPath                            dbus.ObjectPath
+	JobID                                 uint32
+	JobType                               string
+	JobPath                               dbus.ObjectPath
+}
+
+func (c *DbusSystemdClient) ListUnits() ([]*SystemdUnit, error) {
+	method := DBUS_SYSTEMD_MANAGER + ".ListUnits"
+	systemd := c.conn.Object(DBUS_SYSTEMD_DEST, DBUS_SYSTEMD_PATH)
+
+	var resp []unitInfo
+	err := systemd.Call(method, 0).Store(&resp)
+	if err != nil {
+		return nil, err
+	}
+
+	var units []*SystemdUnit
+	for _, u := range resp {
+		units = append(units, NewSystemdUnit(
+			SystemdUnitName(u.Name), u.Desc, u.Load, u.Active, u.Sub, u.Follow,
+			string(u.ObjectPath), u.JobID, u.JobType, string(u.JobPath),
+		))
+	}
+	return units, nil
+}
+
+func (c *DbusSystemdClient) ListUnitsByPatterns(patterns ...string) ([]*SystemdUnit, error) {
+	methodName := "ListUnitsByPatterns"
+
+	// check if method is available
+	if err := availableMethodCheck(methodName, c.version, SYSTEMD_BYPATTERNS_VERSION); err != nil {
+		return nil, err
+	}
+
+	method := DBUS_SYSTEMD_MANAGER + "." + methodName
+	systemd := c.conn.Object(DBUS_SYSTEMD_DEST, DBUS_SYSTEMD_PATH)
+
+	var resp []unitInfo
+	err := systemd.Call(method, 0, []string{}, patterns).Store(&resp)
+	if err != nil {
+		return nil, err
+	}
+
+	var units []*SystemdUnit
+	for _, u := range resp {
+		units = append(units, NewSystemdUnit(
+			SystemdUnitName(u.Name), u.Desc, u.Load, u.Active, u.Sub, u.Follow,
+			string(u.ObjectPath), u.JobID, u.JobType, string(u.JobPath),
+		))
+	}
+	return units, nil
+}
+
+//
+// Implement ListUnitFiles* methods
+//
+
+// type signature for unit info returned by ListUnitFiles* methods: ss
+type unitFileInfo struct {
+	Name  string
+	State string
+}
+
+func (c *DbusSystemdClient) ListUnitFiles() ([]*SystemdUnitFile, error) {
+	method := DBUS_SYSTEMD_MANAGER + ".ListUnitFiles"
+	systemd := c.conn.Object(DBUS_SYSTEMD_DEST, DBUS_SYSTEMD_PATH)
+
+	var resp []unitFileInfo
+	err := systemd.Call(method, 0).Store(&resp)
+	if err != nil {
+		return nil, err
+	}
+
+	var units []*SystemdUnitFile
+	for _, u := range resp {
+		units = append(units, NewSystemdUnitFile(u.Name, u.State))
+	}
+	return units, nil
+}
+
+func (c *DbusSystemdClient) ListUnitFilesByPatterns(patterns ...string) ([]*SystemdUnitFile, error) {
+	methodName := "ListUnitFilesByPatterns"
+
+	// check if method is available
+	if err := availableMethodCheck(methodName, c.version, SYSTEMD_BYPATTERNS_VERSION); err != nil {
+		return nil, err
+	}
+
+	method := DBUS_SYSTEMD_MANAGER + "." + methodName
+	systemd := c.conn.Object(DBUS_SYSTEMD_DEST, DBUS_SYSTEMD_PATH)
+
+	// type signature for unit info returned by ListUnitFilesByPattern: ss
+	type unitFileInfo struct {
+		Name  string
+		State string
+	}
+
+	var resp []unitFileInfo
+	err := systemd.Call(method, 0, []string{}, patterns).Store(&resp)
+	if err != nil {
+		return nil, err
+	}
+
+	var units []*SystemdUnitFile
+	for _, u := range resp {
+		units = append(units, NewSystemdUnitFile(u.Name, u.State))
+	}
+	return units, nil
+}
+
+func (c *DbusSystemdClient) GetUnitFileState(unitName SystemdUnitName) (string, error) {
+	method := DBUS_SYSTEMD_MANAGER + ".GetUnitFileState"
+	systemd := c.conn.Object(DBUS_SYSTEMD_DEST, DBUS_SYSTEMD_PATH)
+
+	var resp string
+	err := systemd.Call(method, 0, unitName).Store(&resp)
+	if err != nil {
+		return "", err
+	}
+
+	return resp, nil
+}
+
+func (c *DbusSystemdClient) GetExecStart(unitObjectPath string) ([]*SystemdServiceExecStart, error) {
+	property := DBUS_SYSTEMD_SERVICE + ".ExecStart"
+	systemd := c.conn.Object(DBUS_SYSTEMD_DEST, dbus.ObjectPath(unitObjectPath))
+
+	// signature of the ExecStart property value is: a(sasbttttuii)
+	variant, err := systemd.GetProperty(property)
+	if err != nil {
+		return nil, err
+	}
+
+	execStartEntries, ok := variant.Value().([][]any)
+	if !ok {
+		return nil, fmt.Errorf("unexpected ExecStart signature")
+	}
+
+	var results []*SystemdServiceExecStart
+	for _, entry := range execStartEntries {
+		// there should be at least 10 fields per entry
+		if len(entry) < SYSTEMD_EXEC_START_NUM_FIELDS {
+			continue
+		}
+
+		// convert the 10 fields per the signature: sasbttttuii
+		path, ok0 := entry[0].(string)
+		args, ok1 := entry[1].([]string)
+		ignoreErrors, ok2 := entry[2].(bool)
+		startTimestamp, ok3 := entry[3].(uint64)
+		startTimestampMonotonic, ok4 := entry[4].(uint64)
+		exitTimestamp, ok5 := entry[5].(uint64)
+		exitTimestampMonotonic, ok6 := entry[6].(uint64)
+		pid, ok7 := entry[7].(uint32)
+		exitCode, ok8 := entry[8].(int32)
+		exitStatus, ok9 := entry[9].(int32)
+
+		// skip if any field failed to convert
+		if !ok0 || !ok1 || !ok2 || !ok3 || !ok4 || !ok5 || !ok6 || !ok7 || !ok8 || !ok9 {
+			continue
+		}
+
+		results = append(results, NewSystemdServiceExecStart(
+			path, args, ignoreErrors,
+			startTimestamp, startTimestampMonotonic,
+			exitTimestamp, exitTimestampMonotonic,
+			pid, exitCode, exitStatus,
+		))
+	}
+
+	return results, nil
+}
+
+func (c *DbusSystemdClient) GetSystemdVersion() (string, error) {
+	property := DBUS_SYSTEMD_MANAGER + ".Version"
+	systemd := c.conn.Object(DBUS_SYSTEMD_DEST, dbus.ObjectPath(DBUS_SYSTEMD_PATH))
+
+	// signature of the Version property value is: s
+	variant, err := systemd.GetProperty(property)
+	if err != nil {
+		return "", err
+	}
+
+	systemdVersion, ok := variant.Value().(string)
+	if !ok {
+		return "", fmt.Errorf("unexpected Version signature")
+	}
+
+	return systemdVersion, nil
+}
+
+// verify that DbusSystemdClient implements the SystemdClient interface
+var _ SystemdClient = (*DbusSystemdClient)(nil)

--- a/internal/util/systemd_dbus_test.go
+++ b/internal/util/systemd_dbus_test.go
@@ -1,0 +1,26 @@
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestDbusSystemdClient_Integration attempts to use the real D-Bus connection.
+// It skips the test if the system bus is not reachable (e.g. in CI or non-Linux environments).
+func TestDbusSystemdClient_Integration(t *testing.T) {
+	client, err := NewDbusSystemdClient()
+	if err != nil {
+		t.Skipf("Skipping systemd integration test: %v", err)
+	}
+	defer client.Close()
+
+	require.NotZero(t, client.version, "GetSystemdVersion() returned empty string during Init()")
+
+	// Basic connectivity check: List units and unit files
+	_, err = client.ListUnits()
+	require.NoError(t, err, "ListUnits() failed")
+
+	_, err = client.ListUnitFiles()
+	require.NoError(t, err, "ListUnitFiles() failed")
+}

--- a/internal/util/systemd_mock.go
+++ b/internal/util/systemd_mock.go
@@ -1,0 +1,104 @@
+package util
+
+const (
+	MOCK_SYSTEMD_SLE12SP5_VERSION = "228"
+	MOCK_SYSTEMD_SLE15SP3_VERSION = "246.16+suse.312.gb540e1826d"
+)
+
+// MockSystemdClient allows injecting fake data for testing.
+type MockSystemdClient struct {
+	// method mocking
+	CloseFunc                   func() error
+	ListUnitsFunc               func() ([]*SystemdUnit, error)
+	ListUnitsByPatternsFunc     func(patterns ...string) ([]*SystemdUnit, error)
+	ListUnitFilesFunc           func() ([]*SystemdUnitFile, error)
+	ListUnitFilesByPatternsFunc func(patterns ...string) ([]*SystemdUnitFile, error)
+	GetExecStartFunc            func(unitObjectPath string) ([]*SystemdServiceExecStart, error)
+	GetSystemdVersionFunc       func() (string, error)
+	GetUnitFileStateFunc        func(unitName SystemdUnitName) (string, error)
+
+	// local variables
+	version     uint64
+	fullVersion string
+}
+
+func NewMockSystemdClient(fullVersion string) *MockSystemdClient {
+	client := new(MockSystemdClient)
+
+	if fullVersion == "" {
+		fullVersion = MOCK_SYSTEMD_SLE15SP3_VERSION
+	}
+	client.fullVersion = fullVersion
+	client.version, _ = parseSystemdVersion(fullVersion)
+
+	return client
+}
+
+func (m *MockSystemdClient) Close() error {
+	if m.CloseFunc != nil {
+		return m.CloseFunc()
+	}
+	return nil
+}
+
+func (m *MockSystemdClient) ListUnits() ([]*SystemdUnit, error) {
+	if m.ListUnitsFunc != nil {
+		return m.ListUnitsFunc()
+	}
+	return nil, nil
+}
+
+func (m *MockSystemdClient) ListUnitsByPatterns(patterns ...string) ([]*SystemdUnit, error) {
+	// check if method is available
+	if err := availableMethodCheck("ListUnitsByPatterns", m.version, SYSTEMD_BYPATTERNS_VERSION); err != nil {
+		return nil, err
+	}
+
+	if m.ListUnitsByPatternsFunc != nil {
+		return m.ListUnitsByPatternsFunc(patterns...)
+	}
+	return nil, nil
+}
+
+func (m *MockSystemdClient) ListUnitFiles() ([]*SystemdUnitFile, error) {
+	if m.ListUnitFilesFunc != nil {
+		return m.ListUnitFilesFunc()
+	}
+	return nil, nil
+}
+
+func (m *MockSystemdClient) ListUnitFilesByPatterns(patterns ...string) ([]*SystemdUnitFile, error) {
+	// check if method is available
+	if err := availableMethodCheck("ListUnitFilesByPatterns", m.version, SYSTEMD_BYPATTERNS_VERSION); err != nil {
+		return nil, err
+	}
+
+	if m.ListUnitFilesByPatternsFunc != nil {
+		return m.ListUnitFilesByPatternsFunc(patterns...)
+	}
+	return nil, nil
+}
+
+func (m *MockSystemdClient) GetExecStart(unitObjectPath string) ([]*SystemdServiceExecStart, error) {
+	if m.GetExecStartFunc != nil {
+		return m.GetExecStartFunc(unitObjectPath)
+	}
+	return nil, nil
+}
+
+func (m *MockSystemdClient) GetSystemdVersion() (string, error) {
+	if m.GetSystemdVersionFunc != nil {
+		return m.GetSystemdVersionFunc()
+	}
+	return "", nil
+}
+
+func (m *MockSystemdClient) GetUnitFileState(unitName SystemdUnitName) (string, error) {
+	if m.GetUnitFileStateFunc != nil {
+		return m.GetUnitFileStateFunc(unitName)
+	}
+	return "", nil
+}
+
+// verify that MockSystemdClient implements the SystemdClient interface
+var _ SystemdClient = (*MockSystemdClient)(nil)

--- a/internal/util/systemd_mock_test.go
+++ b/internal/util/systemd_mock_test.go
@@ -1,0 +1,350 @@
+package util
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// define a error to be returned by our failure handlers
+var forcedError = errors.New("forced")
+
+// TestMockSystemdClient verifies that the MockSystemdClient implementation
+// correctly delegates to the injected function fields. This ensures that the
+// mocking mechanism behaves as expected for other tests.
+func TestMockSystemdClient(t *testing.T) {
+
+	// verify each of the interface methods
+	t.Run("Close", testMockSystemdClientClose)
+	t.Run("ListUnits", testMockSystemdClientListUnits)
+	t.Run("ListUnitsByPatterns", testMockSystemdClientListUnitsByPatterns)
+	t.Run("ListUnitFiles", testMockSystemdClientListUnitFiles)
+	t.Run("ListUnitFilesByPatterns", testMockSystemdClientListUnitFilesByPatterns)
+	t.Run("GetExecStart", testMockSystemdClientGetExecStart)
+	t.Run("GetSystemdVersion", testMockSystemdClientGetSystemdVersion)
+	t.Run("GetUnitFileState", testMockSystemdClientGetUnitFileState)
+}
+
+func testMockSystemdClientClose(t *testing.T) {
+	// test setup
+	assert := assert.New(t)
+
+	// define a mock systemd client with a custom Close handler
+	m := NewMockSystemdClient("")
+	m.CloseFunc = func() error {
+		return forcedError
+	}
+
+	// verify that custom handler is triggered
+	err := m.Close()
+	assert.Error(err, "Close() should return an error")
+	assert.ErrorIs(err, forcedError, "Close() should return the expected error")
+
+	// verify default nil behavior
+	mClean := NewMockSystemdClient("")
+	err = mClean.Close()
+	assert.NoError(err, "Close() should not return an error for default mock handler")
+}
+
+func testMockSystemdClientListUnits(t *testing.T) {
+	// test setup
+	assert := assert.New(t)
+
+	// define a response for a mock.service
+	mockUnits := []*SystemdUnit{
+		NewSystemdUnit(
+			"mock.service",
+			"Mock service",
+			"active",
+			"active",
+			"",
+			"",
+			"/org/freedesktop/systemd1/unit/mock_2eservice",
+			0,
+			"",
+			"",
+		),
+	}
+
+	// define a mock systemd client with a custom ListUnits handler
+	m := NewMockSystemdClient("")
+	m.ListUnitsFunc = func() ([]*SystemdUnit, error) {
+		return mockUnits, nil
+	}
+
+	// verify success mocking
+	units, err := m.ListUnits()
+	assert.NoError(err, "ListUnits() shouldn't have returned an error")
+	assert.Equal(mockUnits, units, "ListUnits() should return the expected units")
+
+	// verify failure mocking
+	m.ListUnitsFunc = func() ([]*SystemdUnit, error) {
+		return nil, forcedError
+	}
+	units, err = m.ListUnits()
+	assert.Nil(units, "ListUnits() should have returned nil for failure")
+	assert.Error(err, "ListUnits() should have returned an error")
+	assert.ErrorIs(err, forcedError, "ListUnits() should have returned the expected error")
+
+	// verify default nil behavior
+	mClean := NewMockSystemdClient("")
+	units, err = mClean.ListUnits()
+	assert.Nil(units, "ListUnits() should have returned nil for default mock handler")
+	assert.NoError(err, "ListUnits() should not have returned an error for default mock handler")
+}
+
+func testMockSystemdClientListUnitsByPatterns(t *testing.T) {
+	// test setup
+	assert := assert.New(t)
+
+	// define a response for a mock.service
+	mockUnits := []*SystemdUnit{
+		NewSystemdUnit(
+			"mock.service",
+			"Mock service",
+			"active",
+			"active",
+			"",
+			"",
+			"/org/freedesktop/systemd1/unit/mock_2eservice",
+			0,
+			"",
+			"",
+		),
+	}
+
+	// define a mock systemd client with a custom ListUnitsByPatterns handler
+	m := NewMockSystemdClient("")
+	m.ListUnitsByPatternsFunc = func(patterns ...string) ([]*SystemdUnit, error) {
+		if len(patterns) > 0 && patterns[0] == "fail" {
+			return nil, forcedError
+		}
+		return mockUnits, nil
+	}
+
+	// verify success mocking
+	units, err := m.ListUnitsByPatterns("mock*")
+	assert.NoError(err, "ListUnitsByPatterns() shouldn't have returned an error")
+	assert.Equal(mockUnits, units, "ListUnitsByPatterns() should return the expected units")
+
+	// verify failure mocking
+	units, err = m.ListUnitsByPatterns("fail")
+	assert.Nil(units, "ListUnitsByPatterns() should have returned nil for failure")
+	assert.Error(err, "ListUnitsByPatterns() should have returned an error")
+	assert.ErrorIs(err, forcedError, "ListUnitsByPatterns() should have returned the expected error")
+
+	// verify legacy not available behavior
+	mLegacy := NewMockSystemdClient(MOCK_SYSTEMD_SLE12SP5_VERSION)
+	units, err = mLegacy.ListUnitsByPatterns("mock*")
+	assert.Nil(units, "ListUnitsByPatterns() should have returned nil for not available method error")
+	assert.ErrorIs(err, SystemdMethodNotAvailable, "ListUnitsByPatterns() should have returned not available method error")
+
+	// verify default nil behavior
+	mClean := NewMockSystemdClient("")
+	units, err = mClean.ListUnitsByPatterns("ok")
+	assert.Nil(units, "ListUnitsByPatterns() should have returned nil for default mock handler")
+	assert.NoError(err, "ListUnitsByPatterns() should not have returned an error for default mock handler")
+}
+
+func testMockSystemdClientListUnitFiles(t *testing.T) {
+	// test setup
+	assert := assert.New(t)
+
+	// define a response for a mock.service
+	mockUnitFiles := []*SystemdUnitFile{
+		NewSystemdUnitFile(
+			"mock_2eservice",
+			"enabled",
+		),
+	}
+
+	// define a mock systemd client with a custom ListUnitFiles handler
+	m := NewMockSystemdClient("")
+	m.ListUnitFilesFunc = func() ([]*SystemdUnitFile, error) {
+		return mockUnitFiles, nil
+	}
+
+	// verify success mocking
+	units, err := m.ListUnitFiles()
+	assert.NoError(err, "ListUnitFiles() shouldn't have returned an error")
+	assert.Equal(mockUnitFiles, units, "ListUnitFiles() should return the expected units")
+
+	// verify failure mocking
+	m.ListUnitFilesFunc = func() ([]*SystemdUnitFile, error) {
+		return nil, forcedError
+	}
+	units, err = m.ListUnitFiles()
+	assert.Nil(units, "ListUnitFiles() should have returned nil for failure")
+	assert.Error(err, "ListUnitFiles() should have returned an error")
+	assert.ErrorIs(err, forcedError, "ListUnitFiles() should have returned the expected error")
+
+	// verify default nil behavior
+	mClean := NewMockSystemdClient("")
+	units, err = mClean.ListUnitFiles()
+	assert.Nil(units, "ListUnitFiles() should have returned nil for default mock handler")
+	assert.NoError(err, "ListUnitFiles() should not have returned an error for default mock handler")
+}
+
+func testMockSystemdClientListUnitFilesByPatterns(t *testing.T) {
+	// test setup
+	assert := assert.New(t)
+
+	// define a response for a mock.service
+	mockUnitFiles := []*SystemdUnitFile{
+		NewSystemdUnitFile(
+			"mock_2eservice",
+			"enabled",
+		),
+	}
+
+	// define a mock systemd client with a custom ListUnitsByPatterns handler
+	m := NewMockSystemdClient("")
+	m.ListUnitFilesByPatternsFunc = func(patterns ...string) ([]*SystemdUnitFile, error) {
+		if len(patterns) > 0 && patterns[0] == "fail" {
+			return nil, forcedError
+		}
+		return mockUnitFiles, nil
+	}
+
+	// verify success mocking
+	units, err := m.ListUnitFilesByPatterns("mock*")
+	assert.NoError(err, "ListUnitFilesByPatterns() shouldn't have returned an error")
+	assert.Equal(mockUnitFiles, units, "ListUnitFilesByPatterns() should return the expected units")
+
+	// verify failure mocking
+	units, err = m.ListUnitFilesByPatterns("fail")
+	assert.Nil(units, "ListUnitFilesByPatterns() should have returned nil for failure")
+	assert.Error(err, "ListUnitFilesByPatterns() should have returned an error")
+	assert.ErrorIs(err, forcedError, "ListUnitFilesByPatterns() should have returned the expected error")
+
+	// verify legacy not available behavior
+	mLegacy := NewMockSystemdClient(MOCK_SYSTEMD_SLE12SP5_VERSION)
+	units, err = mLegacy.ListUnitFilesByPatterns("mock*")
+	assert.Nil(units, "ListUnitFilesByPatterns() should have returned nil for not available method error")
+	assert.ErrorIs(err, SystemdMethodNotAvailable, "ListUnitFilesByPatterns() should have returned not available method error")
+
+	// verify default nil behavior
+	mClean := NewMockSystemdClient("")
+	units, err = mClean.ListUnitFilesByPatterns("ok")
+	assert.Nil(units, "ListUnitFilesByPatterns() should have returned nil for default mock handler")
+	assert.NoError(err, "ListUnitFilesByPatterns() should not have returned an error for default mock handler")
+}
+
+func testMockSystemdClientGetExecStart(t *testing.T) {
+	// test setup
+	assert := assert.New(t)
+
+	// define a response for a mock.service
+	mockExecStart := []*SystemdServiceExecStart{
+		NewSystemdServiceExecStart(
+			"/some/path",
+			[]string{
+				"/some/path",
+				"arg1",
+				"arg2",
+			},
+			true,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+		),
+	}
+
+	// define a mock systemd client with a custom GetExecStart handler
+	m := NewMockSystemdClient("")
+	m.GetExecStartFunc = func(unitPath string) ([]*SystemdServiceExecStart, error) {
+		if unitPath == "fail" {
+			return nil, forcedError
+		}
+
+		return mockExecStart, nil
+	}
+
+	// verify success mocking
+	execStarts, err := m.GetExecStart("/org/freedesktop/systemd1/unit/mock_2eservice")
+	assert.Equal(mockExecStart, execStarts, "GetExecStart() should return the expected response")
+	assert.NoError(err, "GetExecStart() shouldn't have returned an error")
+
+	// verify failure mocking
+	execStarts, err = m.GetExecStart("fail")
+	assert.Nil(execStarts, "GetExecStart() should have returned nil for failure")
+	assert.Error(err, "GetExecStart() should have returned an error")
+	assert.ErrorIs(err, forcedError, "GetExecStart() should have returned the expected error")
+
+	// verify default nil behavior
+	mClean := NewMockSystemdClient("")
+	execStarts, err = mClean.GetExecStart("/org/freedesktop/systemd1/unit/mock_2eservice")
+	assert.Nil(execStarts, "GetExecStart() should have returned nil for default mock handler")
+	assert.NoError(err, "GetExecStart() should not have returned an error for default mock handler")
+}
+
+func testMockSystemdClientGetSystemdVersion(t *testing.T) {
+	// test setup
+	assert := assert.New(t)
+
+	mockVersion := "246"
+
+	// define a mock systemd client with a custom GetSystemdVersion handler
+	m := NewMockSystemdClient("")
+	m.GetSystemdVersionFunc = func() (string, error) {
+		return mockVersion, nil
+	}
+
+	// verify success mocking
+	version, err := m.GetSystemdVersion()
+	assert.Equal(mockVersion, version, "GetSystemdVersion() should return the expected response")
+	assert.NoError(err, "GetSystemdVersion() shouldn't have returned an error")
+
+	// verify failure mocking
+	m.GetSystemdVersionFunc = func() (string, error) {
+		return "", forcedError
+	}
+	version, err = m.GetSystemdVersion()
+	assert.Empty(version, "GetSystemdVersion() should have returned an empty string for failure")
+	assert.Error(err, "GetSystemdVersion() should have returned an error")
+	assert.ErrorIs(err, forcedError, "GetSystemdVersion() should have returned the expected error")
+
+	// verify default nil behavior
+	mClean := NewMockSystemdClient("")
+	version, err = mClean.GetSystemdVersion()
+	assert.Empty(version, "GetSystemdVersion() should have returned an empty string for default mock handler")
+	assert.NoError(err, "GetSystemdVersion() should not have returned an error for default mock handler")
+}
+
+func testMockSystemdClientGetUnitFileState(t *testing.T) {
+	// test setup
+	assert := assert.New(t)
+
+	mockState := "enabled"
+
+	// define a mock systemd client with a custom GetUnitFileState handler
+	m := NewMockSystemdClient("")
+	m.GetUnitFileStateFunc = func(unitName SystemdUnitName) (string, error) {
+		if unitName == "fail" {
+			return "", forcedError
+		}
+		return mockState, nil
+	}
+
+	// verify success mocking
+	state, err := m.GetUnitFileState("/org/freedesktop/systemd1/unit/mock_2eservice")
+	assert.Equal(mockState, state, "GetUnitFileState() should return the expected response")
+	assert.NoError(err, "GetUnitFileState() shouldn't have returned an error")
+
+	// verify success mocking
+	state, err = m.GetUnitFileState("fail")
+	assert.Empty(state, "GetUnitFileState() should have returned an empty string for failure")
+	assert.Error(err, "GetUnitFileState() should have returned an error")
+	assert.ErrorIs(err, forcedError, "GetUnitFileState() should have returned the expected error")
+
+	// verify default nil behavior
+	mClean := NewMockSystemdClient("")
+	state, err = mClean.GetUnitFileState("/org/freedesktop/systemd1/unit/mock_2eservice")
+	assert.Empty(state, "GetUnitFileState() should have returned an empty string for default mock handler")
+	assert.NoError(err, "GetExecStart() should not have returned an error for default mock handler")
+}

--- a/internal/util/systemd_test.go
+++ b/internal/util/systemd_test.go
@@ -1,0 +1,180 @@
+package util
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Test the parseSystemdVersion() helper
+func TestParseSystemdVersion(t *testing.T) {
+	// general test setup
+	assert := assert.New(t)
+
+	// Define test cases
+	testCases := []struct {
+		name            string
+		version         string
+		expectedVersion uint64
+		expectedError   error
+	}{
+		{ // SLE 12 SP 5
+			name:            "Valid simple version",
+			version:         "228",
+			expectedVersion: 228,
+			expectedError:   nil,
+		},
+		{ // SLE 15 SP3
+			name:            "Valid complex version",
+			version:         "246.16+suse.312.gb540e1826d",
+			expectedVersion: 246,
+			expectedError:   nil,
+		},
+		{ // invalid number
+			name:            "Invalid version number",
+			version:         "-123",
+			expectedVersion: 0,
+			expectedError:   strconv.ErrSyntax,
+		},
+		{ // invalid value
+			name:            "Invalid version",
+			version:         "invalid",
+			expectedVersion: 0,
+			expectedError:   strconv.ErrSyntax,
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			version, err := parseSystemdVersion(tt.version)
+			if tt.expectedError != nil {
+				assert.ErrorIs(err, tt.expectedError, "Unexpected parsing error when parsing version")
+			} else {
+				assert.NoError(err, "Version parsing should not have failed")
+				assert.Equal(tt.expectedVersion, version, "Parsed version does not match expected value")
+			}
+		})
+	}
+}
+
+// Test correct operation of the UnitType() routine associated with SystemdUnitName type
+func TestSystemdUnitName(t *testing.T) {
+	tests := []struct {
+		input SystemdUnitName
+		ext   string
+	}{
+		{"mock.service", "service"},
+		{"mock.target", "target"},
+		{"mock.timer", "timer"},
+		{"mock", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.input), func(t *testing.T) {
+			assert.Equal(t, tt.ext, tt.input.UnitType())
+		})
+	}
+}
+
+// Test correct operation of the UnitName() routine associated with SystemdUnitName type
+func TestSystemdUnitName_UnitName(t *testing.T) {
+	tests := []struct {
+		input    SystemdUnitName
+		expected string
+	}{
+		{"mock.service", "mock.service"},
+		{"/etc/systemd/system/mock.service", "mock.service"},
+		{"mock", "mock"},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.input), func(t *testing.T) {
+			assert.Equal(t, tt.expected, tt.input.UnitName())
+		})
+	}
+}
+
+// Test correct operation of the NameMatch() routine associated with SystemdUnitName type
+func TestSystemdUnitName_Match(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    SystemdUnitName
+		patterns []string
+		match    bool
+	}{
+		{"match_prefix", "mock.service", []string{"mock.*"}, true},
+		{"match_suffix", "mock.service", []string{"*.service"}, true},
+		{"match_multiple", "mock.service", []string{"test.*", "mock.*"}, true},
+		{"no_match", "mock.service", []string{"test.*", "*.target"}, false},
+		{"match_with_path", "/etc/systemd/system/mock.service", []string{"mock.*"}, true},
+		{"empty_patterns", "mock.service", []string{}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.match, tt.input.Match(tt.patterns...))
+		})
+	}
+}
+
+// Validate correct operation of constructors
+func TestSystemdConstructors(t *testing.T) {
+	t.Run("NewSystemdUnitFile", func(t *testing.T) {
+		unit := NewSystemdUnitFile("test.service", "enabled")
+		assert.Equal(t, SystemdUnitName("test.service"), unit.Name)
+		assert.Equal(t, "enabled", unit.State)
+	})
+
+	t.Run("NewSystemdUnit", func(t *testing.T) {
+		unit := NewSystemdUnit(
+			"test.service",
+			"Test Description",
+			"loaded",
+			"active",
+			"running",
+			"none",
+			"/object/path/to/test_2eservice",
+			123,
+			"start",
+			"/path/to/job",
+		)
+
+		assert.Equal(t, SystemdUnitName("test.service"), unit.Name)
+		assert.Equal(t, "/object/path/to/test_2eservice", unit.ObjectPath)
+		assert.Equal(t, "Test Description", unit.Description)
+		assert.Equal(t, "loaded", unit.LoadState)
+		assert.Equal(t, "active", unit.ActiveState)
+		assert.Equal(t, "running", unit.SubState)
+		assert.Equal(t, "none", unit.Following)
+		assert.Equal(t, uint32(123), unit.JobId)
+		assert.Equal(t, "start", unit.JobType)
+		assert.Equal(t, "/path/to/job", unit.JobPath)
+	})
+
+	t.Run("NewSystemdServiceExecStart", func(t *testing.T) {
+		execStart := NewSystemdServiceExecStart(
+			"/bin/true",
+			[]string{"/bin/true", "--version"},
+			true,
+			1000,
+			2000,
+			3000,
+			4000,
+			9999,
+			0,
+			1,
+		)
+
+		assert.Equal(t, "/bin/true", execStart.Path)
+		assert.Equal(t, []string{"/bin/true", "--version"}, execStart.Args)
+		assert.True(t, execStart.IgnoreErrors)
+		assert.Equal(t, uint64(1000), execStart.StartTimestamp)
+		assert.Equal(t, uint64(2000), execStart.StartTimestampMonotonic)
+		assert.Equal(t, uint64(3000), execStart.ExitTimestamp)
+		assert.Equal(t, uint64(4000), execStart.ExitTimestampMonotonic)
+		assert.Equal(t, uint32(9999), execStart.Pid)
+		assert.Equal(t, int32(0), execStart.ExitCode)
+		assert.Equal(t, int32(1), execStart.ExitStatus)
+	})
+}


### PR DESCRIPTION
The new collector checks for the existence of RKE2 and K3s server and agent services being enabled in the local systemd environment and will generate a "kubernetes_provider" entry that will be included in the system hardware info blob.

The format of the "kubernetes_provider" entry is as follows:

    "kubernetes_provider": {
      "type": "<solution_type>",
      "role": "<node_role>",
      "version": "<version>"
    }

A "kubernetes_provider" entry will be generated only when a single provider service is detected, as a system should only ever be a member of a single kubernetes cluster, and should only ever have a single node role assigned to it within that cluster.

If multiple kubernetes providers are detected then a debug message will be printed reporting that multiple provideres were detected but no "kubernetes_provider" entry will be generated.

To assist with collecting this information a SystemdClient interface has been defined wthin the internal/util package. The SystemdClient interface currently supports the following methods, though more can be added as needed:

  * ListUnitsByPattern List defined units similar to systemctl list-units. Requires systemd version 230+.
  * ListUnitFilesByPattern List defined unit files similar to systemctl list-units-files. Requires systemd version 230+.
  * GetExecStart Retrieve the ExecStart property value for a given unit file.
  * GetSystemdVersion Retrieve the Version property value for the target systemd.
  * GetUnitFileState Query the state (enabled/disabled/masked) for a given unit file.
  * Close Close underly systemd client connection and release resources.

Older versions of systemd, such as that found in SLE 12 SP5, do not support the List...ByPatterns methods, so we have to fall back to retrieving all of the Units or UnitFiles and use filepath.Match() pattern matching to exclude based upon the specified patterns.

Two implementations of the SystemdClient interface are provided:

  * DbusSystemdClient Leverages github.com/godbus/dbus/v5 to provide a native Golang D-Bus implementation that is used to query the local systemd.
  * MockSystemdClient A mock implementation that unit tests can leverage to test the code.

The DbusSystemdClient retrieves the systemd Version as part of the client initialisation and caches it to assist in determining if a method is available from the target systemd or not.

The MockSystemdClient can be initialised with a specific systemd Version value and similarly uses it to determine if methods should failed with the SystemdMethodNotAvailable error.

Implement unit tests leveraging the MockSystemdClient to exercise as much of the new collector code as possible.

Add optional feature tests (disabled by default), that can be used to validate correct operation of the kubernetes provider detection collector. These feature tests an environment with a working systemd ecosystem, meaning either a VM or a specially crafted containerised environment.

Update features/README.md with instructions on how to set up a viable containerised environment to be able to run the new feature tests.

Implements: TEL-317, TEL-359