### PR TITLE
Validate email address syntax

### DIFF
--- a/build/packaging/suseconnect-ng.changes
+++ b/build/packaging/suseconnect-ng.changes
@@ -8,9 +8,7 @@ Mon Apr  6 15:40:58 UTC 2026 - Fergal Mc Carthy <fmccarthy@suse.com>
     registered (bsc#1263772)
   - Add collector support for gathering RKE2 & K3s kubernetes provider
     info if enabled on a system (jsc#TEL-317)
-  - Add email address validation to SUSEConnect -e/--email option
-    Since the email address is not actually used for registration
-    an malformed email addresses are flagged as warning. (bsc#1197231)
+  - Add email address validation to SUSEConnect -e/--email option. (bsc#1197231)
 
 -------------------------------------------------------------------
 Wed Apr  1 16:43:26 UTC 2026 - Fergal Mc Carthy <fmccarthy@suse.com>

--- a/build/packaging/suseconnect-ng.changes
+++ b/build/packaging/suseconnect-ng.changes
@@ -8,6 +8,9 @@ Mon Apr  6 15:40:58 UTC 2026 - Fergal Mc Carthy <fmccarthy@suse.com>
     registered (bsc#1263772)
   - Add collector support for gathering RKE2 & K3s kubernetes provider
     info if enabled on a system (jsc#TEL-317)
+  - Add email address validation to SUSEConnect -e/--email option
+    Since the email address is not actually used for registration
+    an malformed email addresses are flagged as warning. (bsc#1197231)
 
 -------------------------------------------------------------------
 Wed Apr  1 16:43:26 UTC 2026 - Fergal Mc Carthy <fmccarthy@suse.com>

--- a/cmd/suseconnect/suseconnect.go
+++ b/cmd/suseconnect/suseconnect.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/mail"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -198,6 +199,11 @@ func main() {
 		opts.InstanceDataFile = instanceDataFile
 	}
 	if email != "" {
+		_, err := mail.ParseAddress(email)
+		if err != nil {
+			fmt.Printf("SUSEConnect warning: ignoring malformed email address: %s\n", email)
+			email = ""
+		}
 		opts.Email = email
 	}
 	if lang, ok := os.LookupEnv("LANG"); ok {


### PR DESCRIPTION
Add email address validation to SUSEConnect -e/--email option Since the email address is not actually used for registration an malformed email addresses are flagged as warning. (bsc#1197231)