### PR TITLE
Add HA collector

### DIFF
--- a/build/packaging/suseconnect-ng.changes
+++ b/build/packaging/suseconnect-ng.changes
@@ -9,6 +9,8 @@ Mon Apr  6 15:40:58 UTC 2026 - Fergal Mc Carthy <fmccarthy@suse.com>
   - Add collector support for gathering RKE2 & K3s kubernetes provider
     info if enabled on a system (jsc#TEL-317)
   - Add email address validation to SUSEConnect -e/--email option. (bsc#1197231)
+  - Add collector support for detecting if systen is running pacemaker
+    (jsc#SCC-693)
 
 -------------------------------------------------------------------
 Wed Apr  1 16:43:26 UTC 2026 - Fergal Mc Carthy <fmccarthy@suse.com>

--- a/internal/collectors/collectors.go
+++ b/internal/collectors/collectors.go
@@ -13,6 +13,7 @@ Example:
 		collectors.Memory{},
 		collectors.UUID{},
 		collectors.Vendor{},
+		collectors.HA{},
 	}
 
 result, error := collectors.CollectInformation("x86_64", MandatoryCollectors)

--- a/internal/collectors/ha.go
+++ b/internal/collectors/ha.go
@@ -1,0 +1,87 @@
+package collectors
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/SUSE/connect-ng/internal/util"
+)
+
+type HA struct{}
+
+// Get Pacemaker version
+func getPacemakerVersion() (string, error) {
+	pacemakerdOut, err := util.Execute([]string{"pacemakerd", "--version"}, nil)
+	if err != nil {
+		return "", err
+	}
+	scanner := bufio.NewScanner(bytes.NewReader(pacemakerdOut))
+	for scanner.Scan() {
+		testLine := scanner.Text()
+		fields := strings.Fields(testLine)
+		if len(fields) >= 2 {
+			if fields[0] == "Pacemaker" {
+				return fields[1], nil
+			}
+		}
+	}
+
+	return "", scanner.Err()
+}
+
+func isPacemakerRunning(systemdClient util.SystemdClient) (bool, error) {
+	// first try to use ListUnitsByPatterns, failing back to ListUnits if not available
+	units, err := systemdClient.ListUnitsByPatterns("pacemaker.service")
+	if err != nil {
+		fmt.Printf("!!!!!!!!!!systemdClient.ListUnitsByPatterns() failed: %s %t\n", err, errors.Is(err, util.SystemdMethodNotAvailable))
+		if !errors.Is(err, util.SystemdMethodNotAvailable) {
+			util.Debug.Printf("systemdClient.ListUnitsByPatterns() failed: %s\n", err)
+			return false, err
+		}
+		units, err = systemdClient.ListUnits()
+	}
+
+	util.Debug.Printf("pacemakerActive: units: %+v err: %+v\n", units, err)
+	if err != nil {
+		util.Debug.Printf("systemdClient.ListUnits() failed: %s\n", err)
+		return false, err
+	}
+
+	for _, unit := range units {
+		util.Debug.Printf("pacemakerActive: unit: %+v \n", unit)
+		// is pacemaker running
+		if unit.Name.Match("pacemaker.service") && unit.SubState == "running" {
+			return true, nil
+		}
+	}
+	return false, nil
+
+}
+
+func isSystemHA(systemdClient util.SystemdClient) (Result, error) {
+	haActive, err := isPacemakerRunning(systemdClient)
+	util.Debug.Print("ha:haActive ", haActive)
+	if !haActive {
+		return Result{}, err
+	}
+	pacemakerVersion, err := getPacemakerVersion()
+	if pacemakerVersion != "" {
+		result := Result{"ha_active": pacemakerVersion}
+		util.Debug.Printf("ha:pacemakerVersion:Result: %+v \n", result)
+		return result, err
+	}
+	return Result{}, err
+}
+
+func (HA) run(arch string) (Result, error) {
+	systemdClient, err := util.NewDbusSystemdClient()
+	if err != nil {
+		return nil, err
+	}
+	defer systemdClient.Close()
+	result, err := isSystemHA(systemdClient)
+	return result, err
+}

--- a/internal/collectors/ha.go
+++ b/internal/collectors/ha.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"bytes"
 	"errors"
-	"fmt"
 	"strings"
 
 	"github.com/SUSE/connect-ng/internal/util"
@@ -36,7 +35,6 @@ func isPacemakerRunning(systemdClient util.SystemdClient) (bool, error) {
 	// first try to use ListUnitsByPatterns, failing back to ListUnits if not available
 	units, err := systemdClient.ListUnitsByPatterns("pacemaker.service")
 	if err != nil {
-		fmt.Printf("!!!!!!!!!!systemdClient.ListUnitsByPatterns() failed: %s %t\n", err, errors.Is(err, util.SystemdMethodNotAvailable))
 		if !errors.Is(err, util.SystemdMethodNotAvailable) {
 			util.Debug.Printf("systemdClient.ListUnitsByPatterns() failed: %s\n", err)
 			return false, err

--- a/internal/collectors/ha_test.go
+++ b/internal/collectors/ha_test.go
@@ -135,52 +135,28 @@ func TestPacemakerActiveErrorUnits(t *testing.T) {
 	assert.Equal(false, res, "isPacemakerRunning() returned unexpected result")
 }
 
-func TestGetPacemakerVersionPass(t *testing.T) {
+func TestGetPacemakerVersion(t *testing.T) {
 	// general setup
 	assert := assert.New(t)
+	var tests = []struct {
+		input  string
+		result string
+	}{
+		{"Pacemaker 2.1.10+20250718.fdf796ebc8-150700.3.3.1", "2.1.10+20250718.fdf796ebc8-150700.3.3.1"},
+		{"Pacemaker", ""},
+		{"Test Data", ""},
+	}
 
-	pacemakerVersion := "2.1.10+20250718.fdf796ebc8-150700.3.3.1"
-	paceMakerName := "Pacemaker"
+	for _, v := range tests {
+		// setup execute for pacemakerd --version
+		mockUtilExecute(v.input, nil)
+		// run test case
+		res, err := getPacemakerVersion()
 
-	// setup execute for pacemakerd --version
-	mockUtilExecute(strings.Join([]string{paceMakerName, pacemakerVersion}, " "), nil)
-
-	// run test case
-	res, err := getPacemakerVersion()
-
-	// check returned values
-	assert.NoError(err, "getPacemakerVersion() returned expected error")
-	assert.Equal(pacemakerVersion, res, "getPacemakerVersion() returned unexpected result")
-}
-
-func TestGetPacemakerVersionNoPacemaker(t *testing.T) {
-	// general setup
-	assert := assert.New(t)
-
-	// setup execute for pacemakerd --version
-	mockUtilExecute("test data", nil)
-
-	// run test case
-	res, err := getPacemakerVersion()
-
-	// check returned values
-	assert.NoError(err, "getPacemakerVersionNoPacemaker() returned expected error")
-	assert.Equal("", res, "getPacemakerVersionNoPacemker() returned unexpected result")
-}
-
-func TestGetPacemakerVersionNoVersion(t *testing.T) {
-	// general setup
-	assert := assert.New(t)
-
-	// setup execute for pacemakerd --version
-	mockUtilExecute("Pacemaker", nil)
-
-	// run test case
-	res, err := getPacemakerVersion()
-
-	// check returned values
-	assert.NoError(err, "getPacemakerVersionNoVersion() returned expected error")
-	assert.Equal("", res, "getPacemakerVersionNoVersion() returned unexpected result")
+		// check returned values
+		assert.NoError(err, "getPacemakerVersion() returned expected error")
+		assert.Equal(v.result, res, "getPacemakerVersion() returned unexpected result")
+	}
 }
 
 func TestGetPacemakerVersionExecuteError(t *testing.T) {

--- a/internal/collectors/ha_test.go
+++ b/internal/collectors/ha_test.go
@@ -1,0 +1,291 @@
+package collectors
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/SUSE/connect-ng/internal/util"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPacemakerActiveNoPacemaker(t *testing.T) {
+	// general setup
+	assert := assert.New(t)
+
+	// test settings
+	testEnv := NewSystemdTestEnv()
+
+	// create a mock systemd client
+	systemdClient := testEnv.NewClient()
+	defer testEnv.Cleanup()
+
+	// run test case
+	res, err := isPacemakerRunning(systemdClient)
+
+	// check returned values
+	assert.NoError(err, "isPacemakerRunning() returned unexpected error")
+	assert.Equal(false, res, "isPacemakerRunning() returned unexpected result")
+}
+
+func TestPacemakerActiveRunning(t *testing.T) {
+	// general setup
+	assert := assert.New(t)
+
+	// test settings
+	testEnv := NewSystemdTestEnv()
+	testEnv.AddK8sUnit("dummy1.service", "dummy1 service", "server", "enabled")
+	testEnv.AddK8sUnit("pacemaker.service", "Pacemaker High Availability Cluster Manager", "server", "enabled")
+	testEnv.AddK8sUnit("dummy2.service", "dummy2 service", "server", "enabled")
+
+	// create a mock systemd client
+	systemdClient := testEnv.NewClient()
+	defer testEnv.Cleanup()
+
+	// run test case
+	res, err := isPacemakerRunning(systemdClient)
+
+	// check returned values
+	assert.NoError(err, "isPacemakerRunning() returned unexpected error")
+	assert.Equal(true, res, "isPacemakerRunning() returned unexpected result")
+}
+
+func TestPacemakerActiveRunningNoPattern(t *testing.T) {
+	// general setup
+	assert := assert.New(t)
+
+	// test settings
+	testEnv := NewSystemdTestEnv()
+	testEnv.AddK8sUnit("dummy1.service", "dummy1 service", "server", "enabled")
+	testEnv.AddK8sUnit("pacemaker.service", "Pacemaker High Availability Cluster Manager", "server", "enabled")
+	testEnv.AddK8sUnit("dummy2.service", "dummy2 service", "server", "enabled")
+	// test using ListUnits
+	testEnv.listUnitsByPatternsError = util.SystemdMethodNotAvailable
+
+	// create a mock systemd client
+	systemdClient := testEnv.NewClient()
+	defer testEnv.Cleanup()
+
+	// run test case
+	res, err := isPacemakerRunning(systemdClient)
+
+	// check returned values
+	assert.NoError(err, "isPacemakerRunning() returned unexpected error")
+	assert.Equal(true, res, "isPacemakerRunning() returned unexpected result")
+}
+
+func TestPacemakerActiveNotRunning(t *testing.T) {
+	// general setup
+	assert := assert.New(t)
+
+	// test settings
+	testEnv := NewSystemdTestEnv()
+	testEnv.AddK8sUnit("pacemaker.service", "Pacemaker High Availability Cluster Manager", "server", "disabled")
+
+	// create a mock systemd client
+	systemdClient := testEnv.NewClient()
+	defer testEnv.Cleanup()
+
+	// run test case
+	res, err := isPacemakerRunning(systemdClient)
+
+	// check returned values
+	assert.NoError(err, "isPacemakerRunning() returned unexpected error")
+	assert.Equal(false, res, "isPacemakerRunning() returned unexpected result")
+}
+
+func TestPacemakerActiveErrorPattern(t *testing.T) {
+	// general setup
+	assert := assert.New(t)
+
+	// test settings
+	testEnv := NewSystemdTestEnv()
+	testEnv.listUnitsByPatternsError = fmt.Errorf("test error")
+
+	// create a mock systemd client
+	systemdClient := testEnv.NewClient()
+	defer testEnv.Cleanup()
+
+	// run test case
+	res, err := isPacemakerRunning(systemdClient)
+
+	// check returned values
+	assert.Error(err, "isPacemakerRunning() failed to returned expected error")
+	assert.Equal(false, res, "isPacemakerRunning() returned unexpected result")
+}
+
+func TestPacemakerActiveErrorUnits(t *testing.T) {
+	// general setup
+	assert := assert.New(t)
+
+	// test settings
+	testEnv := NewSystemdTestEnv()
+	testEnv.listUnitsByPatternsError = util.SystemdMethodNotAvailable
+	testEnv.listUnitsError = fmt.Errorf("test error")
+
+	// create a mock systemd client
+	systemdClient := testEnv.NewClient()
+	defer testEnv.Cleanup()
+
+	// run test case
+	res, err := isPacemakerRunning(systemdClient)
+
+	// check returned values
+	assert.Error(err, "isPacemakerRunning() failed to returned expected error")
+	assert.Equal(false, res, "isPacemakerRunning() returned unexpected result")
+}
+
+func TestGetPacemakerVersionPass(t *testing.T) {
+	// general setup
+	assert := assert.New(t)
+
+	pacemakerVersion := "2.1.10+20250718.fdf796ebc8-150700.3.3.1"
+	paceMakerName := "Pacemaker"
+
+	// setup execute for pacemakerd --version
+	mockUtilExecute(strings.Join([]string{paceMakerName, pacemakerVersion}, " "), nil)
+
+	// run test case
+	res, err := getPacemakerVersion()
+
+	// check returned values
+	assert.NoError(err, "getPacemakerVersion() returned expected error")
+	assert.Equal(pacemakerVersion, res, "getPacemakerVersion() returned unexpected result")
+}
+
+func TestGetPacemakerVersionNoPacemaker(t *testing.T) {
+	// general setup
+	assert := assert.New(t)
+
+	// setup execute for pacemakerd --version
+	mockUtilExecute("test data", nil)
+
+	// run test case
+	res, err := getPacemakerVersion()
+
+	// check returned values
+	assert.NoError(err, "getPacemakerVersionNoPacemaker() returned expected error")
+	assert.Equal("", res, "getPacemakerVersionNoPacemker() returned unexpected result")
+}
+
+func TestGetPacemakerVersionNoVersion(t *testing.T) {
+	// general setup
+	assert := assert.New(t)
+
+	// setup execute for pacemakerd --version
+	mockUtilExecute("Pacemaker", nil)
+
+	// run test case
+	res, err := getPacemakerVersion()
+
+	// check returned values
+	assert.NoError(err, "getPacemakerVersionNoVersion() returned expected error")
+	assert.Equal("", res, "getPacemakerVersionNoVersion() returned unexpected result")
+}
+
+func TestGetPacemakerVersionExecuteError(t *testing.T) {
+	// general setup
+	assert := assert.New(t)
+
+	// setup execute for pacemakerd --version
+	mockUtilExecute("", fmt.Errorf("forced error"))
+
+	// run test case
+	res, err := getPacemakerVersion()
+
+	// check returned values
+	assert.Error(err, "isSystemHA() failed to returned unexpected error")
+	assert.ErrorContains(err, "forced error")
+	assert.Equal("", res, "getPacemakerVersionNoInput() returned unexpected result")
+}
+
+func TestGetPacemakerVersionScannerError(t *testing.T) {
+	// general setup
+	assert := assert.New(t)
+
+	// we want to force a scanner error, which requires
+	// execute returning a line > 64kb
+	// from execute for pacemakerd --version
+	mockUtilExecute(strings.Repeat("x", 65*1024), nil)
+
+	// run test case
+	res, err := getPacemakerVersion()
+
+	// check returned values
+	assert.Error(err, "getPacemakerVersioScannerErrorn() failed to returned expected error")
+	assert.ErrorContains(err, "token too long")
+	assert.Equal("", res, "getPacemakerVersionScannerError() returned unexpected result")
+}
+
+func TestIsPacemakerActiveNoPacemaker(t *testing.T) {
+	// general setup
+	assert := assert.New(t)
+	expectedRes := Result{}
+
+	// test settings
+	testEnv := NewSystemdTestEnv()
+
+	// create a mock systemd client
+	systemdClient := testEnv.NewClient()
+	defer testEnv.Cleanup()
+
+	// run test case
+	res, err := isSystemHA(systemdClient)
+
+	// check returned values
+	assert.NoError(err, "isSystemHA() returned unexpected error")
+	assert.Equal(expectedRes, res, "isSystemHA() returned unexpected result")
+}
+
+func TestIsPacemakerActiveRunningError(t *testing.T) {
+	// general setup
+	expectedRes := Result{}
+	assert := assert.New(t)
+
+	// test settings
+	testEnv := NewSystemdTestEnv()
+	testEnv.AddK8sUnit("pacemaker.service", "Pacemaker High Availability Cluster Manager", "server", "enabled")
+
+	// create a mock systemd client
+	systemdClient := testEnv.NewClient()
+	defer testEnv.Cleanup()
+
+	// setup execute for pacemakerd --version
+	mockUtilExecute("", fmt.Errorf("forced error"))
+
+	// run test case
+	res, err := isSystemHA(systemdClient)
+
+	// check returned values
+	assert.Error(err, "isSystemHA() failed to returned unexpected error")
+	assert.ErrorContains(err, "forced error")
+	assert.Equal(expectedRes, res, "isSystemHA() returned unexpected result")
+}
+
+func TestIsPacemakerActiveRunningSuccess(t *testing.T) {
+	// general setup
+	assert := assert.New(t)
+
+	// test settings
+	testEnv := NewSystemdTestEnv()
+	testEnv.AddK8sUnit("pacemaker.service", "Pacemaker High Availability Cluster Manager", "server", "enabled")
+
+	// create a mock systemd client
+	systemdClient := testEnv.NewClient()
+	defer testEnv.Cleanup()
+
+	// setup execute for pacemakerd --version
+	pacemakerVersion := "2.1.10+20250718.fdf796ebc8-150700.3.3.1"
+	paceMakerName := "Pacemaker"
+	expectedRes := Result{"ha_active": pacemakerVersion}
+
+	// setup execute for pacemakerd --version
+	mockUtilExecute(strings.Join([]string{paceMakerName, pacemakerVersion}, " "), nil)
+
+	// run test case
+	res, err := isSystemHA(systemdClient)
+
+	// check returned values
+	assert.NoError(err, "isSystemHA() returned unexpected error")
+	assert.Equal(expectedRes, res, "isSystemHA() returned unexpected result")
+}

--- a/internal/connect/collectors.go
+++ b/internal/connect/collectors.go
@@ -22,6 +22,7 @@ func FetchSystemInformation(arch string) (collectors.Result, error) {
 		collectors.SAP{},
 		collectors.Vendor{},
 		collectors.K8S{},
+		collectors.HA{},
 	}
 
 	var err error


### PR DESCRIPTION
The HA collector determines if pacemaker is running on the system. If pacemaker is active, the record ha_active is added to the sysinfo blob with contents returned by "pacemaked --version".

If pacemaker is not running, the ha_active record is NOT included in the sysinfo blob.