### PR TITLE
Restore exit status 71 handling for unregistered keepalive

### DIFF
--- a/build/packaging/suseconnect-ng.changes
+++ b/build/packaging/suseconnect-ng.changes
@@ -4,6 +4,8 @@ Mon Apr  6 15:40:58 UTC 2026 - Fergal Mc Carthy <fmccarthy@suse.com>
 - Update version to 1.22 (pre):
   - InstallReleasePackage should consider zypperFilesystemRoot
     (jsc#SCC-630).
+  - Restore exit code 71 handling when attempting keepalive and not
+    registered (bsc#1263772)
   
 -------------------------------------------------------------------
 Wed Apr  1 16:43:26 UTC 2026 - Fergal Mc Carthy <fmccarthy@suse.com>

--- a/features/suseconnect/cli_test.go
+++ b/features/suseconnect/cli_test.go
@@ -11,6 +11,7 @@ import (
 func TestCLI(t *testing.T) {
 	t.Run("showing help", testCLIPrintsHelp)
 	t.Run("showing version", testCLIPrintsVersion)
+	t.Run("keepalive unregistered", testCLIKeepAliveUnregistered)
 }
 
 func testCLIPrintsHelp(t *testing.T) {
@@ -42,4 +43,13 @@ func testCLIPrintsVersion(t *testing.T) {
 	cli.Run()
 	assert.Regexp(regexp.MustCompile(`\d{1,2}\.\d{1,2}(\.\d{1,2})?`), cli.Stdout())
 	assert.Equal(0, cli.ExitCode())
+}
+
+func testCLIKeepAliveUnregistered(t *testing.T) {
+	assert := assert.New(t)
+	cli := helpers.NewRunner(t, "suseconnect --keepalive")
+
+	cli.Run()
+	assert.Contains(cli.Stdout(), "Error sending keepalive: System is not registered. Use the --regcode parameter to register it.")
+	assert.Equal(71, cli.ExitCode())
 }

--- a/internal/connect/wrapper.go
+++ b/internal/connect/wrapper.go
@@ -137,7 +137,7 @@ func (w Wrapper) KeepAlive(uptimeTracking bool) error {
 	code, err := registration.Status(w.Connection, hostname, hwinfo, profileData, extraData)
 	if code == registration.Unregistered {
 		profiles.DeleteProfileCache("*-profile-id")
-		return fmt.Errorf("trying to send a keepalive from a system not yet registered. Register this system first")
+		return ErrPingFromUnregistered
 	} else if err != nil {
 		profiles.DeleteProfileCache("*-profile-id")
 	}


### PR DESCRIPTION
If attempting a keepalive for an unregistered system we should be returning the special ErrPingFromUnregistered error not a generic error message. Doing so will trigger the exit code 71 handling in the ExitOnError() routine in cmd/suseconnect.go.

Update suseconnect-ng.changes with entry referencing bsc#1263772.

Add a feature test to verify this scenario.