### PR TITLE
util.MockExecutor helps with util.Execute mocking

### DIFF
--- a/internal/collectors/ha.go
+++ b/internal/collectors/ha.go
@@ -9,11 +9,16 @@ import (
 	"github.com/SUSE/connect-ng/internal/util"
 )
 
+const (
+	// Pacemaker constants
+	pacemakerCmdPath = "/usr/sbin/pacemakerd"
+)
+
 type HA struct{}
 
 // Get Pacemaker version
 func getPacemakerVersion() (string, error) {
-	pacemakerdOut, err := util.Execute([]string{"pacemakerd", "--version"}, nil)
+	pacemakerdOut, err := util.Execute([]string{pacemakerCmdPath, "--version"}, []int{0})
 	if err != nil {
 		return "", err
 	}

--- a/internal/collectors/ha_test.go
+++ b/internal/collectors/ha_test.go
@@ -9,12 +9,19 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+const (
+	pacemakerName          = "Pacemaker"
+	pacemakerDesc          = pacemakerName + " " + "High Availability Cluster Manager"
+	pacemakerVersion       = "2.1.10+20250718.fdf796ebc8-150700.3.3.1"
+	pacemakerVersionOutput = pacemakerName + " " + pacemakerVersion
+)
+
 func TestPacemakerActiveNoPacemaker(t *testing.T) {
 	// general setup
 	assert := assert.New(t)
 
 	// test settings
-	testEnv := NewSystemdTestEnv()
+	testEnv := NewSystemdTestEnv(t)
 
 	// create a mock systemd client
 	systemdClient := testEnv.NewClient()
@@ -33,10 +40,10 @@ func TestPacemakerActiveRunning(t *testing.T) {
 	assert := assert.New(t)
 
 	// test settings
-	testEnv := NewSystemdTestEnv()
-	testEnv.AddK8sUnit("dummy1.service", "dummy1 service", "server", "enabled")
-	testEnv.AddK8sUnit("pacemaker.service", "Pacemaker High Availability Cluster Manager", "server", "enabled")
-	testEnv.AddK8sUnit("dummy2.service", "dummy2 service", "server", "enabled")
+	testEnv := NewSystemdTestEnv(t)
+	testEnv.AddDummyUnit("dummy1.service", "enabled")
+	testEnv.AddServiceUnit("pacemaker.service", pacemakerDesc, "enabled", pacemakerCmdPath, pacemakerVersionOutput)
+	testEnv.AddDummyUnit("dummy2.service", "enabled")
 
 	// create a mock systemd client
 	systemdClient := testEnv.NewClient()
@@ -55,10 +62,11 @@ func TestPacemakerActiveRunningNoPattern(t *testing.T) {
 	assert := assert.New(t)
 
 	// test settings
-	testEnv := NewSystemdTestEnv()
-	testEnv.AddK8sUnit("dummy1.service", "dummy1 service", "server", "enabled")
-	testEnv.AddK8sUnit("pacemaker.service", "Pacemaker High Availability Cluster Manager", "server", "enabled")
-	testEnv.AddK8sUnit("dummy2.service", "dummy2 service", "server", "enabled")
+	testEnv := NewSystemdTestEnv(t)
+	testEnv.AddDummyUnit("dummy1.service", "enabled")
+	testEnv.AddServiceUnit("pacemaker.service", pacemakerDesc, "enabled", pacemakerCmdPath, pacemakerVersionOutput)
+	testEnv.AddDummyUnit("dummy2.service", "enabled")
+
 	// test using ListUnits
 	testEnv.listUnitsByPatternsError = util.SystemdMethodNotAvailable
 
@@ -79,8 +87,8 @@ func TestPacemakerActiveNotRunning(t *testing.T) {
 	assert := assert.New(t)
 
 	// test settings
-	testEnv := NewSystemdTestEnv()
-	testEnv.AddK8sUnit("pacemaker.service", "Pacemaker High Availability Cluster Manager", "server", "disabled")
+	testEnv := NewSystemdTestEnv(t)
+	testEnv.AddServiceUnit("pacemaker.service", pacemakerDesc, "disabled", pacemakerCmdPath, pacemakerVersionOutput)
 
 	// create a mock systemd client
 	systemdClient := testEnv.NewClient()
@@ -99,7 +107,7 @@ func TestPacemakerActiveErrorPattern(t *testing.T) {
 	assert := assert.New(t)
 
 	// test settings
-	testEnv := NewSystemdTestEnv()
+	testEnv := NewSystemdTestEnv(t)
 	testEnv.listUnitsByPatternsError = fmt.Errorf("test error")
 
 	// create a mock systemd client
@@ -119,7 +127,7 @@ func TestPacemakerActiveErrorUnits(t *testing.T) {
 	assert := assert.New(t)
 
 	// test settings
-	testEnv := NewSystemdTestEnv()
+	testEnv := NewSystemdTestEnv(t)
 	testEnv.listUnitsByPatternsError = util.SystemdMethodNotAvailable
 	testEnv.listUnitsError = fmt.Errorf("test error")
 
@@ -138,40 +146,68 @@ func TestPacemakerActiveErrorUnits(t *testing.T) {
 func TestGetPacemakerVersion(t *testing.T) {
 	// general setup
 	assert := assert.New(t)
-	var tests = []struct {
+
+	// define test cases
+	var testCases = []struct {
+		name   string
 		input  string
 		result string
 	}{
-		{"Pacemaker 2.1.10+20250718.fdf796ebc8-150700.3.3.1", "2.1.10+20250718.fdf796ebc8-150700.3.3.1"},
-		{"Pacemaker", ""},
-		{"Test Data", ""},
+		{
+			"Valid Version",
+			pacemakerName + " " + pacemakerVersion,
+			pacemakerVersion,
+		},
+		{
+			"Empty Version",
+			pacemakerName,
+			"",
+		},
+		{
+			"Invalid Version",
+			"Test Data",
+			"",
+		},
 	}
 
-	for _, v := range tests {
-		// setup execute for pacemakerd --version
-		mockUtilExecute(v.input, nil)
-		// run test case
-		res, err := getPacemakerVersion()
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
 
-		// check returned values
-		assert.NoError(err, "getPacemakerVersion() returned expected error")
-		assert.Equal(v.result, res, "getPacemakerVersion() returned unexpected result")
+			// create an Execute() mocker
+			mockExecutor := util.NewMockExecutor()
+			teardown := mockExecutor.Setup(t)
+			defer teardown()
+
+			// setup execute for pacemakerd --version
+			mockExecutor.OnExecuteReturn([]string{pacemakerCmdPath, "--version"}, []int{0}, []byte(tc.input), nil).Once()
+
+			// run test case
+			res, err := getPacemakerVersion()
+
+			// check returned values
+			assert.NoError(err, "getPacemakerVersion() returned expected error")
+			assert.Equal(tc.result, res, "getPacemakerVersion() returned unexpected result")
+		})
 	}
 }
 
 func TestGetPacemakerVersionExecuteError(t *testing.T) {
 	// general setup
 	assert := assert.New(t)
+	testErr := fmt.Errorf("test error")
 
 	// setup execute for pacemakerd --version
-	mockUtilExecute("", fmt.Errorf("forced error"))
+	mockExecutor := util.NewMockExecutor()
+	mockExecutor.OnExecuteReturn([]string{pacemakerCmdPath, "--version"}, []int{0}, []byte{}, testErr).Once()
+	teardown := mockExecutor.Setup(t)
+	defer teardown()
 
 	// run test case
 	res, err := getPacemakerVersion()
 
 	// check returned values
 	assert.Error(err, "isSystemHA() failed to returned unexpected error")
-	assert.ErrorContains(err, "forced error")
+	assert.ErrorIs(err, testErr, "isSystemHA() error is not the expected error")
 	assert.Equal("", res, "getPacemakerVersionNoInput() returned unexpected result")
 }
 
@@ -181,8 +217,13 @@ func TestGetPacemakerVersionScannerError(t *testing.T) {
 
 	// we want to force a scanner error, which requires
 	// execute returning a line > 64kb
-	// from execute for pacemakerd --version
-	mockUtilExecute(strings.Repeat("x", 65*1024), nil)
+	invalidOutput := strings.Repeat("x", 65*1024)
+
+	// setup execute for pacemakerd --version
+	mockExecutor := util.NewMockExecutor()
+	mockExecutor.OnExecuteReturn([]string{pacemakerCmdPath, "--version"}, []int{0}, []byte(invalidOutput), nil).Once()
+	teardown := mockExecutor.Setup(t)
+	defer teardown()
 
 	// run test case
 	res, err := getPacemakerVersion()
@@ -199,7 +240,7 @@ func TestIsPacemakerActiveNoPacemaker(t *testing.T) {
 	expectedRes := Result{}
 
 	// test settings
-	testEnv := NewSystemdTestEnv()
+	testEnv := NewSystemdTestEnv(t)
 
 	// create a mock systemd client
 	systemdClient := testEnv.NewClient()
@@ -219,22 +260,20 @@ func TestIsPacemakerActiveRunningError(t *testing.T) {
 	assert := assert.New(t)
 
 	// test settings
-	testEnv := NewSystemdTestEnv()
-	testEnv.AddK8sUnit("pacemaker.service", "Pacemaker High Availability Cluster Manager", "server", "enabled")
+	testEnv := NewSystemdTestEnv(t)
+	testEnv.AddServiceUnit("pacemaker.service", pacemakerDesc, "enabled", pacemakerCmdPath, pacemakerVersionOutput)
+	testEnv.executeError = fmt.Errorf("test error")
 
 	// create a mock systemd client
 	systemdClient := testEnv.NewClient()
 	defer testEnv.Cleanup()
-
-	// setup execute for pacemakerd --version
-	mockUtilExecute("", fmt.Errorf("forced error"))
 
 	// run test case
 	res, err := isSystemHA(systemdClient)
 
 	// check returned values
 	assert.Error(err, "isSystemHA() failed to returned unexpected error")
-	assert.ErrorContains(err, "forced error")
+	assert.ErrorIs(err, testEnv.executeError, "isSystemHA() error is not the expected error")
 	assert.Equal(expectedRes, res, "isSystemHA() returned unexpected result")
 }
 
@@ -243,20 +282,19 @@ func TestIsPacemakerActiveRunningSuccess(t *testing.T) {
 	assert := assert.New(t)
 
 	// test settings
-	testEnv := NewSystemdTestEnv()
-	testEnv.AddK8sUnit("pacemaker.service", "Pacemaker High Availability Cluster Manager", "server", "enabled")
+	testEnv := NewSystemdTestEnv(t)
+	testEnv.AddServiceUnit("pacemaker.service", pacemakerDesc, "enabled", pacemakerCmdPath, pacemakerVersionOutput)
 
 	// create a mock systemd client
 	systemdClient := testEnv.NewClient()
 	defer testEnv.Cleanup()
 
 	// setup execute for pacemakerd --version
-	pacemakerVersion := "2.1.10+20250718.fdf796ebc8-150700.3.3.1"
-	paceMakerName := "Pacemaker"
+	//paceMakerName := "Pacemaker"
 	expectedRes := Result{"ha_active": pacemakerVersion}
 
 	// setup execute for pacemakerd --version
-	mockUtilExecute(strings.Join([]string{paceMakerName, pacemakerVersion}, " "), nil)
+	//mockUtilExecute(strings.Join([]string{paceMakerName, pacemakerVersion}, " "), nil)
 
 	// run test case
 	res, err := isSystemHA(systemdClient)

--- a/internal/collectors/kubernetes_provider_test.go
+++ b/internal/collectors/kubernetes_provider_test.go
@@ -14,23 +14,18 @@ import (
 const (
 	// RKE2 consts
 	rke2BinPath       = "/opt/rke2/bin/rke2"
-	rke2ListPattern   = "rke2-*"
 	rke2Version       = "v1.33.6+rke2r1"
 	rke2VersionHash   = "2c2298232b55a94bd16b059f893c76a950811489"
 	rke2VersionGolang = "go version go1.24.9 X:boringcrypto"
 
 	// K3s consts
 	k3sBinPath       = "/usr/local/bin/k3s"
-	k3sListPattern   = "k3s*"
 	k3sVersion       = "v1.33.6+k3s1"
 	k3sVersionHash   = "b5847677"
 	k3sVersionGolang = "go version go1.24.9"
-
-	// Dummy consts
-	dummyBinPath = "/usr/local/bin/dummy"
 )
 
-func TestMatchers(t *testing.T) {
+func TestKubernetesProviderMatchers(t *testing.T) {
 	testVersion := "testVersion"
 	testVerHash := "deadbeef"
 
@@ -88,284 +83,19 @@ func TestMatchers(t *testing.T) {
 	}
 }
 
-func generatek8sProviderVersionOutput(binary, version, hash, golang string) string {
-	return fmt.Sprintf(
-		"%s version %s (%s)\n%s\n",
-		filepath.Base(binary),
-		version,
-		hash,
-		golang,
-	)
-}
-
-// helper code for testing systemd client operations
-type systemdTestEnv struct {
-	// forced errors
-	closeError                   error
-	listUnitsError               error
-	listUnitsByPatternsError     error
-	listUnitFilesError           error
-	listUnitFilesByPatternsError error
-	getExecStartError            error
-	getSystemdVersionError       error
-	getUnitFileStateError        error
-	executeError                 error
-
-	// systemd client response objects
-	units          []*util.SystemdUnit
-	unitFiles      []*util.SystemdUnitFile
-	execStarts     map[string]*util.SystemdServiceExecStart
-	systemdVersion string
-	unitFileStates map[util.SystemdUnitName]string
-	versionOutputs map[string]string
-
-	// saved util.Execute
-	savedUtilExecute func(cmd []string, validExitCodes []int) ([]byte, error)
-
-	// mock util.Execute call state tracking
-	numCalls      int
-	cmdLinesList  [][]string
-	exitCodesList [][]int
-}
-
-func NewSystemdTestEnv() *systemdTestEnv {
-	testEnv := new(systemdTestEnv)
-	testEnv.Init(util.MOCK_SYSTEMD_SLE15SP3_VERSION)
-	return testEnv
-}
-
-func (env *systemdTestEnv) Init(systemVersion string) {
-	env.units = []*util.SystemdUnit{}
-	env.unitFiles = []*util.SystemdUnitFile{}
-	env.execStarts = map[string]*util.SystemdServiceExecStart{}
-	env.unitFileStates = map[util.SystemdUnitName]string{}
-	env.versionOutputs = map[string]string{}
-	env.SetSystemdVersion(systemVersion)
-}
-
-func (env *systemdTestEnv) SetSystemdVersion(systemdVersion string) {
-	env.systemdVersion = systemdVersion
-}
-
-func (env *systemdTestEnv) AddK8sUnit(svcName, k8sType, k8sRole, svcState string) {
-	// derived values
-	unitName := util.SystemdUnitName(svcName)
-	objectPath := fmt.Sprintf("/org/freedesktop/systemd1/unit/%s", svcName)
-
-	// determine unit state settings
-	var activeState string
-	var subState string
-	switch svcState {
-	case "disabled":
-		activeState = "inactive"
-		subState = "dead"
-	case "enabled":
-		activeState = "active"
-		subState = "running"
-	default:
-		activeState = "unknown"
-		subState = "unknown"
-	}
-
-	// determine version string
-	var binPath string
-	var versionOutput string
-	switch k8sType {
-	case "rke2":
-		binPath = rke2BinPath
-		versionOutput = generatek8sProviderVersionOutput(binPath, rke2Version, rke2VersionHash, rke2VersionGolang)
-	case "k3s":
-		binPath = k3sBinPath
-		versionOutput = generatek8sProviderVersionOutput(binPath, k3sVersion, k3sVersionHash, k3sVersionGolang)
-	default:
-		binPath = dummyBinPath
-		versionOutput = "unknown"
-	}
-
-	// create a SystemdUnit
-	unit := util.NewSystemdUnit(
-		unitName,
-		fmt.Sprintf("%s %s service", k8sType, k8sRole),
-		"loaded",
-		activeState,
-		subState,
-		"",
-		objectPath,
-		0,
-		"",
-		"/",
-	)
-
-	// create a SystemdUnitFile
-	unitFile := util.NewSystemdUnitFile(
-		fmt.Sprintf("/etc/systemd/system/%s", unitName),
-		svcState,
-	)
-
-	// create a SystemdServiceExecStart
-	execStart := util.NewSystemdServiceExecStart(
-		binPath,
-		[]string{
-			binPath,
-			k8sRole,
-		},
-		false,
-		0,
-		0,
-		0,
-		0,
-		0,
-		0,
-		0,
-	)
-
-	// add unit entry
-	env.units = append(env.units, unit)
-
-	// add unitFile entry
-	env.unitFiles = append(env.unitFiles, unitFile)
-
-	// add execStart entry
-	env.execStarts[objectPath] = execStart
-
-	// add state entry
-	env.unitFileStates[unitName] = svcState
-
-	// add version output
-	env.versionOutputs[binPath] = versionOutput
-}
-
-func (env *systemdTestEnv) NewClient() util.SystemdClient {
-	mockClient := util.NewMockSystemdClient(env.systemdVersion)
-
-	mockClient.CloseFunc = func() error {
-		if env.closeError != nil {
-			return env.closeError
-		}
-
-		return nil
-	}
-
-	mockClient.ListUnitsFunc = func() ([]*util.SystemdUnit, error) {
-		if env.listUnitsError != nil {
-			return nil, env.listUnitsError
-		}
-
-		return env.units, nil
-	}
-
-	mockClient.ListUnitsByPatternsFunc = func(patterns ...string) ([]*util.SystemdUnit, error) {
-		if env.listUnitsByPatternsError != nil {
-			return nil, env.listUnitsByPatternsError
-		}
-
-		return env.units, nil
-	}
-
-	mockClient.ListUnitFilesFunc = func() ([]*util.SystemdUnitFile, error) {
-		if env.listUnitFilesError != nil {
-			return nil, env.listUnitFilesError
-		}
-
-		return env.unitFiles, nil
-	}
-
-	mockClient.ListUnitFilesByPatternsFunc = func(patterns ...string) ([]*util.SystemdUnitFile, error) {
-		if env.listUnitFilesByPatternsError != nil {
-			return nil, env.listUnitFilesByPatternsError
-		}
-
-		return env.unitFiles, nil
-	}
-
-	mockClient.GetExecStartFunc = func(unitObjectPath string) ([]*util.SystemdServiceExecStart, error) {
-		execStarts := []*util.SystemdServiceExecStart{}
-
-		if env.getExecStartError != nil {
-			return nil, env.getExecStartError
-		}
-
-		execStart, ok := env.execStarts[unitObjectPath]
-		if ok {
-			execStarts = append(execStarts, execStart)
-		}
-
-		return execStarts, nil
-	}
-
-	mockClient.GetSystemdVersionFunc = func() (string, error) {
-		if env.getSystemdVersionError != nil {
-			return "", env.getSystemdVersionError
-		}
-
-		return env.systemdVersion, nil
-	}
-
-	mockClient.GetUnitFileStateFunc = func(unitName util.SystemdUnitName) (string, error) {
-		state := "unknown"
-
-		if env.getUnitFileStateError != nil {
-			return "", env.getUnitFileStateError
-		}
-		if unitState, ok := env.unitFileStates[unitName]; ok {
-			state = unitState
-		}
-
-		return state, nil
-	}
-
-	env.savedUtilExecute = util.Execute
-	util.Execute = func(cmd []string, validExitCodes []int) ([]byte, error) {
-		env.numCalls++
-		env.cmdLinesList = append(env.cmdLinesList, cmd)
-		env.exitCodesList = append(env.exitCodesList, validExitCodes)
-
-		var output []byte
-		var err error
-
-		// return immediately an error has been specified
-		if env.executeError != nil {
-			return nil, env.executeError
-		}
-
-		switch cmd[0] {
-		case rke2BinPath:
-			fallthrough
-		case k3sBinPath:
-			switch cmd[1] {
-			case "--version":
-				output = []byte(env.versionOutputs[cmd[0]])
-			default:
-				output = []byte("some version output")
-			}
-		default:
-			output = []byte("some command output")
-		}
-
-		return output, err
-	}
-
-	return mockClient
-}
-
-func (env *systemdTestEnv) Cleanup() {
-	util.Execute = env.savedUtilExecute
-}
-
 func TestKubernetesServiceInitNormalOperation(t *testing.T) {
 	// general setup
 	assert := assert.New(t)
-	require := require.New(t)
 
 	// test settings
-	testEnv := NewSystemdTestEnv()
-	k8sSvc := "rke2-server.service"
-	k8sType := RKE2_PROVIDER
-	k8sRole := "server"
-	k8sVersion := rke2Version
-	k8sVersionHash := rke2VersionHash
-	versionCmdLine := []string{rke2BinPath, "--version"}
-	testEnv.AddK8sUnit(k8sSvc, k8sType, k8sRole, "enabled")
+	testEnv := NewSystemdTestEnv(t)
+	rke2Svc := "rke2-server.service"
+	rke2Type := RKE2_PROVIDER
+	rke2Role := "server"
+	testEnv.AddK8sUnit(rke2Svc, rke2Type, rke2Role, "enabled")
+
+	// set expected command --version call counts
+	testEnv.SetCommandVersionCallCount(rke2BinPath, 1)
 
 	// create a mock systemd client
 	systemdClient := testEnv.NewClient()
@@ -380,23 +110,12 @@ func TestKubernetesServiceInitNormalOperation(t *testing.T) {
 	assert.NoError(err, "KubernetesService.Init() returned unexpected error")
 
 	// check KubernetesService.Init() extracted binary and role correctly
-	assert.Equal(k8sSvc, ks.Name, "KubernetesService.Init() extracted binary incorrectly")
-	assert.Equal(k8sType, ks.Type, "KubernetesService.Init() extracted type incorrectly")
-	assert.Equal(k8sRole, ks.Role, "KubernetesService.Init() extracted role incorrectly")
+	assert.Equal(rke2Svc, ks.Name, "KubernetesService.Init() extracted binary incorrectly")
+	assert.Equal(rke2Type, ks.Type, "KubernetesService.Init() extracted type incorrectly")
+	assert.Equal(rke2Role, ks.Role, "KubernetesService.Init() extracted role incorrectly")
 	assert.Equal(rke2BinPath, ks.Binary, "KubernetesService.Init() extracted binary incorrectly")
-	assert.Equal(k8sVersion, ks.Version, "KubernetesService.setVersion() extracted version incorrectly")
-	assert.Equal(k8sVersionHash, ks.VersionHash, "KubernetesService.setVersion() extracted version hash incorrectly")
-
-	// check util.Execute() called expected number of times and skip remaining tests if not
-	require.Equal(1, testEnv.numCalls, "util.Execute() called unexpected number of times")
-
-	// check util.Execute() was called as expected for KubernetesService.setVersion()
-	assert.Equal(versionCmdLine, testEnv.cmdLinesList[0], "UnitFile.Property() triggered util.Execute() with unexperect cmd argument")
-
-	// check all util.Execute() permitted exit codes are as expected
-	for i, exitCodes := range testEnv.exitCodesList {
-		assert.Equal([]int{0}, exitCodes, "util.Execute() returned unexpected exitCodes for call %d", i)
-	}
+	assert.Equal(rke2Version, ks.Version, "KubernetesService.setVersion() extracted version incorrectly")
+	assert.Equal(rke2VersionHash, ks.VersionHash, "KubernetesService.setVersion() extracted version hash incorrectly")
 }
 
 func TestKubernetesServiceInitFailedExecStartPropertyOperation(t *testing.T) {
@@ -404,7 +123,7 @@ func TestKubernetesServiceInitFailedExecStartPropertyOperation(t *testing.T) {
 	assert := assert.New(t)
 
 	// test settings
-	testEnv := NewSystemdTestEnv()
+	testEnv := NewSystemdTestEnv(t)
 	testEnv.AddK8sUnit("rke2-server.service", RKE2_PROVIDER, "server", "enabled")
 	testEnv.getExecStartError = fmt.Errorf("test error")
 
@@ -424,15 +143,11 @@ func TestKubernetesServiceInitFailedExecStartPropertyOperation(t *testing.T) {
 func TestKubernetesServiceInitFailedSetVersionOperation(t *testing.T) {
 	// general setup
 	assert := assert.New(t)
-	require := require.New(t)
 
 	// test settings
-	testEnv := NewSystemdTestEnv()
+	testEnv := NewSystemdTestEnv(t)
 	testEnv.AddK8sUnit("rke2-server.service", RKE2_PROVIDER, "server", "enabled")
 	testEnv.executeError = fmt.Errorf("test error")
-
-	// expected values
-	versionCmdLine := []string{rke2BinPath, "--version"}
 
 	// create a mock systemd client
 	systemdClient := testEnv.NewClient()
@@ -445,17 +160,6 @@ func TestKubernetesServiceInitFailedSetVersionOperation(t *testing.T) {
 	// check returned values
 	assert.Nil(ks, "KubernetesService.Init() returned non-nil object")
 	assert.ErrorIs(err, testEnv.executeError, "KubernetesService.Init() returned unexpected error")
-
-	// check util.Execute() called expected number of times and skip remaining tests if not
-	require.Equal(1, testEnv.numCalls, "util.Execute() called unexpected number of times")
-
-	// check util.Execute() was called as expected for KubernetesService.setVersion()
-	assert.Equal(versionCmdLine, testEnv.cmdLinesList[0], "KubernetesService.setVersion() triggered util.Execute() with unexperect cmd argument")
-
-	// check all util.Execute() permitted exit codes are as expected
-	for i, exitCodes := range testEnv.exitCodesList {
-		assert.Equal([]int{0}, exitCodes, "util.Execute() returned unexpected exitCodes for call %d", i)
-	}
 }
 
 func TestGetKubernetesServicesNormalOperation(t *testing.T) {
@@ -464,7 +168,7 @@ func TestGetKubernetesServicesNormalOperation(t *testing.T) {
 	require := require.New(t)
 
 	// test settings
-	testEnv := NewSystemdTestEnv()
+	testEnv := NewSystemdTestEnv(t)
 	testEnv.AddK8sUnit("rke2-server.service", RKE2_PROVIDER, "server", "enabled")
 	testEnv.AddK8sUnit("rke2-agent.service", RKE2_PROVIDER, "agent", "enabled")
 	testEnv.AddK8sUnit("rke2-dummy.service", RKE2_PROVIDER, "dummy", "enabled")
@@ -473,6 +177,10 @@ func TestGetKubernetesServicesNormalOperation(t *testing.T) {
 	testEnv.AddK8sUnit("k3s-custom.service", K3S_PROVIDER, "server", "enabled")
 	testEnv.AddK8sUnit("k3s-dummy.service", K3S_PROVIDER, "dummy", "enabled")
 	testEnv.AddK8sUnit("k3snodash.service", K3S_PROVIDER, "nodash", "enabled")
+
+	// set expected command --version call counts
+	testEnv.SetCommandVersionCallCount(rke2BinPath, 2)
+	testEnv.SetCommandVersionCallCount(k3sBinPath, 3)
 
 	// expected values
 	rke2VersionCmdLine := []string{rke2BinPath, "--version"}
@@ -489,9 +197,6 @@ func TestGetKubernetesServicesNormalOperation(t *testing.T) {
 	assert.NotNil(ksList, "getKubernetesServices() returned nil")
 	assert.NoError(err, "getKubernetesServices() returned unexpected error")
 	require.Len(ksList, 5, "getKubernetesServices() returned unexpected number of services")
-
-	// expect util.Execute() to have been called 5 times to retrieve version info
-	require.Equal(5, testEnv.numCalls, "util.Execute() called unexpected number of times")
 
 	// check discovered services
 	for i, tks := range []struct {
@@ -550,12 +255,6 @@ func TestGetKubernetesServicesNormalOperation(t *testing.T) {
 		assert.Equal(tks.binPath, ksList[i].Binary, "getKubernetesServices() returned unexpected binary path for service [%d]%s", i, ksList[i].Name)
 		assert.Equal(tks.version, ksList[i].Version, "getKubernetesServices() returned unexpected version for service [%d]%s", i, ksList[i].Name)
 		assert.Equal(tks.hash, ksList[i].VersionHash, "getKubernetesServices() returned unexpected version hash for service [%d]%s", i, ksList[i].Name)
-		assert.Equal(tks.versionCmdLine, testEnv.cmdLinesList[i], "util.Execute() called with unexpected version command line for service [%d]%s", i, ksList[i].Name)
-	}
-
-	// check all util.Execute() exit codes are as expected
-	for i, exitCodes := range testEnv.exitCodesList {
-		assert.Equal([]int{0}, exitCodes, "util.Execute() returned unexpected exitCodes for call %d", i)
 	}
 }
 
@@ -565,11 +264,15 @@ func TestGetKubernetesServicesFallbackOperation(t *testing.T) {
 	require := require.New(t)
 
 	// test settings
-	testEnv := NewSystemdTestEnv()
+	testEnv := NewSystemdTestEnv(t)
 	testEnv.AddK8sUnit("rke2-server.service", RKE2_PROVIDER, "server", "enabled")
 	testEnv.AddK8sUnit("k3s.service", K3S_PROVIDER, "server", "enabled")
 	// Add a non-matching service to ensure filtering works via unit.Name.Match() in fallback
 	testEnv.AddK8sUnit("unrelated.service", "dummy", "dummy", "enabled")
+
+	// set expected command --version call counts
+	testEnv.SetCommandVersionCallCount(rke2BinPath, 1)
+	testEnv.SetCommandVersionCallCount(k3sBinPath, 1)
 
 	// force fallback by simulating ListUnitsByPatterns not available
 	testEnv.listUnitsByPatternsError = util.SystemdMethodNotAvailable
@@ -596,7 +299,7 @@ func TestGetKubernetesServicesGetUnitFileStateError(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 
-	testEnv := NewSystemdTestEnv()
+	testEnv := NewSystemdTestEnv(t)
 	testEnv.AddK8sUnit("rke2-server.service", RKE2_PROVIDER, "server", "enabled")
 
 	// force state fetch to fail
@@ -615,15 +318,14 @@ func TestGetKubernetesServicesGetUnitFileStateError(t *testing.T) {
 func TestGetKubernetesProviderNormalOperation(t *testing.T) {
 	// general setup
 	assert := assert.New(t)
-	require := require.New(t)
 
 	// test settings
-	testEnv := NewSystemdTestEnv()
+	testEnv := NewSystemdTestEnv(t)
 	testEnv.AddK8sUnit("rke2-server.service", RKE2_PROVIDER, "server", "enabled")
 	testEnv.AddK8sUnit("rke2-agent.service", RKE2_PROVIDER, "agent", "disabled")
 
-	// expeected values
-	versionCmdLine := []string{rke2BinPath, "--version"}
+	// set expected command --version call counts
+	testEnv.SetCommandVersionCallCount(rke2BinPath, 1)
 
 	// expected kubernetes provider info
 	expectedKpInfo := map[string]any{
@@ -644,26 +346,14 @@ func TestGetKubernetesProviderNormalOperation(t *testing.T) {
 	assert.NoError(err, "getKubernetesProvider() returned unexpected error")
 	assert.Len(kpInfo, 3, "getKubernetesProvider() returned map with unexpected number of fields")
 	assert.Equal(expectedKpInfo, kpInfo, "getKubernetesProvider() returned unexpected provider info")
-
-	// check util.Execute() called expected number of times and skip remaining tests if not
-	require.Equal(1, testEnv.numCalls, "util.Execute() called unexpected number of times")
-
-	// check util.Execute() was called as expected for KubernetesService.setVersion()
-	assert.Equal(versionCmdLine, testEnv.cmdLinesList[0], "KubernetesService.setVersion() triggered util.Execute() with unexperect cmd argument")
-
-	// check all util.Execute() permitted exit codes are as expected
-	for i, exitCodes := range testEnv.exitCodesList {
-		assert.Equal([]int{0}, exitCodes, "util.Execute() returned unexpected exitCodes for call %d", i)
-	}
 }
 
 func TestGetKubernetesProviderNoServicesOperation(t *testing.T) {
 	// general setup
 	assert := assert.New(t)
-	require := require.New(t)
 
 	// test settings
-	testEnv := NewSystemdTestEnv()
+	testEnv := NewSystemdTestEnv(t)
 	testEnv.AddK8sUnit("rke2-server.service", RKE2_PROVIDER, "server", "disabled")
 	testEnv.AddK8sUnit("rke2-agent.service", RKE2_PROVIDER, "agent", "disabled")
 
@@ -677,24 +367,21 @@ func TestGetKubernetesProviderNoServicesOperation(t *testing.T) {
 	// check returned values
 	assert.Nil(kpInfo, "getKubernetesProvider() should have returned nil for provider info")
 	assert.NoError(err, "getKubernetesProvider() returned unexpected error")
-
-	// check util.Execute() called expected number of times and skip remaining tests if not
-	require.Equal(0, testEnv.numCalls, "util.Execute() called unexpected number of times")
 }
 
 func TestGetKubernetesProviderTooManyServicesOperation(t *testing.T) {
 	// general setup
 	assert := assert.New(t)
-	require := require.New(t)
+	//require := require.New(t)
 
 	// test settings
-	testEnv := NewSystemdTestEnv()
+	testEnv := NewSystemdTestEnv(t)
 	testEnv.AddK8sUnit("rke2-server.service", RKE2_PROVIDER, "server", "enabled")
 	testEnv.AddK8sUnit("k3s.service", K3S_PROVIDER, "server", "enabled")
 
-	// expeected values
-	rke2VersionCmdLine := []string{rke2BinPath, "--version"}
-	k3sVersionCmdLine := []string{k3sBinPath, "--version"}
+	// set expected command --version call counts
+	testEnv.SetCommandVersionCallCount(rke2BinPath, 1)
+	testEnv.SetCommandVersionCallCount(k3sBinPath, 1)
 
 	// create a mock systemd client
 	systemdClient := testEnv.NewClient()
@@ -706,27 +393,14 @@ func TestGetKubernetesProviderTooManyServicesOperation(t *testing.T) {
 	// check returned values
 	assert.Nil(kpInfo, "getKubernetesProvider() should have returned nil for provider info")
 	assert.ErrorIs(err, KubernetesMultipleProvidersEnabled, "getKubernetesProvider() returned unexpected error")
-
-	// check util.Execute() called expected number of times and skip remaining tests if not
-	require.Equal(2, testEnv.numCalls, "util.Execute() called unexpected number of times")
-
-	// check util.Execute() was called as expected for KubernetesService.setVersion()
-	assert.Equal(rke2VersionCmdLine, testEnv.cmdLinesList[0], "KubernetesService.setVersion() triggered util.Execute() with unexperect cmd argument")
-	assert.Equal(k3sVersionCmdLine, testEnv.cmdLinesList[1], "KubernetesService.setVersion() triggered util.Execute() with unexperect cmd argument")
-
-	// check all util.Execute() permitted exit codes are as expected
-	for i, exitCodes := range testEnv.exitCodesList {
-		assert.Equal([]int{0}, exitCodes, "util.Execute() returned unexpected exitCodes for call %d", i)
-	}
 }
 
 func TestGetKubernetesProviderFailedOperation(t *testing.T) {
 	// general setup
 	assert := assert.New(t)
-	require := require.New(t)
 
 	// test settings
-	testEnv := NewSystemdTestEnv()
+	testEnv := NewSystemdTestEnv(t)
 	testEnv.listUnitsByPatternsError = fmt.Errorf("test error")
 
 	// create a mock systemd client
@@ -739,23 +413,19 @@ func TestGetKubernetesProviderFailedOperation(t *testing.T) {
 	// check returned values
 	assert.Nil(kpInfo, "getKubernetesProvider() should have returned nil for provider info")
 	assert.ErrorIs(err, testEnv.listUnitsByPatternsError, "getKubernetesProvider() returned unexpected error")
-
-	// check util.Execute() called expected number of times and skip remaining tests if not
-	require.Equal(0, testEnv.numCalls, "util.Execute() called unexpected number of times")
 }
 
 func TestGenerateKubernetesProviderNormalOperation(t *testing.T) {
 	// general setup
 	assert := assert.New(t)
-	require := require.New(t)
 
 	// test settings
-	testEnv := NewSystemdTestEnv()
+	testEnv := NewSystemdTestEnv(t)
 	testEnv.AddK8sUnit("rke2-server.service", RKE2_PROVIDER, "server", "enabled")
 	testEnv.AddK8sUnit("rke2-agent.service", RKE2_PROVIDER, "agent", "disabled")
 
-	// expected values
-	versionCmdLine := []string{rke2BinPath, "--version"}
+	// set expected command --version call counts
+	testEnv.SetCommandVersionCallCount(rke2BinPath, 1)
 
 	// expected result info
 	expectedKpInfo := map[string]any{
@@ -776,26 +446,14 @@ func TestGenerateKubernetesProviderNormalOperation(t *testing.T) {
 	assert.NotNil(res, "generateKubernetesProvider() returned nil")
 	assert.NoError(err, "generateKubernetesProvider() returned unexpected error")
 	assert.Equal(expectedResult, res, "generateKubernetesProvider() returned unexpected result")
-
-	// check util.Execute() called expected number of times and skip remaining tests if not
-	require.Equal(1, testEnv.numCalls, "util.Execute() called unexpected number of times")
-
-	// check util.Execute() was called as expected for KubernetesService.setVersion()
-	assert.Equal(versionCmdLine, testEnv.cmdLinesList[0], "KubernetesService.setVersion() triggered util.Execute() with unexperect cmd argument")
-
-	// check all util.Execute() permitted exit codes are as expected
-	for i, exitCodes := range testEnv.exitCodesList {
-		assert.Equal([]int{0}, exitCodes, "util.Execute() returned unexpected exitCodes for call %d", i)
-	}
 }
 
 func TestGenerateKubernetesProviderLegacyNormalOperation(t *testing.T) {
 	// general setup
 	assert := assert.New(t)
-	require := require.New(t)
 
 	// test settings
-	testEnv := NewSystemdTestEnv()
+	testEnv := NewSystemdTestEnv(t)
 	testEnv.SetSystemdVersion(util.MOCK_SYSTEMD_SLE12SP5_VERSION)
 	testEnv.AddK8sUnit("rke2-server.service", RKE2_PROVIDER, "server", "enabled")
 	testEnv.AddK8sUnit("rke2-agent.service", RKE2_PROVIDER, "agent", "disabled")
@@ -805,8 +463,8 @@ func TestGenerateKubernetesProviderLegacyNormalOperation(t *testing.T) {
 	testEnv.AddK8sUnit("k3s-dummy.service", K3S_PROVIDER, "dummy", "disabled")
 	testEnv.AddK8sUnit("k3snodash.service", K3S_PROVIDER, "dummy", "disabled")
 
-	// expected values
-	versionCmdLine := []string{rke2BinPath, "--version"}
+	// set expected command --version call counts
+	testEnv.SetCommandVersionCallCount(rke2BinPath, 1)
 
 	// expected result info
 	expectedKpInfo := map[string]any{
@@ -827,26 +485,14 @@ func TestGenerateKubernetesProviderLegacyNormalOperation(t *testing.T) {
 	assert.NotNil(res, "generateKubernetesProvider() returned nil")
 	assert.NoError(err, "generateKubernetesProvider() returned unexpected error")
 	assert.Equal(expectedResult, res, "generateKubernetesProvider() returned unexpected result")
-
-	// check util.Execute() called expected number of times and skip remaining tests if not
-	require.Equal(1, testEnv.numCalls, "util.Execute() called unexpected number of times")
-
-	// check util.Execute() was called as expected for KubernetesService.setVersion()
-	assert.Equal(versionCmdLine, testEnv.cmdLinesList[0], "KubernetesService.setVersion() triggered util.Execute() with unexperect cmd argument")
-
-	// check all util.Execute() permitted exit codes are as expected
-	for i, exitCodes := range testEnv.exitCodesList {
-		assert.Equal([]int{0}, exitCodes, "util.Execute() returned unexpected exitCodes for call %d", i)
-	}
 }
 
 func TestGenerateKubernetesProviderNoServicesOperation(t *testing.T) {
 	// general setup
 	assert := assert.New(t)
-	require := require.New(t)
 
 	// test settings
-	testEnv := NewSystemdTestEnv()
+	testEnv := NewSystemdTestEnv(t)
 	testEnv.AddK8sUnit("rke2-server.service", RKE2_PROVIDER, "server", "disabled")
 	testEnv.AddK8sUnit("rke2-agent.service", RKE2_PROVIDER, "agent", "disabled")
 
@@ -860,20 +506,20 @@ func TestGenerateKubernetesProviderNoServicesOperation(t *testing.T) {
 	// check returned values
 	assert.Equal(Result{}, res, "generateKubernetesProvider() should have returned an empty result")
 	assert.NoError(err, "generateKubernetesProvider() returned unexpected error")
-
-	// check util.Execute() called expected number of times and skip remaining tests if not
-	require.Equal(0, testEnv.numCalls, "util.Execute() called unexpected number of times")
 }
 
 func TestGenerateKubernetesProviderTooManyServicesOperation(t *testing.T) {
 	// general setup
 	assert := assert.New(t)
-	require := require.New(t)
 
 	// test settings
-	testEnv := NewSystemdTestEnv()
+	testEnv := NewSystemdTestEnv(t)
 	testEnv.AddK8sUnit("rke2-server.service", RKE2_PROVIDER, "server", "enabled")
 	testEnv.AddK8sUnit("k3s.service", K3S_PROVIDER, "server", "enabled")
+
+	// set expected command --version call counts
+	testEnv.SetCommandVersionCallCount(rke2BinPath, 1)
+	testEnv.SetCommandVersionCallCount(k3sBinPath, 1)
 
 	// create a mock systemd client
 	systemdClient := testEnv.NewClient()
@@ -885,17 +531,13 @@ func TestGenerateKubernetesProviderTooManyServicesOperation(t *testing.T) {
 	// check returned values
 	assert.Equal(Result{}, res, "generateKubernetesProvider() should have returned an empty result")
 	assert.ErrorIs(err, KubernetesMultipleProvidersEnabled, "generateKubernetesProvider() returned unexpected error")
-
-	// check util.Execute() called expected number of times and skip remaining tests if not
-	require.Equal(2, testEnv.numCalls, "util.Execute() called unexpected number of times")
 }
 func TestGenerateKubernetesProviderFailedOperation(t *testing.T) {
 	// general setup
 	assert := assert.New(t)
-	require := require.New(t)
 
 	// test settings
-	testEnv := NewSystemdTestEnv()
+	testEnv := NewSystemdTestEnv(t)
 	testEnv.listUnitsByPatternsError = fmt.Errorf("test error")
 
 	// create a mock systemd client
@@ -908,7 +550,95 @@ func TestGenerateKubernetesProviderFailedOperation(t *testing.T) {
 	// check returned values
 	assert.Equal(Result{}, res, "generateKubernetesProvider() should have returned an empty result")
 	assert.ErrorIs(err, testEnv.listUnitsByPatternsError, "generateKubernetesProvider() returned unexpected error")
+}
 
-	// check util.Execute() called expected number of times and skip remaining tests if not
-	require.Equal(0, testEnv.numCalls, "util.Execute() called unexpected number of times")
+//
+// kubernetes provider specific systemdTestEnv extensions
+//
+
+func generatek8sProviderVersionOutput(binary, version, hash, golang string) string {
+	return fmt.Sprintf(
+		"%s version %s (%s)\n%s\n",
+		filepath.Base(binary),
+		version,
+		hash,
+		golang,
+	)
+}
+
+func determinek8sVersionInfo(k8sType string) (binPath, versionOutput string) {
+	// determine version string
+	switch k8sType {
+	case "rke2":
+		binPath = rke2BinPath
+		versionOutput = generatek8sProviderVersionOutput(binPath, rke2Version, rke2VersionHash, rke2VersionGolang)
+	case "k3s":
+		binPath = k3sBinPath
+		versionOutput = generatek8sProviderVersionOutput(binPath, k3sVersion, k3sVersionHash, k3sVersionGolang)
+	default:
+		binPath = dummyBinPath
+		versionOutput = "unknown"
+	}
+
+	return
+}
+
+func (env *systemdTestEnv) AddK8sUnit(svcName, k8sType, k8sRole, svcState string) {
+	// derived values
+	unitName := util.SystemdUnitName(svcName)
+	objectPath := fmt.Sprintf("/org/freedesktop/systemd1/unit/%s", svcName)
+	activeState, subState := determineUnitStates(svcState)
+	binPath, versionOutput := determinek8sVersionInfo(k8sType)
+
+	// create a SystemdUnit
+	unit := util.NewSystemdUnit(
+		unitName,
+		fmt.Sprintf("%s %s service", k8sType, k8sRole),
+		"loaded",
+		activeState,
+		subState,
+		"",
+		objectPath,
+		0,
+		"",
+		"/",
+	)
+
+	// create a SystemdUnitFile
+	unitFile := util.NewSystemdUnitFile(
+		fmt.Sprintf("/etc/systemd/system/%s", unitName),
+		svcState,
+	)
+
+	// create a SystemdServiceExecStart
+	execStart := util.NewSystemdServiceExecStart(
+		binPath,
+		[]string{
+			binPath,
+			k8sRole,
+		},
+		false,
+		0,
+		0,
+		0,
+		0,
+		0,
+		0,
+		0,
+	)
+
+	// add unit entry
+	env.units = append(env.units, unit)
+
+	// add unitFile entry
+	env.unitFiles = append(env.unitFiles, unitFile)
+
+	// add execStart entry
+	env.execStarts[objectPath] = execStart
+
+	// add state entry
+	env.unitFileStates[unitName] = svcState
+
+	// add version output
+	env.AddCommandVersion(binPath, versionOutput)
 }

--- a/internal/collectors/test_helpers.go
+++ b/internal/collectors/test_helpers.go
@@ -1,0 +1,301 @@
+package collectors
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/SUSE/connect-ng/internal/util"
+	"github.com/stretchr/testify/mock"
+)
+
+const (
+	// Dummy consts
+	dummyBinPath = "/usr/local/bin/dummy"
+)
+
+type CommandVersionCall struct {
+	output string
+	count  int
+	call   *mock.Call
+}
+
+func NewCommandVersionCall(output string) *CommandVersionCall {
+	return &CommandVersionCall{
+		output: output,
+		count:  0,
+		call:   nil,
+	}
+}
+
+func (cvc *CommandVersionCall) UpdateExpectedCallCount() {
+	// do nothing of call object not instantiated
+	if cvc.call == nil {
+		return
+	}
+
+	// update expected call count handling to reflect specified count
+	if cvc.count <= 0 {
+		// default to letting tests pass if no call count specified
+		cvc.call.Maybe()
+	} else if cvc.count > cvc.call.Repeatability {
+		// update expected call count to reflect target count; the .Times()
+		// value is additive so calculate necessary increment
+		cvc.call.Times(cvc.count - cvc.call.Repeatability)
+	}
+}
+
+// helper code for testing systemd client operations
+type systemdTestEnv struct {
+	// forced errors
+	closeError                   error
+	listUnitsError               error
+	listUnitsByPatternsError     error
+	listUnitFilesError           error
+	listUnitFilesByPatternsError error
+	getExecStartError            error
+	getSystemdVersionError       error
+	getUnitFileStateError        error
+	executeError                 error
+
+	// systemd client response objects
+	units          []*util.SystemdUnit
+	unitFiles      []*util.SystemdUnitFile
+	execStarts     map[string]*util.SystemdServiceExecStart
+	systemdVersion string
+	unitFileStates map[util.SystemdUnitName]string
+
+	// command --version call management
+	commandVersionCalls map[string]*CommandVersionCall
+
+	// mockExecutor integration
+	mockExecutor         util.MockExecutor
+	mockExecutorTeardown func()
+}
+
+func NewSystemdTestEnv(t *testing.T) *systemdTestEnv {
+	testEnv := new(systemdTestEnv)
+	testEnv.Init(util.MOCK_SYSTEMD_SLE15SP3_VERSION)
+	testEnv.Setup(t)
+	return testEnv
+}
+
+func (env *systemdTestEnv) Init(systemVersion string) {
+	env.units = []*util.SystemdUnit{}
+	env.unitFiles = []*util.SystemdUnitFile{}
+	env.execStarts = map[string]*util.SystemdServiceExecStart{}
+	env.unitFileStates = map[util.SystemdUnitName]string{}
+	env.commandVersionCalls = map[string]*CommandVersionCall{}
+	env.SetSystemdVersion(systemVersion)
+	env.mockExecutor = *util.NewMockExecutor()
+}
+
+func (env *systemdTestEnv) Setup(t *testing.T) {
+	env.mockExecutorTeardown = env.mockExecutor.Setup(t)
+}
+
+func (env *systemdTestEnv) Cleanup() {
+	//util.Execute = env.savedUtilExecute
+	if env.mockExecutorTeardown != nil {
+		env.mockExecutorTeardown()
+	}
+}
+
+func (env *systemdTestEnv) SetSystemdVersion(systemdVersion string) {
+	env.systemdVersion = systemdVersion
+}
+
+func (env *systemdTestEnv) AddCommandVersion(cmdPath string, version string) {
+	env.commandVersionCalls[cmdPath] = NewCommandVersionCall(version)
+}
+
+func (env *systemdTestEnv) SetCommandVersionCallCount(cmdPath string, count int) {
+	// set exepected call count
+	cmdVer := env.commandVersionCalls[cmdPath]
+	cmdVer.count = count
+
+	// trigger update of associated call object's expected call count
+	cmdVer.UpdateExpectedCallCount()
+}
+
+func (env *systemdTestEnv) RegisterCommandVersion(cmdPath string) {
+	// lookup previously created command version management object
+	cmdVer := env.commandVersionCalls[cmdPath]
+
+	// register return values for the expected command line with the
+	// expectation that it might be called
+	cmdVer.call = env.mockExecutor.OnExecuteReturn(
+		[]string{cmdPath, "--version"},
+		[]int{0},
+		[]byte(cmdVer.output),
+		env.executeError,
+	)
+
+	// trigger update of associated call object's expected call count
+	cmdVer.UpdateExpectedCallCount()
+}
+
+func determineUnitStates(svcState string) (activeState, subState string) {
+	// determine unit state settings
+	switch svcState {
+	case "disabled":
+		activeState = "inactive"
+		subState = "dead"
+	case "enabled":
+		activeState = "active"
+		subState = "running"
+	default:
+		activeState = "unknown"
+		subState = "unknown"
+	}
+
+	return
+}
+
+func (env *systemdTestEnv) AddServiceUnit(svcName, svcDesc, svcState, cmdPath, versionOutput string) {
+	// derived values
+	unitName := util.SystemdUnitName(svcName)
+	objectPath := fmt.Sprintf("/org/freedesktop/systemd1/unit/%s", svcName)
+	activeState, subState := determineUnitStates(svcState)
+
+	// create a SystemdUnit
+	unit := util.NewSystemdUnit(
+		unitName,
+		svcDesc,
+		"loaded",
+		activeState,
+		subState,
+		"",
+		objectPath,
+		0,
+		"",
+		"/",
+	)
+
+	// create a SystemdUnitFile
+	unitFile := util.NewSystemdUnitFile(
+		fmt.Sprintf("/etc/systemd/system/%s", unitName),
+		svcState,
+	)
+
+	// create a SystemdServiceExecStart
+	execStart := util.NewSystemdServiceExecStart(
+		cmdPath,
+		[]string{
+			cmdPath,
+		},
+		false,
+		0,
+		0,
+		0,
+		0,
+		0,
+		0,
+		0,
+	)
+
+	// add unit entry
+	env.units = append(env.units, unit)
+
+	// add unitFile entry
+	env.unitFiles = append(env.unitFiles, unitFile)
+
+	// add execStart entry
+	env.execStarts[objectPath] = execStart
+
+	// add state entry
+	env.unitFileStates[unitName] = svcState
+
+	// add version output
+	env.AddCommandVersion(cmdPath, versionOutput)
+}
+
+func (env *systemdTestEnv) AddDummyUnit(svcName, svcState string) {
+	env.AddServiceUnit(svcName, "dummy service", svcState, dummyBinPath, "dummy version")
+}
+
+func (env *systemdTestEnv) NewClient() util.SystemdClient {
+	mockClient := util.NewMockSystemdClient(env.systemdVersion)
+
+	mockClient.CloseFunc = func() error {
+		if env.closeError != nil {
+			return env.closeError
+		}
+
+		return nil
+	}
+
+	mockClient.ListUnitsFunc = func() ([]*util.SystemdUnit, error) {
+		if env.listUnitsError != nil {
+			return nil, env.listUnitsError
+		}
+
+		return env.units, nil
+	}
+
+	mockClient.ListUnitsByPatternsFunc = func(patterns ...string) ([]*util.SystemdUnit, error) {
+		if env.listUnitsByPatternsError != nil {
+			return nil, env.listUnitsByPatternsError
+		}
+
+		return env.units, nil
+	}
+
+	mockClient.ListUnitFilesFunc = func() ([]*util.SystemdUnitFile, error) {
+		if env.listUnitFilesError != nil {
+			return nil, env.listUnitFilesError
+		}
+
+		return env.unitFiles, nil
+	}
+
+	mockClient.ListUnitFilesByPatternsFunc = func(patterns ...string) ([]*util.SystemdUnitFile, error) {
+		if env.listUnitFilesByPatternsError != nil {
+			return nil, env.listUnitFilesByPatternsError
+		}
+
+		return env.unitFiles, nil
+	}
+
+	mockClient.GetExecStartFunc = func(unitObjectPath string) ([]*util.SystemdServiceExecStart, error) {
+		execStarts := []*util.SystemdServiceExecStart{}
+
+		if env.getExecStartError != nil {
+			return nil, env.getExecStartError
+		}
+
+		execStart, ok := env.execStarts[unitObjectPath]
+		if ok {
+			execStarts = append(execStarts, execStart)
+		}
+
+		return execStarts, nil
+	}
+
+	mockClient.GetSystemdVersionFunc = func() (string, error) {
+		if env.getSystemdVersionError != nil {
+			return "", env.getSystemdVersionError
+		}
+
+		return env.systemdVersion, nil
+	}
+
+	mockClient.GetUnitFileStateFunc = func(unitName util.SystemdUnitName) (string, error) {
+		state := "unknown"
+
+		if env.getUnitFileStateError != nil {
+			return "", env.getUnitFileStateError
+		}
+		if unitState, ok := env.unitFileStates[unitName]; ok {
+			state = unitState
+		}
+
+		return state, nil
+	}
+
+	// setup handling for command --version calls
+	for cmdPath := range env.commandVersionCalls {
+		env.RegisterCommandVersion(cmdPath)
+	}
+
+	return mockClient
+}

--- a/internal/util/system.go
+++ b/internal/util/system.go
@@ -40,8 +40,11 @@ func SetSystemEcho(v bool) bool {
 	return prev
 }
 
+// ExecuteFunc type
+type ExecuteFunc func(cmd []string, validExitCodes []int) ([]byte, error)
+
 // Assign function for running external commands to a variable so it can be mocked by tests.
-var Execute = func(cmd []string, validExitCodes []int) ([]byte, error) {
+var Execute ExecuteFunc = func(cmd []string, validExitCodes []int) ([]byte, error) {
 	Debug.Print("Executing: ", cmd)
 	var stderr, stdout bytes.Buffer
 	comm := exec.Command(cmd[0], cmd[1:]...)

--- a/internal/util/test_helpers.go
+++ b/internal/util/test_helpers.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/mock"
 )
 
 func ReadTestFile(name string, t *testing.T) []byte {
@@ -28,4 +30,91 @@ func TestContentMatches(t *testing.T, expected string, got string) {
 			"---"}
 		t.Errorf(strings.Join(message, "\n"), expected, got)
 	}
+}
+
+//
+// Helpers for mocking Execute()
+//
+
+type MockExecutor struct {
+	mock.Mock
+}
+
+func NewMockExecutor() *MockExecutor {
+	return &MockExecutor{}
+}
+
+// Setup replaces the standard Execute with a MockExecutor.Execute and
+// returns a teardown function that should be called as a deferred call
+// to restore the original Execute.
+//
+// Example:
+//
+//	mockExecutor := util.NewMockExecutor()
+//	someCall := mockExecutor.OnExecuteReturn(
+//	    []string{"some", "command", "line"],
+//	    []int{0},
+//	    []byte("output from running command"),
+//	    nil, // no error
+//	)
+//	... // define additional mock calls
+//	teardown := mockExecutor.Setup()
+//	defer teardown()
+//
+//	res, err := CodeThatCallsExecuteWithAboveCommandline()
+func (m *MockExecutor) Setup(t *testing.T) func() {
+	// retrieve the original Execute
+	origExecute := Execute
+
+	// define a teardown function
+	teardown := func() {
+		// restore the original Execute handler
+		Execute = origExecute
+
+		// check that expectations were met, such as calls being made
+		// or only
+		m.Mock.AssertExpectations(t)
+	}
+
+	// replace the original Execute with the Mock handler
+	Execute = m.Execute
+
+	return teardown
+}
+
+// Execute attempts to retrieve an associated pre-registered mocking
+// for the provided command line, and can be used to mock the Execute()
+// routine.
+func (m *MockExecutor) Execute(cmd []string, validExitCodes []int) (output []byte, err error) {
+	// attempt to retrieve any return values previously registered for this
+	// call signature; will panic if matching call signature not registered
+	args := m.Called(cmd, validExitCodes)
+
+	// extract output return value if provided
+	if args.Get(0) != nil {
+		output = args.Get(0).([]byte)
+	}
+
+	// extract error return value if provided
+	if args.Get(1) != nil {
+		err = args.Get(1).(error)
+	}
+
+	return
+}
+
+// compile time validation that MockExecutor.Execute matches ExecuteFunc
+var _ ExecuteFunc = (*MockExecutor)(nil).Execute
+
+// add an On("Execute", ...) mocking directive, returning a mock.Call that
+// can be manipulated with standard mock.Call methods, such as Once(), Maybe(),
+// etc. See https://pkg.go.dev/github.com/stretchr/testify/mock#Call for more
+// details on mock.Call.
+func (m *MockExecutor) OnExecute(cmd []string, validExitCodes []int) *mock.Call {
+	return m.On("Execute", cmd, validExitCodes)
+}
+
+// simplified wrapper to quickly setup a simple call with return values
+func (m *MockExecutor) OnExecuteReturn(cmd []string, validExitCodes []int, output []byte, err error) *mock.Call {
+	return m.OnExecute(cmd, validExitCodes).Return(output, err)
 }

--- a/internal/util/test_helpers_test.go
+++ b/internal/util/test_helpers_test.go
@@ -1,0 +1,99 @@
+package util
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Test the MockExecute helper functionality
+
+func TestMockExecutor(t *testing.T) {
+	// remember the original Execute
+	originalExecute := Execute
+
+	// define a test config that will be used by test handler
+	type testCfg struct {
+		name      string
+		cmd       []string
+		exitCodes []int
+		output    []byte
+		err       error
+	}
+
+	// define a test error
+	testError := assert.AnError
+
+	// setup a table of subtests to run
+	for _, tc := range []testCfg{
+		{
+			name:      "verify successful command handling",
+			cmd:       []string{"success"},
+			exitCodes: []int{0},
+			output:    []byte("successful command execution"),
+			err:       nil,
+		},
+		{
+			name:      "verify unpermitted failed command handling",
+			cmd:       []string{"failure"},
+			exitCodes: []int{0},
+			output:    []byte(nil),
+			err:       testError,
+		},
+		{
+			name:      "verify permitted failing command handling",
+			cmd:       []string{"failure"},
+			exitCodes: []int{0, 1},
+			output:    []byte("permitted failing command execution"),
+			err:       nil,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			// general setup
+			assert := assert.New(t)
+			require := require.New(t)
+
+			// create the MockExec and verify that cfg was setup correctly
+			mockExec := NewMockExecutor()
+
+			// setup the mock Execute() which returns a teardown function for use with defer
+			teardown := mockExec.Setup(t)
+
+			// verify that Execute was replaced by a mock Execute
+			require.NotNil(Execute, "MockExecutor.Setup() did not mock Execute correctly")
+			require.NotEqual(
+				reflect.ValueOf(originalExecute).Pointer(),
+				reflect.ValueOf(Execute).Pointer(),
+				"MockExecutor.Setup() did not replace the original Execute function properly",
+			)
+
+			require.Equal(
+				reflect.ValueOf(mockExec.Execute).Pointer(),
+				reflect.ValueOf(Execute).Pointer(),
+				"MockExecutor.Setup() did setup the mock Execute function properly",
+			)
+
+			// setup mocking for the requested call to happen once only
+			mockExec.OnExecute(tc.cmd, tc.exitCodes).Return(tc.output, tc.err).Once()
+
+			// perform the mocked call
+			output, err := Execute(tc.cmd, tc.exitCodes)
+
+			// verify that expected mocked output and error were returned
+			assert.Equal(tc.output, output, "Mocked Execute() returned unexpected output")
+			assert.Equal(tc.err, err, "Mocked Execute() returned unexpected error")
+
+			// verify that after teardown the original Execute is restored
+			teardown()
+			require.NotNil(Execute, "MockExecutor.Setup()'s teardown function did not retore Execute correctly")
+			require.Equal(
+				reflect.ValueOf(originalExecute).Pointer(),
+				reflect.ValueOf(Execute).Pointer(),
+				"MockExecutor.Setup()'s teardown function did not restore the original Execute function",
+			)
+
+		})
+	}
+}


### PR DESCRIPTION
Leveraging the stretchr/testify/mock to provide a more capabale means for mocking util.Execute() calls.

The MockExecutor.Setup() routine is used to replace util.Execute() with the MockExecutor's Execute() handler, and returns a teardown function that should be called with defer to restore the original Execute().

The MockExecutor.Execute() routine is mock replacement for Execute() that checks for a pre-registered command line mocking and if found, handles it appropriately.

The MockExecutor.OnExecute() routine allows registration of a command line to be mocked, returing a mock.Call that can be further used to manage the mocking of that call; for further details see the https://pkg.go.dev/github.com/stretchr/testify/mock#Call docs.

The MockExecutor.OnExecuteReturn() return allows for registration of a command line and it's asssociated return values in a single command to simplify setting up mocking for a single command.

Update ha.go and kubernetes_provider.go testing in internal/collectors to leverage the new MockExecutor for mocking util.Execute() calls.

Also moved the systemdTestEnv support code that is shared by both of these collector implmentations into a separate test_helpers.go file, and added support for defining regular and dummy systemd services, and updated ha.go to use these new service definition helpers.

Tweaked ha.go and ha_test.go to leverage constants for fixed string values and used full path for pacemakerd binary when calling it.