### PR TITLE
Enable unit test coverage reporting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ bin
 *.tar.xz
 *.env*
 .mise.toml
+coverage/

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,10 @@ DIST          = $(NAME)-$(VERSION)/
 PWD           = $(shell pwd)
 GO            = go
 OUT           = -o out/
+# coverage testing enabled by default
+COVERAGE     ?= true
+COVERAGE_DIR  = $(PWD)/coverage
+COVERAGE_UNIT = $(COVERAGE_DIR)/unit
 GOFLAGS       = -v -mod=vendor
 BINFLAGS      = -buildmode=pie
 SOFLAGS       = -buildmode=c-shared
@@ -14,8 +18,23 @@ ENVFILE       = .env
 WORKDIR       = /usr/src/connect-ng
 MOUNT         = -v $(PWD):$(WORKDIR)
 
+define go-tool-covdata
+	@if [ -z "$(strip $(1))" ]; then \
+		echo "ERROR: no go tool covdata action specified."; \
+		exit 1; \
+	fi
+	@if $(if $(filter true,$(strip $(COVERAGE))),true,false); then \
+		$(GO) tool covdata $(1) -i=$(COVERAGE_UNIT); \
+	fi
+endef
+
+define cover-test-flags
+	$(if $(filter true,$(strip $(COVERAGE))),-cover -args -test.gocoverdir=$(COVERAGE_UNIT))
+endef
+
 .PHONY: all build build-arm build-ppc64le build-rpm build-s390 check-format
 .PHONY: ci-env clean dist feature-tests out test test-yast vendor vet
+.PHONY: coverage coverage-check-enabled coverage-dirs coverage-func coverage-percent
 
 all: clean build test
 
@@ -73,8 +92,27 @@ build-s390: clean out internal/connect/version.txt
 build-ppc64le: clean out internal/connect/version.txt
 	GOOS=linux GOARCH=ppc64le $(GO) build $(GOFLAGS) $(OUT) github.com/SUSE/connect-ng/cmd/suseconnect
 
-test: internal/connect/version.txt
-	$(GO) test ./internal/* ./cmd/suseconnect ./pkg/*
+coverage-dirs:
+	@mkdir -p $(COVERAGE_UNIT)
+
+coverage-check-enabled:
+	@if [ -z "$(filter true,$(strip $(COVERAGE)))" ]; then \
+		echo "WARNING: Coverage generation and collection not enabled."; \
+		echo "To enable it either add COVERAGE=true on the make command line arguments or set COVERAGE=true in the environment."; \
+		exit 1; \
+	fi
+
+coverage-func: coverage-check-enabled coverage-dirs
+	$(call go-tool-covdata,func)
+
+coverage-percent: coverage-check-enabled coverage-dirs
+	$(call go-tool-covdata,percent)
+
+coverage: coverage-func
+
+test: internal/connect/version.txt coverage-dirs
+	$(GO) test ./internal/* ./cmd/suseconnect ./pkg/* $(call cover-test-flags)
+	$(call go-tool-covdata,func)
 
 ci-env:
 	$(CRM) $(MOUNT) --env-file $(ENVFILE) -w $(WORKDIR) $(CONTAINER) bash

--- a/README.md
+++ b/README.md
@@ -32,16 +32,23 @@ This will create a `out/suseconnect` binary on the host.
 
 ### Testing
 
+There are three test suites available to run:
+  * unit tests
+  * feature tests
+  * YaST2 registration tests
+
+#### Unit Tests
+
 You can run all unit tests by running `make test`. If you then want to run unit
 tests for a specific package, you can simply run it as you would do for any Go
 project, for example: `go test ./internal/collectors/`.
+
+#### Feature Tests
 
 For feature tests you first need to create an `.env` file in the root directory
 of the project with the following contents:
 
 ``` sh
-BETA_VALID_REGCODE="<regcode>"
-BETA_NOT_ACTIVATED_REGCODE="<regcode>"
 VALID_REGCODE="<regcode>"
 EXPIRED_REGCODE="<regcode>"
 NOT_ACTIVATED_REGCODE="<regcode>"
@@ -51,3 +58,40 @@ These values can be picked up from Glue's production environment. Once that is
 done, you can then simply run `make feature-tests`. This will run a all feature
 tests inside of a container by using the registration codes as provided by the
 `.env` file.
+
+**NOTE**: You may find that the `vendor` directory is owned by root after running
+the `feature-tests` target; to delete it you may need to run `sudo rm -rf vendor`.
+
+#### YaST2 Registration Tests
+
+You can run the YaST2 registration tests using `make test-yast`, which uses
+the [yast/yast-registration repo](https://github.com/yast/yast-registration)
+from within a customer container image, defined in [third_party/Dockerfile.yast](third_party/Dockerfile.yast),
+to exercise the `libsuseconnect.so` library via the suseconnect Ruby bindings.
+
+#### Coverage Reporting for Unit Tests
+
+Coverage reporting for unit tests has been added, and is enabled by default.
+To disable it you can add `COVERAGE=false` to your `make test` command line,
+or set it in your environment.
+
+By default the `make test` will report the percentage of statements covered
+on a per package basis as they are tested (similar to the `coverage-percent`
+target described below), and will then generate the same detailed coverage
+report as the `coverage-func` target described below.
+
+**NOTE**: Support for generating coverage testing for the feature and YaST2
+registratoon tests is under development and will be available at a later date.
+
+##### Reviewing the most recent coverage data
+
+Coverage data will be saved under the `coverage` directory, and you can review
+the most recent unit test run's data using the the following coverage targets:
+  * `coverage-func`
+    This will report detail coverage stats for each function, with the overall
+    summary coverage percentage for all functions in the code base at the end.
+  * `coverage-percent`
+    This will report the percentage of statements coverage on a per package
+    basis as found in the tested codebase.
+  * `coverage`
+    This is currently an alias for `coverage-func`.


### PR DESCRIPTION
Update the Makefile to add support for generating coverage data when running the unit tests. This coverage data will be saved under the coverage directory.

Add additional coverage related targets to the Makefile that report on the coverage data from the most recent unit test run.

Update the README.md file's section on testing to outline the testing targets that are available in the Makefile and also add a section on coverage collection and reporting.

Add git ignorance of the coverage directory.