### PR TITLE
Add agama testing GitHub Actions workflow

### DIFF
--- a/.actrc
+++ b/.actrc
@@ -1,0 +1,4 @@
+--artifact-server-path /tmp/act-connect-ng-artifact-server
+--env-file .env
+--platform ubuntu-latest=ghcr.io/catthehacker/ubuntu:go-latest
+

--- a/.env-example
+++ b/.env-example
@@ -1,4 +1,4 @@
-# Needed to run feature tests
+# Needed to run feature tests or agama tests
 REGCODE=
 HA_REGCODE=
 EXPIRED_REGCODE=

--- a/.github/workflows/agama.yml
+++ b/.github/workflows/agama.yml
@@ -1,0 +1,112 @@
+---
+name: agama tests
+
+# About security when running the tests and NOT exposing
+# the secrets to externals. Currently Github Actions does
+# NOT expose the secrets if the branch is coming from a forked
+# repository.
+# See: https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/
+# See: https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions
+#
+# An alternate would be to set, pull_request_target but this takes the CI code
+# from master removing the ability to change the code in a PR easily.
+#
+# Aditionally, since 2021 pull requests from new contributors will not
+# trigger workflows automatically but will wait for approval from somebody
+# with write access.
+# See: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
+on: [pull_request]
+
+env:
+  CONNECTNG_SOURCE: /usr/src/connect-ng
+  AGAMA_SOURCE: /usr/src/agama
+  CONNECTNG_ARTIFACT: suseconnect-build-out
+  CONNECTNG_TARBALL: /usr/src/suseconnect-build-out.tar.gz
+  REGCODE: ${{ secrets.REGCODE }}
+
+jobs:
+
+  build-suseconnect:
+    name: Build SUSE/connect-ng inputs required by Agama
+    runs-on: ubuntu-latest
+    container:
+      image: registry.suse.com/bci/golang:1.24-openssl
+      options: --user root --privileged
+
+    steps:
+      - name: Install dependencies for artifact upload/download
+        run: |
+          zypper --non-interactive in nodejs-default
+
+      - name: Checkout SUSE/connect-ng
+        uses: actions/checkout@v4
+        with:
+          path: connect-ng
+
+      - name: Move checked out connect-ng to /usr/src
+        run: |
+          mv connect-ng ${{ env.CONNECTNG_SOURCE }}
+
+      - name: Build SUSE/connect-ng
+        working-directory: ${{ env.CONNECTNG_SOURCE }}
+        run: |
+          make vendor build
+
+      - name: Create a tarball of the build output
+        working-directory: ${{ env.CONNECTNG_SOURCE }}
+        run: |
+          tar -czf ${CONNECTNG_TARBALL} out/
+
+      - name: Upload the tarball
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.CONNECTNG_ARTIFACT }}
+          path: ${{ env.CONNECTNG_TARBALL }}
+          retention-days: 1 # no need to retain this for long
+
+  run-agama-rust-tests:
+    name: Run agama rust tests
+    needs: build-suseconnect
+    runs-on: ubuntu-latest
+    container:
+      image: registry.suse.com/bci/rust:1.95
+      options: --user root --privileged
+
+    steps:
+      - name: Install dependencies for artifact upload/download
+        run: |
+          zypper --non-interactive in nodejs-default
+
+      - name: Checkout SUSE/connect-ng
+        uses: actions/checkout@v4
+        with:
+          path: connect-ng
+
+      - name: Move checked out connect-ng to /usr/src
+        run: |
+          mv connect-ng ${CONNECTNG_SOURCE}
+
+      - name: Download suseconnect-build-out tarball
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ env.CONNECTNG_ARTIFACT }}
+          path: /usr/src  # dirname of env.CONNECTNG_TARBALL
+
+      - name: Extract tarball contents to expected location
+        run: |
+          tar -C ${CONNECTNG_SOURCE} -xzf ${CONNECTNG_TARBALL}
+
+      - name: Checkout agama-project/agama
+        uses: actions/checkout@v4
+        with:
+          repository: agama-project/agama
+          path: agama
+
+      - name: Move checked out agama code to /usr/src
+        run: |
+          mv agama ${AGAMA_SOURCE}
+
+      - name: Run agama rust tests
+        working-directory: ${{ env.CONNECTNG_SOURCE }}
+        run: |
+          build/ci/run-agama-rust-tests

--- a/.github/workflows/lint-unit.yml
+++ b/.github/workflows/lint-unit.yml
@@ -16,9 +16,6 @@ name: lint + unit tests
 # See: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
 on: [pull_request]
 
