### PR TITLE
Fail if any Product triplet parts are empty in FromTriplet()

### DIFF
--- a/pkg/registration/product.go
+++ b/pkg/registration/product.go
@@ -3,6 +3,7 @@ package registration
 import (
 	"encoding/json"
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/SUSE/connect-ng/pkg/connection"
@@ -73,10 +74,11 @@ func (p *Product) UnmarshalJSON(data []byte) error {
 }
 
 // Builds a new Product object by parsing the given string considering to be a
-// product "triplet" (i.e. a string with the format "<name>/<version>/<arch>").
+// product "triplet" (i.e. a string with the format "<name>/<version>/<arch>"
+// without any empty elements).
 func FromTriplet(triplet string) (Product, error) {
 	parts := strings.Split(triplet, "/")
-	if len(parts) != 3 {
+	if (len(parts) != 3) || slices.Contains(parts, "") {
 		return Product{}, fmt.Errorf("invalid product; <internal name>/<version>/<architecture> format expected")
 	}
 	return Product{Identifier: parts[0], Version: parts[1], Arch: parts[2]}, nil

--- a/pkg/registration/product_test.go
+++ b/pkg/registration/product_test.go
@@ -158,3 +158,73 @@ func TestFindExtension(t *testing.T) {
 	_, err := product.FindExtension("sle-module-fakesystem/15.5/x86_64")
 	assert.Equal("extension not found", err.Error())
 }
+
+func TestFromTriplet(t *testing.T) {
+	assert := assert.New(t)
+
+	t.Run("valid triplets with component validation", func(t *testing.T) {
+		tests := []struct {
+			triplet      string
+			expectedName string
+			expectedVer  string
+			expectedArch string
+		}{
+			{
+				triplet:      "SLES/15/x86_64",
+				expectedName: "SLES",
+				expectedVer:  "15",
+				expectedArch: "x86_64",
+			},
+			{
+				triplet:      "sle-module-basesystem/15.5/aarch64",
+				expectedName: "sle-module-basesystem",
+				expectedVer:  "15.5",
+				expectedArch: "aarch64",
+			},
+			{
+				triplet:      "sle-module-python3/15.6/ppc64le",
+				expectedName: "sle-module-python3",
+				expectedVer:  "15.6",
+				expectedArch: "ppc64le",
+			},
+			{
+				triplet:      "sle-module-server-applications/15.4/s390x",
+				expectedName: "sle-module-server-applications",
+				expectedVer:  "15.4",
+				expectedArch: "s390x",
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.triplet, func(t *testing.T) {
+				product, err := FromTriplet(tt.triplet)
+				assert.NoError(err, "triplet should be valid: %q", tt.triplet)
+				assert.NotNil(product)
+				assert.Equal(tt.expectedName, product.Identifier, "triplet identifier not expected value")
+				assert.Equal(tt.expectedVer, product.Version, "triplet version  not expected value")
+				assert.Equal(tt.expectedArch, product.Arch, "triplet arch not expected value")
+			})
+		}
+	})
+
+	t.Run("invalid triplets", func(t *testing.T) {
+		tests := []struct {
+			triplet string
+			name    string
+		}{
+			{triplet: "", name: "empty string"},
+			{triplet: "single", name: "single part"},
+			{triplet: "two/parts", name: "two parts"},
+			{triplet: "four/parts/too/many", name: "four parts"},
+			{triplet: "empty//part", name: "empty part"},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				_, err := FromTriplet(tt.triplet)
+				assert.Error(err, "expected error for: %q (%s)", tt.triplet, tt.name)
+			})
+		}
+	})
+
+}


### PR DESCRIPTION
Add FromTriplet() tests extracted, ported over and simplified from
the proposed tests in SUSE/connect-ng#351, and updated to test the
new failure condition.