### PR TITLE
add 1.22.1 to changes log and move post 1.22.0 change in

### DIFF
--- a/build/packaging/suseconnect-ng.changes
+++ b/build/packaging/suseconnect-ng.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Jun 10 18:43:58 UTC 2026 - Earl Sampson <esampson@suse.com>
+
+- Update version to 1.22.1:
+  - library: Allow clients to disable the token handling mechanism (jsc#SCC-801)
+
+-------------------------------------------------------------------
 Mon Apr  6 15:40:58 UTC 2026 - Fergal Mc Carthy <fmccarthy@suse.com>
 
 - Update version to 1.22:
@@ -17,7 +23,6 @@ Mon Apr  6 15:40:58 UTC 2026 - Fergal Mc Carthy <fmccarthy@suse.com>
     migrations. (jsc#SCC=758 bsc#1265410)
   - Add opt in/out support for collectors (jsc#TEL-312)
   - Update config parser for suseconnect to be YAML based (jsc#SCC-730)
-  - library: Allow clients to disable the token handling mechanism (jsc#SCC-801)
 
 -------------------------------------------------------------------
 Wed Apr  1 16:43:26 UTC 2026 - Fergal Mc Carthy <fmccarthy@suse.com>


### PR DESCRIPTION
Since 1.22.0 was accepted we need to move version to 1.22.1
which requires adding entry to change log.