-env:
-  SOURCE: /usr/src/connect-ng
-
 jobs:
   unit-tests:
     runs-on: ubuntu-latest
@@ -27,11 +24,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-
-      - name: move source to /usr/src/connect-ng
-        run: |
-          [ -d $SOURCE ] && rm -r $SOURCE
-          cp -r $GITHUB_WORKSPACE $SOURCE
 
       - name: run golang linting
         run: make check-format
@@ -42,5 +34,6 @@ jobs:
       - name: build the binary
         run: |
           # We need to make sure git trusts us here. mark the directory as safe playground
-          git config --global --add safe.directory /__w/connect-ng/connect-ng
+          # if it is a git clone; skip if using a git worktree with nektos/act
+          [ -d .git ] && git config --global --add safe.directory $GITHUB_WORKSPACE
           make vendor build

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ bin
 *.env*
 .mise.toml
 coverage/
+testdata/agama_srcs/

--- a/Makefile
+++ b/Makefile
@@ -12,11 +12,15 @@ GOFLAGS       = -v -mod=vendor
 BINFLAGS      = -buildmode=pie
 SOFLAGS       = -buildmode=c-shared
 
-CONTAINER     = registry.suse.com/bci/golang:1.24-openssl
+GOCONTAINER   = registry.suse.com/bci/golang:1.24-openssl
+RUSTCONTAINER = registry.suse.com/bci/rust:1.95
 CRM           = docker run --rm -it --privileged
 ENVFILE       = .env
 WORKDIR       = /usr/src/connect-ng
 MOUNT         = -v $(PWD):$(WORKDIR)
+AGAMA_SOURCES = $(PWD)/testdata/agama_srcs
+AGAMA_REPO    = https://github.com/agama-project/agama
+AGAMA_MOUNT   = -v $(AGAMA_SOURCES):/usr/src/agama
 
 define go-tool-covdata
 	@if [ -z "$(strip $(1))" ]; then \
@@ -35,6 +39,7 @@ endef
 .PHONY: all build build-arm build-ppc64le build-rpm build-s390 check-format
 .PHONY: ci-env clean dist feature-tests out show-version test test-yast vendor vet
 .PHONY: coverage coverage-check-enabled coverage-dirs coverage-func coverage-percent
+.PHONY: agama-sources agama-tests bci-build go-env rust-env
 
 all: clean build test
 
@@ -85,6 +90,9 @@ build: clean out internal/connect/version.txt
 	$(GO) build $(GOFLAGS) $(BINFLAGS) $(OUT) github.com/SUSE/connect-ng/cmd/suseconnect-mcp
 	$(GO) build $(GOFLAGS) $(SOFLAGS) $(OUT) github.com/SUSE/connect-ng/third_party/libsuseconnect
 
+bci-build:
+	$(CRM) $(MOUNT) -w $(WORKDIR) $(GOCONTAINER) bash -c 'make vendor build'
+
 # This "arm" means ARM64v8 little endian, the one being delivered currently on
 # OBS.
 build-arm: clean out internal/connect/version.txt
