### PR TITLE
Include updates certs when setting up HTTP clients

### DIFF
--- a/build/packaging/suseconnect-ng.changes
+++ b/build/packaging/suseconnect-ng.changes
@@ -3,6 +3,8 @@ Wed Jun 10 18:43:58 UTC 2026 - Earl Sampson <esampson@suse.com>
 
 - Update version to 1.22.1:
   - library: Allow clients to disable the token handling mechanism (jsc#SCC-801)
+  - Ensure updated system certs are included when creating HTTP client
+    connections (bsc#1268017, jsc#SCC-804)
 
 -------------------------------------------------------------------
 Mon Apr  6 15:40:58 UTC 2026 - Fergal Mc Carthy <fmccarthy@suse.com>

--- a/pkg/connection/cert_pool.go
+++ b/pkg/connection/cert_pool.go
@@ -1,7 +1,7 @@
 // TODO: remove when https://github.com/golang/go/issues/41888 is fixed
 // code copied from standard library crypto/x509/root.go to enable system certs reloading
 
-package connect
+package connection
 
 import (
 	"crypto/x509"
@@ -9,11 +9,14 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/SUSE/connect-ng/internal/util"
 )
 
 func systemRootsPool() *x509.CertPool {
 	systemRoots, systemRootsErr := _loadSystemRoots()
 	if systemRootsErr != nil {
+		util.Debug.Printf("Failed to load system roots: %s", systemRootsErr.Error())
 		return nil
 	}
 	return systemRoots

--- a/pkg/connection/connection.go
+++ b/pkg/connection/connection.go
@@ -9,6 +9,8 @@ import (
 	"io"
 	"net/http"
 	"strings"
+
+	"github.com/SUSE/connect-ng/internal/util"
 )
 
 const (
@@ -159,12 +161,30 @@ func (conn ApiConnection) setupHTTPClient() *http.Client {
 		transport.Proxy = conn.Options.Proxy
 	}
 
-	if conn.Options.Certificate != nil {
-		pool := x509.NewCertPool()
-		pool.AddCert(conn.Options.Certificate)
+	// retrieve current system root certs pool; this ensures any new certs
+	// added since x509.SystemCertPool() was first initialised are included
+	// TODO: rework if https://github.com/golang/go/issues/41888 is resolved
+	pool := systemRootsPool()
 
-		transport.TLSClientConfig.RootCAs = pool
+	// if we fail to retrieve the latest systemRootsPoll fall back on using
+	// a clone of the x509.SystemCertPool(), otherwise use a new empty pool.
+	if pool == nil {
+		systemPool, err := x509.SystemCertPool()
+		if err == nil {
+			pool = systemPool.Clone()
+		} else {
+			util.Debug.Printf("Failed to retrieve x509.SystemCertPool(): %s", err.Error())
+			pool = x509.NewCertPool()
+		}
 	}
+
+	// if a cert has been provided add it to the pool
+	if conn.Options.Certificate != nil {
+		pool.AddCert(conn.Options.Certificate)
+	}
+
+	// use the pool for handling TLS certs
+	transport.TLSClientConfig.RootCAs = pool
 
 	return &http.Client{Transport: transport, Timeout: conn.Options.Timeout}
 }


### PR DESCRIPTION
Restore the earlier TLS client cert handling by ensuring that we load the latest available system certs when setting up any HTTP client connections. This is required because the Golang crypto/x509 module samples the system cert pool once, and reuses that pool state even if the system certs are updated. This is a known Golan issue tracked in https://github.com/golang/go/issues/41888 that the earlier version of suseconnect-ng worked around, but the workaround was not migrated to the new HTTP client connection setup as part of the refactoring efforts.

Moves internal/connect/cert_pool.go to pkg/connection and leverages it in the ApiConnection.setupHTTPClient() receiver to ensure that we are using a pool that includes any recently updated certs.

Added some debug messages to cert_pool.go for ignored errors.

Issues: bsc#1268017, jsc#SCC-804