### PR TITLE
Avoid double // at start of url path component

### DIFF
--- a/build/packaging/suseconnect-ng.changes
+++ b/build/packaging/suseconnect-ng.changes
@@ -9,8 +9,10 @@ Mon Apr  6 15:40:58 UTC 2026 - Fergal Mc Carthy <fmccarthy@suse.com>
   - Add collector support for gathering RKE2 & K3s kubernetes provider
     info if enabled on a system (jsc#TEL-317)
   - Add email address validation to SUSEConnect -e/--email option. (bsc#1197231)
-  - Add collector support for detecting if systen is running pacemaker
+  - Add collector support for detecting if system is running pacemaker
     (jsc#SCC-693)
+  - Avoid double slash at start of request URL path component.
+    (jsc#SCC-775)
 
 -------------------------------------------------------------------
 Wed Apr  1 16:43:26 UTC 2026 - Fergal Mc Carthy <fmccarthy@suse.com>

--- a/pkg/connection/connection.go
+++ b/pkg/connection/connection.go
@@ -74,7 +74,7 @@ func (conn ApiConnection) BuildRequest(verb string, path string, body any) (*htt
 }
 
 func (conn ApiConnection) BuildRequestRaw(verb string, path string, body io.Reader) (*http.Request, error) {
-	fullUrl := fmt.Sprintf("%s/%s", strings.TrimSuffix(conn.Options.URL, "/"), strings.TrimPrefix(path, "/"))
+	fullUrl := fmt.Sprintf("%s/%s", strings.TrimRight(conn.Options.URL, "/"), strings.TrimLeft(path, "/"))
 	request, err := http.NewRequest(verb, fullUrl, body)
 	if err != nil {
 		return nil, err

--- a/pkg/connection/connection.go
+++ b/pkg/connection/connection.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 )
 
 const (
@@ -73,7 +74,7 @@ func (conn ApiConnection) BuildRequest(verb string, path string, body any) (*htt
 }
 
 func (conn ApiConnection) BuildRequestRaw(verb string, path string, body io.Reader) (*http.Request, error) {
-	fullUrl := fmt.Sprintf("%s%s", conn.Options.URL, path)
+	fullUrl := fmt.Sprintf("%s/%s", strings.TrimSuffix(conn.Options.URL, "/"), strings.TrimPrefix(path, "/"))
 	request, err := http.NewRequest(verb, fullUrl, body)
 	if err != nil {
 		return nil, err

--- a/pkg/connection/connection_test.go
+++ b/pkg/connection/connection_test.go
@@ -39,21 +39,73 @@ func TestConnectionBuildRequest(t *testing.T) {
 	assert.Equal(request.Header.Get("Accept-Language"), "en_US")
 }
 
-func TestConnectionBuildRequestDoubleSlashHandling(t *testing.T) {
+func TestConnectionBuildRequestRawSlashHandling(t *testing.T) {
 	assert := assert.New(t)
 
-	opts := DefaultOptions("testApp", "1.0", "en_US")
-	opts.URL = opts.URL + "/" // append a trailing slash to url
-	creds := NoCredentials{}
-	conn := New(opts, creds)
+	testCases := []struct {
+		name        string
+		baseURL     string
+		path        string
+		expectedURL string
+	}{
+		{
+			name:        "No trailing baseURL slash",
+			baseURL:     "https://scc.suse.com",
+			path:        "/test/api",
+			expectedURL: "https://scc.suse.com/test/api",
+		},
+		{
+			name:        "Trailing baseURL slash",
+			baseURL:     "https://scc.suse.com/",
+			path:        "/test/api",
+			expectedURL: "https://scc.suse.com/test/api",
+		},
+		{
+			name:        "No loading path slash",
+			baseURL:     "https://scc.suse.com/",
+			path:        "test/api",
+			expectedURL: "https://scc.suse.com/test/api",
+		},
+		{
+			name:        "No trailing baseURL or loading path slash",
+			baseURL:     "https://scc.suse.com",
+			path:        "test/api",
+			expectedURL: "https://scc.suse.com/test/api",
+		},
+		{
+			name:        "Multiple trailing baseURL slashes",
+			baseURL:     "https://scc.suse.com//",
+			path:        "/test/api",
+			expectedURL: "https://scc.suse.com/test/api",
+		},
+		{
+			name:        "Multiple leading path slashes",
+			baseURL:     "https://scc.suse.com",
+			path:        "//test/api",
+			expectedURL: "https://scc.suse.com/test/api",
+		},
+		{
+			name:        "Multiple trailing baseURL and leading path slashes",
+			baseURL:     "https://scc.suse.com//",
+			path:        "//test/api",
+			expectedURL: "https://scc.suse.com/test/api",
+		},
+	}
 
-	request, err := conn.BuildRequest("GET", "/test/api", nil)
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var reader io.Reader
+			opts := DefaultOptions("testApp", "1.0", "en_US")
+			opts.URL = tc.baseURL
+			creds := NoCredentials{}
+			conn := New(opts, creds)
 
-	assert.NoError(err)
-	assert.Equal(request.URL.String(), "https://scc.suse.com/test/api")
-	assert.Contains(request.Header.Get("User-Agent"), "testApp/1.0")
-	assert.Equal(request.Header.Get("Accept"), DefaultAPIVersion)
-	assert.Equal(request.Header.Get("Accept-Language"), "en_US")
+			request, err := conn.BuildRequestRaw("GET", tc.path, reader)
+
+			assert.NoError(err, "BuildRequestRaw returned an unexpected error")
+			assert.Equal(tc.expectedURL, request.URL.String(), "request URL doesn't match expected URL")
+		})
+	}
 }
 
 func TestConnectionBuildRequestNoHTMLEscaping(t *testing.T) {

--- a/pkg/connection/connection_test.go
+++ b/pkg/connection/connection_test.go
@@ -39,6 +39,23 @@ func TestConnectionBuildRequest(t *testing.T) {
 	assert.Equal(request.Header.Get("Accept-Language"), "en_US")
 }
 
+func TestConnectionBuildRequestDoubleSlashHandling(t *testing.T) {
+	assert := assert.New(t)
+
+	opts := DefaultOptions("testApp", "1.0", "en_US")
+	opts.URL = opts.URL + "/" // append a trailing slash to url
+	creds := NoCredentials{}
+	conn := New(opts, creds)
+
+	request, err := conn.BuildRequest("GET", "/test/api", nil)
+
+	assert.NoError(err)
+	assert.Equal(request.URL.String(), "https://scc.suse.com/test/api")
+	assert.Contains(request.Header.Get("User-Agent"), "testApp/1.0")
+	assert.Equal(request.Header.Get("Accept"), DefaultAPIVersion)
+	assert.Equal(request.Header.Get("Accept-Language"), "en_US")
+}
+
 func TestConnectionBuildRequestNoHTMLEscaping(t *testing.T) {
 	assert := assert.New(t)
 


### PR DESCRIPTION
Trim off any trailing / in the base URL, and any leading / in the path, and join with a / when constructing fullUrl in BuildRequestRaw.

Add a unit test to catch this scenario.

Jira: SCC-775