### PR TITLE
Allow pkg/ clients to disable duplicate token detection completely

### DIFF
--- a/build/packaging/suseconnect-ng.changes
+++ b/build/packaging/suseconnect-ng.changes
@@ -17,6 +17,7 @@ Mon Apr  6 15:40:58 UTC 2026 - Fergal Mc Carthy <fmccarthy@suse.com>
     migrations. (jsc#SCC=758 bsc#1265410)
   - Add opt in/out support for collectors (jsc#TEL-312)
   - Update config parser for suseconnect to be YAML based (jsc#SCC-730)
+  - library: Allow clients to disable the token handling mechanism (jsc#SCC-801)
 
 -------------------------------------------------------------------
 Wed Apr  1 16:43:26 UTC 2026 - Fergal Mc Carthy <fmccarthy@suse.com>

--- a/cmd/public-api-demo/main.go
+++ b/cmd/public-api-demo/main.go
@@ -42,6 +42,10 @@ func runDemo(identifier, version, arch, infoPath, regcode string) error {
 		isProxy = true
 	}
 
+	if disableTokens := os.Getenv("DISABLE_TOKEN_HANDLING"); disableTokens != "" {
+		opts.DisableTokenHandling = true
+	}
+
 	if credentialTracing := os.Getenv("TRACE_CREDENTIAL_UPDATES"); credentialTracing != "" {
 		creds.ShowTraces = true
 	}

--- a/pkg/connection/connection.go
+++ b/pkg/connection/connection.go
@@ -86,11 +86,19 @@ func (conn ApiConnection) BuildRequestRaw(verb string, path string, body io.Read
 }
 
 func (conn ApiConnection) Do(request *http.Request) ([]byte, error) {
-	token, tokenErr := conn.Credentials.Token()
-	if tokenErr != nil {
-		return []byte{}, tokenErr
+
+	// Allow clients to disable token handling completely if they
+	// do not need duplicate detection. This is the case for the
+	// scc-operator (https://github.com/rancher/scc-operator/)
+	rotateToken := conn.Options.DisableTokenHandling == false
+
+	if rotateToken == true {
+		token, tokenErr := conn.Credentials.Token()
+		if tokenErr != nil {
+			return []byte{}, tokenErr
+		}
+		request.Header.Set("System-Token", token)
 	}
-	request.Header.Set("System-Token", token)
 
 	response, doErr := conn.setupHTTPClient().Do(request)
 	if doErr != nil {
@@ -99,9 +107,11 @@ func (conn ApiConnection) Do(request *http.Request) ([]byte, error) {
 	defer response.Body.Close()
 
 	// Update the credentials from the new system token.
-	token = response.Header.Get("System-Token")
-	if err := conn.Credentials.UpdateToken(token); err != nil {
-		return nil, err
+	if rotateToken == true {
+		token := response.Header.Get("System-Token")
+		if err := conn.Credentials.UpdateToken(token); err != nil {
+			return nil, err
+		}
 	}
 
 	// Check if there was an error from the given API response.

--- a/pkg/connection/connection_test.go
+++ b/pkg/connection/connection_test.go
@@ -228,6 +228,34 @@ func TestConnectionUpdateToken(t *testing.T) {
 	creds.AssertExpectations(t)
 }
 
+func TestConnectionTokenDisabled(t *testing.T) {
+	assert := assert.New(t)
+
+	handler := func(response http.ResponseWriter) {
+		response.WriteHeader(http.StatusOK)
+	}
+
+	server := NewTestServerSetupWith(t, "GET", "/test/api", handler)
+	defer server.Close()
+
+	opts := DefaultOptions("testApp", "1.0", "en_US")
+	opts.URL = server.URL
+	opts.DisableTokenHandling = true
+
+	creds := &MockCredentials{}
+	conn := New(opts, creds)
+
+	request, buildErr := conn.BuildRequest("GET", "/test/api", "")
+	assert.NoError(buildErr)
+
+	_, doErr := conn.Do(request)
+	assert.NoError(doErr)
+
+	creds.AssertNotCalled(t, "Token")
+	creds.AssertNotCalled(t, "UpdateToken")
+	creds.AssertExpectations(t)
+}
+
 func TestCustomCertificateSuccess(t *testing.T) {
 	assert := assert.New(t)
 

--- a/pkg/connection/options.go
+++ b/pkg/connection/options.go
@@ -49,16 +49,20 @@ type Options struct {
 
 	// Timeout on how long to wait for an API response
 	Timeout time.Duration
+
+	// Disable Token handling
+	DisableTokenHandling bool
 }
 
 // Returns the Options suitable for targeting the SCC reference server.
 func DefaultOptions(appName, version, language string) Options {
 	return Options{
-		URL:              DefaultBaseURL,
-		Secure:           true,
-		AppName:          appName,
-		Version:          version,
-		PreferedLanguage: language,
-		Timeout:          DefaultTimeout,
+		URL:                  DefaultBaseURL,
+		Secure:               true,
+		AppName:              appName,
+		Version:              version,
+		PreferedLanguage:     language,
+		Timeout:              DefaultTimeout,
+		DisableTokenHandling: false,
 	}
 }


### PR DESCRIPTION
task: https://jira.suse.com/browse/SCC-801

Allows to use the API without sending the `Token-Header`. This disables the token handling (aka duplicate detection)

**How to test this merge request:**

You need:
  - Checked out branch
  - Running golang environment
  - A regcode to test against

```
$ make build
#expect: It builds

# tokens enabled
$ REGCODE="<SLES REGCODE>" ./out/public-api-demo SLES 15.4 x86_64
# Run until "System fully activated"
# You see the link to the system in SCC. Open it and go to the admin version of the page (little shield icon next to the hostname)
# expect: The token is set as expected
# Finalize the demo

# tokens disabled
$ DISABLE_TOKEN_HANDLING=1 REGCODE="<SLES REGCODE>" ./out/public-api-demo SLES 15.4 x86_64
# Run until "System fully activated"
# You see the link to the system in SCC. Open it and go to the admin version of the page
# expect: The token is not set
# Finalize the demo
```

**Hint:** If you have trouble finding the admin version of the system details page: Just add `/admin/`  to the system details URL: `https://scc.suse.com/systems/25370112 -> https://scc.suse.com/admin/systems/25370112`

**Pro tip:** If you really want to now it you can enable credential change tracing with: `TRACE_CREDENTIAL_UPDATES=1`

**As always, if you think I missed something or you have suggestions, do not hesitate to reach out to me**:rocket:

thank you :smile_cat: 
