### PR TITLE
Use product identifier for finding product packages

### DIFF
--- a/build/packaging/suseconnect-ng.changes
+++ b/build/packaging/suseconnect-ng.changes
@@ -13,6 +13,8 @@ Mon Apr  6 15:40:58 UTC 2026 - Fergal Mc Carthy <fmccarthy@suse.com>
     (jsc#SCC-693)
   - Avoid double slash at start of request URL path component.
     (jsc#SCC-775)
+  - Use product identifier when finding product packages during
+    migrations. (jsc#SCC=758 bsc#1265410)
 
 -------------------------------------------------------------------
 Wed Apr  1 16:43:26 UTC 2026 - Fergal Mc Carthy <fmccarthy@suse.com>

--- a/cmd/zypper-migration/migration.go
+++ b/cmd/zypper-migration/migration.go
@@ -515,7 +515,7 @@ func compareEditions(left, right string) int {
 }
 
 func cleanupProductRepos(p registration.Product, force, autoImportRepoKeys bool) error {
-	productPackages, err := zypper.FindProductPackages(p.Name, autoImportRepoKeys)
+	productPackages, err := zypper.FindProductPackages(p.Identifier, autoImportRepoKeys)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
With the previous refactoring of the code base after the v1.13.0 release, the appropriate value to identify the product is now found in the identifier field, rather than the name field.

With this change in place I now see equivalency between the zypper and migration actions that are generated by both the v1.13.0 and latest code when performing migrations.

Jira: SCC-758
Bugzilla: bsc#1265410