@@ -118,17 +126,30 @@ test: internal/connect/version.txt coverage-dirs
 	$(GO) test ./internal/* ./cmd/suseconnect ./pkg/* $(call cover-test-flags)
 	$(call go-tool-covdata,func)
 
-ci-env:
-	$(CRM) $(MOUNT) --env-file $(ENVFILE) -w $(WORKDIR) $(CONTAINER) bash
+ci-env go-env:
+	$(CRM) $(MOUNT) --env-file $(ENVFILE) -w $(WORKDIR) $(GOCONTAINER) bash
+
+agama-sources:
+	@if [ ! -d $(AGAMA_SOURCES) ]; then \
+		echo "Cloning $(AGAMA_REPO) under $(AGAMA_SOURCES) ..."; \
+		git clone $(AGAMA_REPO) $(AGAMA_SOURCES); \
+	fi
+
+agama-tests: agama-sources bci-build
+	$(CRM) $(MOUNT) --env-file $(ENVFILE) -w $(WORKDIR) $(RUSTCONTAINER) bash -c 'build/ci/run-agama-rust-tests'
+
+
+rust-env: agama-sources
+	$(CRM) $(MOUNT) $(AGAMA_MOUNT) --env-file $(ENVFILE) -w $(WORKDIR) $(RUSTCONTAINER) bash
 
 check-format:
 	@test -z $(shell gofmt -l internal/* cmd/* pkg/* | tee /dev/stderr)
 
 build-rpm:
-	$(CRM) $(MOUNT) -w $(WORKDIR) $(CONTAINER) bash -c 'build/ci/build-rpm'
+	$(CRM) $(MOUNT) -w $(WORKDIR) $(GOCONTAINER) bash -c 'build/ci/build-rpm'
 
 feature-tests:
-	$(CRM) $(MOUNT) --env-file $(ENVFILE) -w $(WORKDIR) $(CONTAINER) bash -c 'build/ci/build-rpm && build/ci/configure && build/ci/run-feature-tests'
+	$(CRM) $(MOUNT) --env-file $(ENVFILE) -w $(WORKDIR) $(GOCONTAINER) bash -c 'build/ci/build-rpm && build/ci/configure && build/ci/run-feature-tests'
 
 test-yast: build
 	docker build -t go-connect-test-yast -f third_party/Dockerfile.yast . && docker run -t go-connect-test-yast

--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ build: clean out internal/connect/version.txt
 	$(GO) build $(GOFLAGS) $(SOFLAGS) $(OUT) github.com/SUSE/connect-ng/third_party/libsuseconnect
 
 bci-build:
-	$(CRM) $(MOUNT) -w $(WORKDIR) $(GOCONTAINER) bash -c 'make vendor build'
+	$(CRM) $(MOUNT) -w $(WORKDIR) $(GOCONTAINER) bash -c 'git config --global --add safe.directory $(WORKDIR); make vendor build'
 
 # This "arm" means ARM64v8 little endian, the one being delivered currently on
 # OBS.
@@ -136,7 +136,7 @@ agama-sources:
 	fi
 
 agama-tests: agama-sources bci-build
-	$(CRM) $(MOUNT) --env-file $(ENVFILE) -w $(WORKDIR) $(RUSTCONTAINER) bash -c 'build/ci/run-agama-rust-tests'
+	$(CRM) $(MOUNT) $(AGAMA_MOUNT) --env-file $(ENVFILE) -w $(WORKDIR) $(RUSTCONTAINER) bash -c 'build/ci/run-agama-rust-tests'
 
 
 rust-env: agama-sources

--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ There are three test suites available to run:
   * feature tests
   * YaST2 registration tests
 
+See also the [Running GitHub Actions Locally](#running-github-actions-locally) section below.
+
 #### Unit Tests
 
 You can run all unit tests by running `make test`. If you then want to run unit
@@ -150,3 +152,91 @@ the most recent unit test run's data using the the following coverage targets:
     basis as found in the tested codebase.
   * `coverage`
     This is currently an alias for `coverage-func`.
+
+### Running GitHub Actions Locally
+
+With the [nektos/act](github.com/nektos/act) tool installed, either directly
+or as a [GitHub CLI](https://cli.github.com/) extension, it can be used to run
+the [SUSE/connect-ng GitHub Action workflows](.github/workflows/) locally.
+
+`act` can also assist in the development and testing of new and existing
+workflows.
+
+#### Install and Setup `act`
+
+Follow the installation instruction for installing `act` in the preferred way,
+either as a local command `act` or via the `gh act` extension.
+
+##### SUSE/connect-ng specific act settings in `.actrc`
+
+The standard platform images used by `act` don't always support all of the features
+that may be needed by a GitHub Actions workflow. `act` provides a mechanism to
+specify alternate platform images via the `--platform` option.
+
+Additionally, enabling the emulation of the v4 artifact upload/download support
+also requires appropriate command line options to be set.
+
+Similarly, to ensure that `act` sets up the appropriate environment settings for
+jobs that run, the `--env-file .env` option should be set.
+
+The [.actrc](.actrc) file in the repo specifies appropriate values for these
+options.
+
+#### Running the workflows locally
+
+The available workflows, and their associated trigger events can be listed by
+running the `act --list` or `gh act --list` command, as follows:
+
+```bash
+% act --list   
+INFO[0000] Using docker host 'unix:///var/run/docker.sock', and daemon socket 'unix:///var/run/docker.sock' 
+Stage  Job ID                Job name                                        Workflow name           Workflow file  Events      
+0      build-suseconnect     Build SUSE/connect-ng inputs required by Agama  agama tests             agama.yml      pull_request
+0      feature-tests         feature-tests                                   feature tests           features.yml   pull_request
+0      unit-tests            unit-tests                                      lint + unit tests       lint-unit.yml  pull_request
+0      yast                  yast                                            YaST integration tests  yast.yml       pull_request
+1      run-agama-rust-tests  Run agama rust tests                            agama tests             agama.yml      pull_request
+```
+
+The `act` command takes as argument the trigger event to simulate,
+defaulting to the `push` event if none is specified, or, if only one event
+is supported by the targeted workflows, it will default to that event.
+
+Since all of the SUSE/connect-ng workflows support just the `pull_request`
+event, running `act` without any arguments will attempt to run all of the
+workflows locally in parallel.
+
+To run a specific a specific workflow locally the full path to the workflow
+file, e.g. [.github/workflows/agama.yml](.github/workflows/agama.yml) can be
+specified with the `--workflows` (`-W`) option, e.g.
+
+```bash
+$ act -W .github/workflows/agama.yml pull_request
+INFO[0000] Using docker host 'unix:///var/run/docker.sock', and daemon socket 'unix:///var/run/docker.sock' 
+INFO[0000] Start server on http://192.168.0.100:34567   
+[agama tests/Build SUSE/connect-ng inputs required by Agama] ⭐ Run Set up job
+[agama tests/Build SUSE/connect-ng inputs required by Agama] 🚀  Start image=registry.suse.com/bci/golang:1.24-openssl
+...
+[agama tests/Run agama rust tests                          ] Cleaning up container for job Run agama rust tests
+[agama tests/Run agama rust tests                          ]   ✅  Success - Complete job
+[agama tests/Run agama rust tests                          ] 🏁  Job succeeded
+```
+
+Alternatively a specific job can be run by specifing its job id using the
+`--job` (`-j`) option.  If the specified job depends on other jobsi, via
+a `needs` attribute, they will also be run.  For example, the job id of
+the final stage of the `agama.yml` workflow is `run-agama-rust-tests`,
+and specifying it will also run the `build-suseconnect` job that it
+depends upon, as follows:
+
+```bash
+$ gh act -j run-agama-rust-tests
+INFO[0000] Using docker host 'unix:///var/run/docker.sock', and daemon socket 'unix:///var/run/docker.sock' 
+INFO[0000] Start server on http://192.168.0.100:34567   
+[agama tests/Build SUSE/connect-ng inputs required by Agama] ⭐ Run Set up job
+[agama tests/Build SUSE/connect-ng inputs required by Agama] 🚀  Start image=registry.suse.com/bci/golang:1.24-openssl
+...
+[agama tests/Run agama rust tests                          ] Cleaning up container for job Run agama rust tests
+[agama tests/Run agama rust tests                          ]   ✅  Success - Complete job
+[agama tests/Run agama rust tests                          ] 🏁  Job succeeded
+```

--- a/build/ci/run-agama-rust-tests
+++ b/build/ci/run-agama-rust-tests
@@ -1,0 +1,101 @@
+#!/bin/bash
+
+set -eu
+
+REQ_PKGS=(
+	clang7-devel
+	dbus-1-devel
+	gcc
+	gcc-c++
+	git
+	glib2-devel
+	libopenssl-devel
+	libudev-devel
+	libzypp-devel
+	make
+	pkgconfig
+	systemd-devel
+)
+
+SOURCE_DIR=/usr/src
+
+CONNECT_SOURCE=/usr/src/connect-ng
+CONNECT_OUT=${CONNECT_SOURCE}/out
+
+AGAMA_REPO=https://github.com/agama-project/agama.git
+AGAMA_SOURCE=${SOURCE_DIR}/agama
+AGAMA_RUST=${AGAMA_SOURCE}/rust
+
+LIB64_DIR=/usr/lib64
+
+# exported variables we expect to exist to run the tests
+KEYS_TO_CHECK=(REGCODE)
+
+# products to remove when cleaning up container state
+REMOVE_PRODUCTS=(sle-module-python3 sle-module-server-applications sle-module-basesystem)
+
+group() { echo "::group::$1"; }
+groupend() { echo "::groupend::"; }
+fail() { echo "::error::$1"; exit 1; }
+
+group "verify required environment variables defined"
+for name in ${KEYS_TO_CHECK[@]}; do
+if [ "${!name}" == "" ]; then
+  echo "Expect the environment variables to be set:"
+  echo "${KEYS_TO_CHECK[*]}"
+  fail "ENV variable not found: $name is not set."
+fi
+done
+groupend
+
+group "cleanup container release package state"
+for product in ${REMOVE_PRODUCTS[@]}; do
+  if zypper --no-refresh se --installed-only -t product ${product} | grep -q ${product}; then
+    zypper --no-refresh --non-interactive remove -t product ${product}
+  fi
+done
+groupend
+
+group "install required packages"
+zypper in -y ${REQ_PKGS[@]}
+groupend
+
+group "clone the agama repo if needed"
+if [[ ! -d ${AGAMA_RUST} ]]; then
+	git clone ${AGAMA_REPO} ${AGAMA_SOURCE}
+fi
+groupend
+
+group "build libsuseconnect if not already available"
+if [[ ! -d ${CONNECT_OUT} ]]; then
+	cd ${CONNECT_SOURCE}
+	make vendor build
+fi
+groupend
+
+group "install libsuseconnect.so"
+mkdir -p ${LIB64_DIR}
+cp ${CONNECT_OUT}/libsuseconnect ${LIB64_DIR}/libsuseconnect.so
+groupend
+
+group "build agama/rust activation example"
+# determine where libstdc++ is located and ensure rust linking looks there
+STDCXX_DIR=$(dirname $(gcc -print-file-name=libstdc++.so))
+
+# append the GCC C++ path to RUSTFLAGS
+export RUSTFLAGS="-L ${STDCXX_DIR}"
+
+# build the rust activation example
+cd ${AGAMA_RUST}
+cargo clean -p suseconnect-agama
+cargo build -p suseconnect-agama --example activation
+groupend
+
+group "run the rmt example"
+${AGAMA_RUST}/target/debug/examples/activation ${REGCODE}
+groupend
+
+group "deregister the system and cleanup registration state"
+${CONNECT_OUT}/suseconnect -d
+${CONNECT_OUT}/suseconnect --clean
+groupend

--- a/build/ci/run-agama-rust-tests
+++ b/build/ci/run-agama-rust-tests
@@ -56,14 +56,15 @@ for product in ${REMOVE_PRODUCTS[@]}; do
 done
 groupend
 
-group "install required packages"
-zypper in -y ${REQ_PKGS[@]}
+group "fail if the agama repo is not available"
+ls -l ${AGAMA_SOURCE}
+if [[ ! -d ${AGAMA_RUST} ]]; then
+	fail "Ensure that ${AGAMA_REPO} is cloned and available at ${AGAMA_SOURCE}"
+fi
 groupend
 
-group "clone the agama repo if needed"
-if [[ ! -d ${AGAMA_RUST} ]]; then
-	git clone ${AGAMA_REPO} ${AGAMA_SOURCE}
-fi
+group "install required packages"
+zypper in -y ${REQ_PKGS[@]}
 groupend
 
 group "build libsuseconnect if not already available"

--- a/third_party/libsuseconnect/libsuseconnect.go
+++ b/third_party/libsuseconnect/libsuseconnect.go
@@ -270,6 +270,9 @@ func loadConfig(clientParams string) *connect.Options {
 	// Read the options from the default configuration path and merge the
 	// provided clientParams into as well.
 	opts, _ := connect.ReadFromConfiguration(connect.DefaultConfigPath)
+	if opts == nil {
+		opts = connect.DefaultOptions()
+	}
 	_ = json.Unmarshal([]byte(clientParams), opts)
 
 	return opts

--- a/third_party/libsuseconnect/libsuseconnect.go
+++ b/third_party/libsuseconnect/libsuseconnect.go
@@ -270,9 +270,6 @@ func loadConfig(clientParams string) *connect.Options {
 	// Read the options from the default configuration path and merge the
 	// provided clientParams into as well.
 	opts, _ := connect.ReadFromConfiguration(connect.DefaultConfigPath)
-	if opts == nil {
-		opts = connect.DefaultOptions()
-	}
 	_ = json.Unmarshal([]byte(clientParams), opts)
 
 	return opts


### PR DESCRIPTION
Add a new agama tests workflow to the GitHub Actions workflows.

The workflow consists of two active phases:
  * build the SUSE/connect-ng repo binaries using the SLE BCI golang container image, uploading the tarballed `out` directory as an artifact
  * build the agama-project/agama repo suseconnect-agama activation test using the `out` directory contents from the retrieved artifact and the SLE BCI rust container image, and then run the activation test.

Also add an `agama-tests` target to the Makefile, along with some
additional helper targets, that:
  * clones the agama-project/agama repo under testdata/agama_srcs (ignored by git)
  * builds the SUSE/connect-ng repo using the SLE BCI golang container image
  * builds the agama-projects/agama repo's rust activation testing tool using the SLE BCI rust container image and runs the activation test.

Also fixes a potential bug in libsuseconnect where the agama activation test tool would fail if no config settings were loaded.

Co-Authored-By: esampson@suse.com

Jira: SCC-775
