### PR TITLE
Fix typo in kubernetes_provider testing

### DIFF
--- a/internal/collectors/kubernetes_provider_test.go
+++ b/internal/collectors/kubernetes_provider_test.go
@@ -159,7 +159,7 @@ func (env *systemdTestEnv) AddK8sUnit(svcName, k8sType, k8sRole, svcState string
 	case "disabled":
 		activeState = "inactive"
 		subState = "dead"
-	case "ensabled":
+	case "enabled":
 		activeState = "active"
 		subState = "running"
 	default:


### PR DESCRIPTION
Spotted by Brett, the case check should be for enabled rather than ensabled.