### PR TITLE
Add coverage reporting for feature tests

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,17 @@
+# Notes About CI Workflow Security Restrictions
+
+About security when running the tests and NOT exposing
+the secrets to externals. Currently Github Actions does
+NOT expose the secrets if the branch is coming from a forked
+repository.
+
+See: https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/
+See: https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions
+
+An alternate would be to set, pull_request_target but this takes the CI code
+from master removing the ability to change the code in a PR easily.
+
+Aditionally, since 2021 pull requests from new contributors will not
+trigger workflows automatically but will wait for approval from somebody
+with write access.
+See: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks

--- a/.github/workflows/agama.yml
+++ b/.github/workflows/agama.yml
@@ -1,20 +1,6 @@
 ---
 name: agama tests
 
-# About security when running the tests and NOT exposing
-# the secrets to externals. Currently Github Actions does
-# NOT expose the secrets if the branch is coming from a forked
-# repository.
-# See: https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/
-# See: https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions
-#
-# An alternate would be to set, pull_request_target but this takes the CI code
-# from master removing the ability to change the code in a PR easily.
-#
-# Aditionally, since 2021 pull requests from new contributors will not
-# trigger workflows automatically but will wait for approval from somebody
-# with write access.
-# See: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
 on: [pull_request]
 
 env:

--- a/.github/workflows/build-rpm.yml
+++ b/.github/workflows/build-rpm.yml
@@ -1,5 +1,5 @@
 ---
-name: feature tests
+name: build and install rpm
 
 # About security when running the tests and NOT exposing
 # the secrets to externals. Currently Github Actions does
@@ -20,13 +20,10 @@ on: [pull_request]
 env:
   SOURCE: /usr/src/connect-ng
   ARTIFACT_SOURCE: artifacts
-  COVERAGE_BIN: true
   REGCODE: ${{ secrets.REGCODE }}
-  HA_REGCODE: ${{ secrets.HA_REGCODE }}
-  EXPIRED_REGCODE: ${{ secrets.EXPIRED_REGCODE }}
 
 jobs:
-  feature-tests:
+  build-rpm:
     runs-on: ubuntu-latest
     container:
       image: registry.suse.com/bci/golang:1.24-openssl
@@ -40,22 +37,14 @@ jobs:
           [ -d $SOURCE ] && rm -r $SOURCE
           cp -r $GITHUB_WORKSPACE $SOURCE
 
-      - name: build suseconnect binaries
-        run: |
-          set -e
-          cd $SOURCE
-          make vendor
-          make build
+      - name: build RPM package
+        run: bash build/ci/build-rpm
 
-      - name: run feature tests
-        run: |
-          set -e
-          cd $SOURCE
-          make coverage-dirs
-          bash build/ci/run-feature-tests
+      # - name: gather RPM build artifacts
+      #   uses: actions/upload-artifact@v4
+      #   with:
+      #     name: connect-rpms
+      #     path: ${{ env.SOURCE }}/${{ env.ARTIFACT_SOURCE }}/*.rpm
 
-      - name: show feature tests coverage reports
-        run: |
-          set -e
-          cd $SOURCE
-          make feature-tests-coverage
+      - name: configure Connect to run feature tests
+        run: bash build/ci/configure

--- a/.github/workflows/build-rpm.yml
+++ b/.github/workflows/build-rpm.yml
@@ -1,20 +1,6 @@
 ---
 name: build and install rpm
 
-# About security when running the tests and NOT exposing
-# the secrets to externals. Currently Github Actions does
-# NOT expose the secrets if the branch is coming from a forked
-# repository.
-# See: https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/
-# See: https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions
-#
-# An alternate would be to set, pull_request_target but this takes the CI code
-# from master removing the ability to change the code in a PR easily.
-#
-# Aditionally, since 2021 pull requests from new contributors will not
-# trigger workflows automatically but will wait for approval from somebody
-# with write access.
-# See: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
 on: [pull_request]
 
 env:

--- a/.github/workflows/features.yml
+++ b/.github/workflows/features.yml
@@ -1,20 +1,6 @@
 ---
 name: feature tests
 
-# About security when running the tests and NOT exposing
-# the secrets to externals. Currently Github Actions does
-# NOT expose the secrets if the branch is coming from a forked
-# repository.
-# See: https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/
-# See: https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions
-#
-# An alternate would be to set, pull_request_target but this takes the CI code
-# from master removing the ability to change the code in a PR easily.
-#
-# Aditionally, since 2021 pull requests from new contributors will not
-# trigger workflows automatically but will wait for approval from somebody
-# with write access.
-# See: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
 on: [pull_request]
 
 env:

--- a/.github/workflows/lint-unit.yml
+++ b/.github/workflows/lint-unit.yml
@@ -1,19 +1,5 @@
 name: lint + unit tests
 
-# About security when running the tests and NOT exposing
-# the secrets to externals. Currently Github Actions does
-# NOT expose the secrets if the branch is coming from a forked
-# repository.
-# See: https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/
-# See: https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions
-#
-# An alternate would be to set, pull_request_target but this takes the CI code
-# from master removing the ability to change the code in a PR easily.
-#
-# Aditionally, since 2021 pull requests from new contributors will not
-# trigger workflows automatically but will wait for approval from somebody
-# with write access.
-# See: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
 on: [pull_request]
 
 jobs:

--- a/.github/workflows/lint-unit.yml
+++ b/.github/workflows/lint-unit.yml
@@ -33,7 +33,12 @@ jobs:
 
       - name: build the binary
         run: |
+          set -e
           # We need to make sure git trusts us here. mark the directory as safe playground
           # if it is a git clone; skip if using a git worktree with nektos/act
           [ -d .git ] && git config --global --add safe.directory $GITHUB_WORKSPACE
           make vendor build
+
+      - name: show unit tests coverage reports
+        run: |
+          make unit-test-coverage

--- a/.github/workflows/yast.yml
+++ b/.github/workflows/yast.yml
@@ -7,8 +7,5 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup Go
-        run: go mod vendor
-
       - name: Run test-yast
         run: make test-yast

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,13 @@
 NAME          = suseconnect-ng
 VERSION       = $(shell bash -c "cat build/packaging/suseconnect-ng.spec | sed -n 's/^Version:\s*\(.*\)/\1/p'")
-DIST          = $(NAME)-$(VERSION)/
+DIST          = $(NAME)-$(VERSION)
 PWD           = $(shell pwd)
 GO            = go
 OUT           = -o out/
 # coverage testing enabled by default
 COVERAGE     ?= true
-COVERAGE_DIR  = $(PWD)/coverage
-COVERAGE_UNIT = $(COVERAGE_DIR)/unit
+COVERAGE_BIN ?= false
+COVERAGE_LIB ?= false
 GOFLAGS       = -v -mod=vendor
 BINFLAGS      = -buildmode=pie
 SOFLAGS       = -buildmode=c-shared
@@ -22,45 +22,79 @@ AGAMA_SOURCES = $(PWD)/testdata/agama_srcs
 AGAMA_REPO    = https://github.com/agama-project/agama
 AGAMA_MOUNT   = -v $(AGAMA_SOURCES):/usr/src/agama
 
-define go-tool-covdata
-	@if [ -z "$(strip $(1))" ]; then \
-		echo "ERROR: no go tool covdata action specified."; \
-		exit 1; \
-	fi
-	@if $(if $(filter true,$(strip $(COVERAGE))),true,false); then \
-		$(GO) tool covdata $(1) -i=$(COVERAGE_UNIT); \
-	fi
+COVERAGE_DIR     = $(PWD)/coverage
+COVERAGE_MERGED  = $(COVERAGE_DIR)/merged
+COVERAGE_UNIT    = $(COVERAGE_DIR)/unit
+COVERAGE_FEATURE = $(COVERAGE_DIR)/feature
+# these directories aren't being used yet
+COVERAGE_YAST    = $(COVERAGE_DIR)/yast
+COVERAGE_AGAMA   = $(COVERAGE_DIR)/agama
+
+define go-tool-covdata-merge
+@if $(if $(filter true,$(strip $(COVERAGE))),true,false); then \
+	mkdir -p $(COVERAGE_MERGED); \
+	$(GO) tool covdata merge -i=$(COVERAGE_UNIT),$(COVERAGE_FEATURE),$(COVERAGE_YAST),$(COVERAGE_AGAMA) -o $(COVERAGE_MERGED); \
+fi
+endef
+
+define go-tool-covdata-report
+@if [ -z "$(strip $(1))" ]; then \
+	echo "ERROR: no go tool covdata action specified."; \
+	exit 1; \
+fi
+@if [ -z "$(strip $(2))" ]; then \
+	echo "ERROR: no test type target directory specified."; \
+	exit 1; \
+fi
+@if $(if $(filter true,$(strip $(COVERAGE))),true,false); then \
+	mkdir -p $(2); \
+	$(GO) tool covdata $(1) -i=$(strip $(2)); \
+fi
 endef
 
 define cover-test-flags
-	$(if $(filter true,$(strip $(COVERAGE))),-cover -args -test.gocoverdir=$(COVERAGE_UNIT))
+$(if $(filter true,$(strip $(COVERAGE))),-cover -args -test.gocoverdir=$(COVERAGE_UNIT))
+endef
+
+define cover-bin-flags
+$(if $(filter true,$(strip $(COVERAGE))),$(if $(filter true,$(strip $(COVERAGE_BIN))),-cover))
+endef
+
+define cover-lib-flags
+$(if $(filter true,$(strip $(COVERAGE))),$(if $(filter true,$(strip $(COVERAGE_LIB))),-cover))
 endef
 
 .PHONY: all build build-arm build-ppc64le build-rpm build-s390 check-format
 .PHONY: ci-env clean dist feature-tests out show-version test test-yast vendor vet
 .PHONY: coverage coverage-check-enabled coverage-dirs coverage-func coverage-percent
-.PHONY: agama-sources agama-tests bci-build go-env rust-env
+.PHONY: agama-sources agama-tests bci-build go-env rust-env run-tests coverage-clean
+.PHONY: fix-ownership real-clean unit-test-coverage feature-tests-coverage
 
 all: clean build test
 
+run-tests: coverage-clean test feature-tests test-yast agama-tests
+	$(call go-tool-covdata-merge)
+	$(call go-tool-covdata-report,percent,$(COVERAGE_MERGED))
+	$(call go-tool-covdata-report,func,$(COVERAGE_MERGED))
+
 dist: clean internal/connect/version.txt vendor
 	@mkdir -p $(DIST)/build/packaging
-	@cp -r internal $(DIST)
-	@cp -r pkg $(DIST)
-	@cp -r third_party $(DIST)
-	@cp -r cmd $(DIST)
-	@cp -r docs $(DIST)
-	@cp go.mod $(DIST)
-	@cp go.sum $(DIST)
-	@cp LICENSE README.md $(DIST)
+	@cp -r internal $(DIST)/
+	@cp -r pkg $(DIST)/
+	@cp -r third_party $(DIST)/
+	@cp -r cmd $(DIST)/
+	@cp -r docs $(DIST)/
+	@cp go.mod $(DIST)/
+	@cp go.sum $(DIST)/
+	@cp LICENSE README.md $(DIST)/
 	@cp build/packaging/suseconnect-keepalive* $(DIST)/build/packaging
 	@cp build/packaging/suse-uptime-tracker* $(DIST)/build/packaging
-	@cp -r build/packaging/suseconnect-ng* $(DIST)
+	@cp -r build/packaging/suseconnect-ng* $(DIST)/
 
 	@tar cfvj vendor.tar.xz vendor
-	@tar cfvj $(NAME)-$(VERSION).tar.xz $(NAME)-$(VERSION)/
+	@tar cfvj $(DIST).tar.xz $(DIST)/
 
-	@rm -r $(NAME)-$(VERSION)
+	@rm -r $(DIST)/
 
 vendor:
 	@$(GO) mod download
@@ -80,15 +114,15 @@ vet: internal/connect/version.txt
 	$(GO) vet ./...
 
 build: clean out internal/connect/version.txt
-	$(GO) build $(GOFLAGS) $(BINFLAGS) $(OUT) github.com/SUSE/connect-ng/cmd/suseconnect
-	$(GO) build $(GOFLAGS) $(BINFLAGS) $(OUT) github.com/SUSE/connect-ng/cmd/zypper-migration
-	$(GO) build $(GOFLAGS) $(BINFLAGS) $(OUT) github.com/SUSE/connect-ng/cmd/zypper-search-packages
-	$(GO) build $(GOFLAGS) $(BINFLAGS) $(OUT) github.com/SUSE/connect-ng/cmd/suse-uptime-tracker
-	$(GO) build $(GOFLAGS) $(BINFLAGS) $(OUT) github.com/SUSE/connect-ng/cmd/public-api-demo
-	$(GO) build $(GOFLAGS) $(BINFLAGS) $(OUT) github.com/SUSE/connect-ng/cmd/validate-offline-certificate
-	$(GO) build $(GOFLAGS) $(BINFLAGS) $(OUT) github.com/SUSE/connect-ng/cmd/offline-register-api
-	$(GO) build $(GOFLAGS) $(BINFLAGS) $(OUT) github.com/SUSE/connect-ng/cmd/suseconnect-mcp
-	$(GO) build $(GOFLAGS) $(SOFLAGS) $(OUT) github.com/SUSE/connect-ng/third_party/libsuseconnect
+	$(GO) build $(GOFLAGS) $(BINFLAGS) $(call cover-bin-flags) $(OUT) github.com/SUSE/connect-ng/cmd/suseconnect
+	$(GO) build $(GOFLAGS) $(BINFLAGS) $(call cover-bin-flags) $(OUT) github.com/SUSE/connect-ng/cmd/zypper-migration
+	$(GO) build $(GOFLAGS) $(BINFLAGS) $(call cover-bin-flags) $(OUT) github.com/SUSE/connect-ng/cmd/zypper-search-packages
+	$(GO) build $(GOFLAGS) $(BINFLAGS) $(call cover-bin-flags) $(OUT) github.com/SUSE/connect-ng/cmd/suse-uptime-tracker
+	$(GO) build $(GOFLAGS) $(BINFLAGS) $(call cover-bin-flags) $(OUT) github.com/SUSE/connect-ng/cmd/public-api-demo
+	$(GO) build $(GOFLAGS) $(BINFLAGS) $(call cover-bin-flags) $(OUT) github.com/SUSE/connect-ng/cmd/validate-offline-certificate
+	$(GO) build $(GOFLAGS) $(BINFLAGS) $(call cover-bin-flags) $(OUT) github.com/SUSE/connect-ng/cmd/offline-register-api
+	$(GO) build $(GOFLAGS) $(BINFLAGS) $(call cover-bin-flags) $(OUT) github.com/SUSE/connect-ng/cmd/suseconnect-mcp
+	$(GO) build $(GOFLAGS) $(SOFLAGS) $(call cover-lib-flags) $(OUT)/libsuseconnect.so github.com/SUSE/connect-ng/third_party/libsuseconnect
 
 bci-build:
 	$(CRM) $(MOUNT) -w $(WORKDIR) $(GOCONTAINER) bash -c 'git config --global --add safe.directory $(WORKDIR); make vendor build'
@@ -105,7 +139,7 @@ build-ppc64le: clean out internal/connect/version.txt
 	GOOS=linux GOARCH=ppc64le $(GO) build $(GOFLAGS) $(OUT) github.com/SUSE/connect-ng/cmd/suseconnect
 
 coverage-dirs:
-	@mkdir -p $(COVERAGE_UNIT)
+	@mkdir -p $(COVERAGE_UNIT) ${COVERAGE_FEATURE} ${COVERAGE_YAST} ${COVERAGE_AGAMA} ${COVERAGE_MERGED}
 
 coverage-check-enabled:
 	@if [ -z "$(filter true,$(strip $(COVERAGE)))" ]; then \
@@ -115,16 +149,22 @@ coverage-check-enabled:
 	fi
 
 coverage-func: coverage-check-enabled coverage-dirs
-	$(call go-tool-covdata,func)
+	$(call go-tool-covdata-merge)
+	$(call go-tool-covdata-report,func,$(COVERAGE_MERGED))
 
 coverage-percent: coverage-check-enabled coverage-dirs
-	$(call go-tool-covdata,percent)
+	$(call go-tool-covdata-merge)
+	$(call go-tool-covdata-report,percent,$(COVERAGE_MERGED))
 
 coverage: coverage-func
 
 test: internal/connect/version.txt coverage-dirs
 	$(GO) test ./internal/* ./cmd/suseconnect ./pkg/* $(call cover-test-flags)
-	$(call go-tool-covdata,func)
+	$(call go-tool-covdata-report,func,$(COVERAGE_UNIT))
+
+unit-test-coverage: coverage-dirs
+	$(call go-tool-covdata-report,percent,$(COVERAGE_UNIT))
+	$(call go-tool-covdata-report,func,$(COVERAGE_UNIT))
 
 ci-env go-env:
 	$(CRM) $(MOUNT) --env-file $(ENVFILE) -w $(WORKDIR) $(GOCONTAINER) bash
@@ -148,15 +188,35 @@ check-format:
 build-rpm:
 	$(CRM) $(MOUNT) -w $(WORKDIR) $(GOCONTAINER) bash -c 'build/ci/build-rpm'
 
-feature-tests:
-	$(CRM) $(MOUNT) --env-file $(ENVFILE) -w $(WORKDIR) $(GOCONTAINER) bash -c 'build/ci/build-rpm && build/ci/configure && build/ci/run-feature-tests'
+feature-tests: coverage-dirs
+	$(CRM) $(MOUNT) --env-file $(ENVFILE) -w $(WORKDIR) $(GOCONTAINER) bash -c 'make vendor build COVERAGE_BIN=true && build/ci/run-feature-tests'
+	$(call go-tool-covdata-report,percent,$(COVERAGE_FEATURE))
+	$(call go-tool-covdata-report,func,$(COVERAGE_FEATURE))
 
-test-yast: build
+feature-tests-coverage: coverage-dirs
+	$(call go-tool-covdata-report,percent,$(COVERAGE_FEATURE))
+	$(call go-tool-covdata-report,func,$(COVERAGE_FEATURE))
+
+test-yast: bci-build
 	docker build -t go-connect-test-yast -f third_party/Dockerfile.yast . && docker run -t go-connect-test-yast
+
+coverage-clean:
+	@rm -rf $(COVERAGE_DIR)
+
+real-clean: clean coverage-clean
+	@rm -rf vendor/
+	@rm -rf out/
 
 clean:
 	go clean
 	@rm -f internal/connect/version.txt
-	@rm -rf connect-ng-$(NAME)-$(VERSION)/
-	@rm -rf vendor.tar.xz
-	@rm -f connect-ng-*.tar.xz
+	@rm -rf $(DIST)/
+	@rm -f vendor.tar.xz
+	@rm -f $(DIST).tar.xz
+
+fix-ownership:
+	@sudo chown -R $$(id -u):$$(id -g) artifacts coverage out vendor internal/connect/version.txt testdata/agama_srcs
+	@for o in artifacts coverage internal/connect/version.txt out testdata/agama_srcs vendor; do \
+		[ -e $${o} ] || continue; \
+		sudo chown -R $$(id -u):$$(id -g) $${o}; \
+	done

--- a/Makefile
+++ b/Makefile
@@ -198,7 +198,7 @@ feature-tests-coverage: coverage-dirs
 	$(call go-tool-covdata-report,percent,$(COVERAGE_FEATURE))
 	$(call go-tool-covdata-report,func,$(COVERAGE_FEATURE))
 
-test-yast: bci-build
+test-yast: vendor build
 	docker build -t go-connect-test-yast -f third_party/Dockerfile.yast . && docker run -t go-connect-test-yast
 
 coverage-clean:

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ NAME          = suseconnect-ng
 VERSION       = $(shell bash -c "cat build/packaging/suseconnect-ng.spec | sed -n 's/^Version:\s*\(.*\)/\1/p'")
 DIST          = $(NAME)-$(VERSION)
 PWD           = $(shell pwd)
+INTERACTIVE  ?= $(shell if [ -t 0 ]; then echo true; else echo false; fi)
 GO            = go
 OUT           = -o out/
 # coverage testing enabled by default
@@ -14,7 +15,7 @@ SOFLAGS       = -buildmode=c-shared
 
 GOCONTAINER   = registry.suse.com/bci/golang:1.24-openssl
 RUSTCONTAINER = registry.suse.com/bci/rust:1.95
-CRM           = docker run --rm -it --privileged
+CRM           = docker run --rm $(if $(filter true,$(strip $(INTERACTIVE))),-it) --privileged
 ENVFILE       = .env
 WORKDIR       = /usr/src/connect-ng
 MOUNT         = -v $(PWD):$(WORKDIR)
@@ -208,7 +209,7 @@ real-clean: clean coverage-clean
 	@rm -rf out/
 
 clean:
-	go clean
+	$(GO) clean
 	@rm -f internal/connect/version.txt
 	@rm -rf $(DIST)/
 	@rm -f vendor.tar.xz

--- a/Makefile
+++ b/Makefile
@@ -201,7 +201,7 @@ feature-tests-coverage: coverage-dirs
 	$(call go-tool-covdata-report,percent,$(COVERAGE_FEATURE))
 	$(call go-tool-covdata-report,func,$(COVERAGE_FEATURE))
 
-test-yast: vendor build
+test-yast:
 	docker build -t go-connect-test-yast -f third_party/Dockerfile.yast . && docker run -t go-connect-test-yast
 
 coverage-clean:

--- a/Makefile
+++ b/Makefile
@@ -192,7 +192,7 @@ build-rpm:
 	$(CRM) $(MOUNT) -w $(WORKDIR) $(GOCONTAINER) bash -c 'build/ci/build-rpm'
 
 feature-tests: coverage-dirs
-	$(CRM) $(MOUNT) --env-file $(ENVFILE) -w $(WORKDIR) $(GOCONTAINER) bash -c 'make vendor build COVERAGE_BIN=true && build/ci/run-feature-tests'
+	$(CRM) $(MOUNT) --env-file $(ENVFILE) -w $(WORKDIR) $(GOCONTAINER) bash -c 'git config --global --add safe.directory $(WORKDIR); make vendor build COVERAGE_BIN=true && build/ci/run-feature-tests'
 	$(MAKE) fix-ownership
 	$(call go-tool-covdata-report,percent,$(COVERAGE_FEATURE))
 	$(call go-tool-covdata-report,func,$(COVERAGE_FEATURE))

--- a/Makefile
+++ b/Makefile
@@ -27,14 +27,15 @@ COVERAGE_DIR     = $(PWD)/coverage
 COVERAGE_MERGED  = $(COVERAGE_DIR)/merged
 COVERAGE_UNIT    = $(COVERAGE_DIR)/unit
 COVERAGE_FEATURE = $(COVERAGE_DIR)/feature
-# these directories aren't being used yet
-COVERAGE_YAST    = $(COVERAGE_DIR)/yast
-COVERAGE_AGAMA   = $(COVERAGE_DIR)/agama
 
+# NOTE: If adding additional coverage groups to be aggregated into the
+# merged coverage results, remember to include the in the comma separated
+# list of directories in the -i=... argument to go tool covdata merge in
+# this routine.
 define go-tool-covdata-merge
 @if $(if $(filter true,$(strip $(COVERAGE))),true,false); then \
 	mkdir -p $(COVERAGE_MERGED); \
-	$(GO) tool covdata merge -i=$(COVERAGE_UNIT),$(COVERAGE_FEATURE),$(COVERAGE_YAST),$(COVERAGE_AGAMA) -o $(COVERAGE_MERGED); \
+	$(GO) tool covdata merge -i=$(COVERAGE_UNIT),$(COVERAGE_FEATURE) -o $(COVERAGE_MERGED); \
 fi
 endef
 
@@ -73,7 +74,7 @@ endef
 
 all: clean build test
 
-run-tests: coverage-clean test feature-tests test-yast agama-tests
+run-tests: coverage-clean check-format test build-rpm feature-tests test-yast agama-tests
 	$(call go-tool-covdata-merge)
 	$(call go-tool-covdata-report,percent,$(COVERAGE_MERGED))
 	$(call go-tool-covdata-report,func,$(COVERAGE_MERGED))
@@ -178,6 +179,7 @@ agama-sources:
 
 agama-tests: agama-sources bci-build
 	$(CRM) $(MOUNT) $(AGAMA_MOUNT) --env-file $(ENVFILE) -w $(WORKDIR) $(RUSTCONTAINER) bash -c 'build/ci/run-agama-rust-tests'
+	$(MAKE) fix-ownership
 
 
 rust-env: agama-sources
@@ -191,6 +193,7 @@ build-rpm:
 
 feature-tests: coverage-dirs
 	$(CRM) $(MOUNT) --env-file $(ENVFILE) -w $(WORKDIR) $(GOCONTAINER) bash -c 'make vendor build COVERAGE_BIN=true && build/ci/run-feature-tests'
+	$(MAKE) fix-ownership
 	$(call go-tool-covdata-report,percent,$(COVERAGE_FEATURE))
 	$(call go-tool-covdata-report,func,$(COVERAGE_FEATURE))
 
@@ -205,18 +208,17 @@ coverage-clean:
 	@rm -rf $(COVERAGE_DIR)
 
 real-clean: clean coverage-clean
+	@rm -f internal/connect/version.txt
 	@rm -rf vendor/
 	@rm -rf out/
 
 clean:
 	$(GO) clean
-	@rm -f internal/connect/version.txt
 	@rm -rf $(DIST)/
 	@rm -f vendor.tar.xz
 	@rm -f $(DIST).tar.xz
 
 fix-ownership:
-	@sudo chown -R $$(id -u):$$(id -g) artifacts coverage out vendor internal/connect/version.txt testdata/agama_srcs
 	@for o in artifacts coverage internal/connect/version.txt out testdata/agama_srcs vendor; do \
 		[ -e $${o} ] || continue; \
 		sudo chown -R $$(id -u):$$(id -g) $${o}; \

--- a/README.md
+++ b/README.md
@@ -95,6 +95,14 @@ The following tools should be available and verified as working:
 
       See [Agama Rust Integration Tests](#agama-rust-integration-tests) for details.
 
+  * To run all of the above test suites in sequence
+      ```
+      make run-tests
+      ```
+
+      See [Running All Test Suites](#running-all-test-suites) for details.
+
+
 ### Build
 Requires Go >= 1.24
 
@@ -113,7 +121,13 @@ Or you can use the `bci-build` Makefile target:
 make bci-build
 ```
 
-Either of these actions will create an `out/` directory on the host containing the built binaries, such as `suseconnect`.
+Either of these actions will create an `out/` directory on the host
+containing the built binaries, such as `suseconnect`.
+
+**NOTE**: Actions that build the code base within a container runtime
+can result in some of the files and directories being owned by root;
+the `fix-owenership` Makefile target can help with restoring correct
+ownership.
 
 ### Testing
 
@@ -178,7 +192,55 @@ Specifically these tests exercise that:
     will download the RMT's self-sigtned cert and provide it to the `rmt` example via
     the optional second argument.
 
-#### Coverage Reporting for Unit Tests
+#### Running All Test Suites
+
+You can run all of the test suites in sequence using `make run-tests`.
+
+This will clear any existing coverage data then run through each of the
+test suites in sequence, and, if all were successful, will finally report
+unified coverage reports in both the package and function level styles,
+similar to the `coverage-percent` and `coverage-func` targets as described
+[below](#reviewing-recent-unified-coverage-data).
+
+#### Coverage Reporting
+
+Currently the unit and feeature test suites are enabled to collect coverage
+reporting counters; running the test suites will generate a suite specific
+coverage report detailing the coverage on a per function basis.
+
+Running a specific test suite will generate a coverage report on completion
+of a successful test run.
+
+Additionally Makefile targets are available to generated unified coverage
+reports for all recently collected test suite runs.
+
+**NOTE**: Support for generating coverage testing for the YaST2 registration
+and Agama tests is under development and will be available at a later date;
+while coverage data can be collected by these test suites, `libsuseconnect.so`
+currently lacks the support to trigger writing out the coverage data at the
+end of a test run.
+
+##### Building with coverage collection enabled
+While the Makefile `COVERAGE` variable can be used to manage whether coverage
+reporting is enabled in general, as well as whether the unit tests are run with
+coverage enabled, there are two additional flags that control whether the tools
+and libraries are built with coverage collection enabled:
+
+  * `COVERAGE_BIN` - if this is `true` then the locally built binary tools that
+    are published in the `out/` directory will have coverage collection support
+    enabled.
+  * `COVERAGE_LIB` - if this is `true` then the locally built `libsuseconnect.so`
+    library will have coverage collection support enabled.
+
+##### Clearing old coverage data
+
+The `make coverage-clean` target can be used to clear out all existing coverage
+data so that only the results from subsequent runs will be available.
+
+**NOTE**: The `run-tests` target clears old test data using this target before
+running all of the test suites.
+
+##### Coverage Reporting for Unit Tests
 
 Coverage reporting for unit tests has been added, and is enabled by default.
 To disable it you can add `COVERAGE=false` to your `make test` command line,
@@ -189,13 +251,31 @@ on a per package basis as they are tested (similar to the `coverage-percent`
 target described below), and will then generate the same detailed coverage
 report as the `coverage-func` target described below.
 
-**NOTE**: Support for generating coverage testing for the feature and YaST2
-registratoon tests is under development and will be available at a later date.
+The `unit-test-coverage` target can be used to review the most coverage
+results collected by the most recent unit test run.
 
-##### Reviewing the most recent coverage data
+##### Coverage Reporting for Feature Tests
 
-Coverage data will be saved under the `coverage` directory, and you can review
-the most recent unit test run's data using the the following coverage targets:
+Coverage reporting for the feature tests has been added, and is enabled by
+default. To disable it you can add `COVERAGE=false` to your `make feature-tests`
+command line, or set it in your environment.
+
+After the feature tests have completed successfully a detailed per function
+coverage report will be generated for the functions that were exercised by
+the feature tests, similar to the `coverage-func` target described below.
+
+The `feature-tests-coverage` target can be used to review the most coverage
+results collected by the most recent feature test run.
+
+**NOTE**: The `COVERAGE_BIN` variable is set to `true` when building the tools
+that are used to run the feature tests.
+
+##### Reviewing Recent Unified Coverage Data
+
+Coverage data will be saved under the `coverage` directory, in test suite
+specific subdirectories, and you can review the most recent unified testing
+coverage data using the the following coverage targets:
+
   * `coverage-func`
     This will report detail coverage stats for each function, with the overall
     summary coverage percentage for all functions in the code base at the end.
@@ -243,6 +323,7 @@ running the `act --list` or `gh act --list` command, as follows:
 % act --list
 Stage  Job ID                Job name                                        Workflow name           Workflow file  Events
 0      build-suseconnect     Build SUSE/connect-ng inputs required by Agama  agama tests             agama.yml      pull_request
+0      build-rpm             build-rpm                                       build and install rpm   build-rpm.yml  pull_request
 0      feature-tests         feature-tests                                   feature tests           features.yml   pull_request
 0      unit-tests            unit-tests                                      lint + unit tests       lint-unit.yml  pull_request
 0      yast                  yast                                            YaST integration tests  yast.yml       pull_request

--- a/README.md
+++ b/README.md
@@ -314,6 +314,27 @@ jobs that run, the `--env-file .env` option should be set.
 The [.actrc](.actrc) file in the repo specifies appropriate values for these
 options.
 
+##### Leap 16.x specific `act` settings
+
+On Leap 16.x systems the ownership and permissions for `/var/run/docker.sock`
+on the host,
+which is mapped into the `act` testing container runtime environments,
+may not be compatible with the runtime environment within the `act` testing
+container runtime environment,
+
+On Leap 16.x systems `act` runs may encounter permissions issues when trying
+to perform "docker-in-docker" actions; this occurrs because the ownership and
+permissions for `/var/run/docker.sock`, which is mapped into the `act` runner
+container instances, are not compatible with the `act` runner docker setup.
+
+To workaround this you can either:
+
+  * add `--container-options "--user root --privileged"` to the `act` (or
+    `gh act`) command line, or
+
+  * add `--container-options --user root --privileged` to `${HOME}/.actrc`
+    to enable this for all subsequent `act` runs.
+
 #### Running the workflows locally
 
 The available workflows, and their associated trigger events can be listed by

--- a/build/ci/README.md
+++ b/build/ci/README.md
@@ -1,52 +1,87 @@
-## connect-ng CI setup
+# connect-ng CI setup
 
 Our CI setup runs the following steps:
 
-### Lint and unit tests
+* [Lint and Unit Tests](#lint-and-unit-tests)
+* [Build RPM](#build-rpm)
+* [CLI Feature Tests](#cli-feature-tests)
+* [YaST2 Registration Tests](#yast2-registration-tests)
+* [Agama Rust Integration Tests](#agama-rust-integration-tests)
 
-workflow definition: [.github/workflows/lint-unit.yml](https://github.com/SUSE/connect-ng/blob/main/.github/workflows/lint-unit.yml)
+## Lint and Unit Tests
 
-This workflow runs our unit tests + the usual `gofmt` to insure we have a broad coverage in functionality and good code style.
+workflow definition: [.github/workflows/lint-unit.yml](../../.github/workflows/lint-unit.yml)
+
+This workflow runs the usual `gofmt` check to ensure that our coding style
+is consistent, followed by running our unit tests to ensure we have a broad
+coverage in functionality, and then verifies that the code base builds.
 
 **Running unit tests locally**
 
-There is no special mechanism needed to run these steps locally. Check the workflow for hints how to run unit tests
+This is equivalent to running the following [Makefile](../../Makefile)
+targets locally:
 
-### CLI feature tests
+* check-format
+* test
+* vendor
+* build
 
-workflow definition: [.github/workflows/features.yml](https://github.com/SUSE/connect-ng/blob/main/.github/workflows/features.yml)
+## Build RPM
 
-This workflow runs our simple CLI feature tests and build the rpm beforehand and runs feature test we imported from the deprecated
-ruby connect version. Check [features/](https://github.com/SUSE/connect-ng/tree/main/features) for more information.
+workflow definition: [.github/workflows/build-rpm.yml](../../.github/workflows/build-rpm.yml)
 
-**Requirements to run feature tests locally**
+This workflow verifies that we can successfully build and install the RPM
+packages defined by the [suseconnect-ng.spec](../packaging/suseconnect-ng.spec) file.
 
-To run feature tests locally, you need:
+**Running build rpm tests locally**
 
-- A checkout of connect-ng
-- You need multiple secrets to run the actual feature tests, since they register and deregister with SCC in the feature tests
+This is equivalent to running `make build-rpm` locally.
 
-```
-# Add this to your .env file
-BETA_VALID_REGCODE=
-VALID_REGCODE=
-EXPIRED_REGCODE=
-NOT_ACTIVATED_REGCODE=
-BETA_NOT_ACTIVATED_REGCODE=
-```
+## CLI Feature Tests
 
-**Running tasks in the container**
+workflow definition: [.github/workflows/features.yml](../../.github/workflows/features.yml)
 
-We use the official SUSE Golang container, providing all we need to run the tests:
+This workflow builds the suseconnect-ng components, installs them similarly to
+how the associated RPMs would install them and then runs our CLI feature test
+suite to help catch errors and help avoid regressions with respect to existing
+functionality and the legacy ruby connect version.
 
-```
-export IMAGE="registry.suse.com/bci/golang:1.24-openssl"
-# Run the required container:
-$ docker run --rm -it --env-file .env -v $(pwd):/usr/src/connect-ng $IMAGE
+Check [features/](../../features) for more information.
 
-# To build the connect-ng rpms within the container use:
-$ docker run --rm -it -v $(pwd):/usr/src/connect-ng $IMAGE 'build/ci/build-rpm'
+**Run feature tests locally using containers**
 
-# Run feature tests in the container
-$ docker run --rm -it --env-file .env -v $(pwd):/usr/src/connect-ng $IMAGE bash -c 'build/ci/build-rpm && build/ci/configure && build/ci/run-feature-tests'
-```
+To run these tests you will need to ensure your local [.env](../../.env-example) file is
+setup appropriately and run `make feature-tests` to build and test the feature tests
+within a container. For more details see [Feature Tests](../../README.md#feature-tests).
+
+## YaST2 Registration Tests
+
+workflow definition: [.github/workflows/yast.yml](../../.github/workflows/yast.yml)
+
+This workflow builds the suseconnect-ng components and then uses them as part of a
+container image build based upon the [third_party/Dockerfile.yast](../../third_party/Dockerfile.yast)
+which is used to create a customised container image to run the
+[YaST2 Registration Test Suite](https://github.com/yast/yast-registration)
+
+**Running YaST2 Registrationbuild rpm tests locally**
+
+This is equivalent to running `make test-yast` locally.
+
+## Agama Rust Integration Tests
+
+workflow definition: [.github/workflows/agama.yml](../../.github/workflows/agama.yml)
+
+This workflow builds the suseconnect-ng components using a SUSE BCI Golang
+container and then pulls those components into a SUSE BCI Rust container
+to build the rust based [Agama suseconnect integration testing examples](https://github.com/agama-project/agama/tree/master/rust/suseconnect-agama/examples)
+and run them to verify basic Agama registration.
+
+**Running Agama Rust Integration Tests locally**
+
+This is equivalent to running `make agama-tests` locally.
+
+**NOTE**: You can optionally define a valid RMT url using the `RMT_HOST`
+setting in the [.env](../../.env-example) file for local testing to
+additionally test Agama registrations against an RMT, using either http
+or https protocol. See [Agama Rust Integration Tests](../../README.md#agama-rust-integration-tests)
+for more details.

--- a/build/ci/build-rpm
+++ b/build/ci/build-rpm
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e
 
+source "$(dirname "$(readlink -e "${BASH_SOURCE[0]}")")/lib.bash"
+
 # Explicitly setting the architecture to use
 ARCH=${ARCH:-x86_64}
 
@@ -26,10 +28,6 @@ TARBALL=${TARBALL:-suseconnect-ng-$VERSION.tar.xz}
 
 # The vendor tarball used for dependencies
 VENDOR=${VENDOR:-vendor.tar.xz}
-
-group() { echo "::group::$1"; }
-groupend() { echo "::groupend::"; }
-fail() { echo "::error::$1"; exit 1;}
 
 group "setup artifact directory"
   if [ -d "$ARTIFACT_DIR" ]; then

--- a/build/ci/configure
+++ b/build/ci/configure
@@ -1,4 +1,7 @@
 #!/bin/bash
+set -e
+
+source "$(dirname "$(readlink -e "${BASH_SOURCE[0]}")")/lib.bash"
 
 # Explicitly setting the architecture to use
 ARCH=${ARCH:-x86_64}
@@ -9,11 +12,7 @@ SOURCE=${SOURCE:-/usr/src/connect-ng}
 # Where is the rpm build environment to be found
 BUILD_DIR=${BUILD_DIR:-/usr/src/packages}
 
-group() { echo "::group::$1"; }
-groupend() { echo "::groupend::"; }
-fail() { echo "::error::$1"; exit 1; }
-
-group "install suseconnect"
+group "install suseconnect from rpms"
 pushd "$BUILD_DIR/RPMS/${ARCH}"
   zypper --non-interactive --no-refresh install --allow-unsigned-rpm *.rpm
   zypper --non-interactive --no-refresh install systemd

--- a/build/ci/lib.bash
+++ b/build/ci/lib.bash
@@ -35,6 +35,29 @@ check_required_env_vars_defined()
     groupend
 }
 
+system_ruby_version()
+{
+    local VERSION_ID ruby_version
+
+    # determine distro version from /etc/os-release
+    eval "$(grep VERSION_ID= /etc/os-release || echo 'VERSION_ID="Unknown"')"
+
+    case "${VERSION_ID:-16.0}" in
+    (15.*) # SLE 15 stream
+        ruby_version=2.5.0
+        ;;
+    (16.*) # SLE 16 stream
+        ruby_version=3.4.0
+        ;;
+    (*)
+        # Tumbleweed/Factory
+        ruby_version=4.0.0
+        ;;
+    esac
+
+    echo "${ruby_version}"
+}
+
 install_locally_built_suseconnect()
 {
     local out_dir="$(readlink -e ${1})" src_dir bin_tools zypp_cmds rc_links systemd_libdir ruby_libdir
@@ -44,7 +67,7 @@ install_locally_built_suseconnect()
     zypp_cmds=( zypper-migration zypper-search-packages )
     svc_cmds=( suseconnect-keepalive suse-uptime-tracker )
     systemd_libdir=/usr/lib/systemd/system
-    ruby_libdir=/usr/lib64/ruby/vendor_ruby/3.4.0
+    ruby_libdir=/usr/lib64/ruby/vendor_ruby/$(system_ruby_version)
 
     # install binary tools
     group "Install binary tools"

--- a/build/ci/lib.bash
+++ b/build/ci/lib.bash
@@ -1,0 +1,135 @@
+#!/bin/bash
+
+group() { echo "::group::$*"; }
+groupend() { echo "::groupend::"; }
+fail() { echo "::error::$*"; exit 1;}
+
+cleanup_testing_environment()
+{
+    group "cleanup test system"
+    suseconnect --clean || true  # ignore failures
+    [ -f /etc/SUSEConnect ] && rm /etc/SUSEConnect
+    groupend
+}
+
+check_required_env_vars_defined()
+{
+    local env_vars_to_check env_vars_missing
+
+    env_vars_to_check=( ${@} )
+    env_vars_missing=()
+
+    group "verify required environment variables defined"
+    echo "Expecting these environment variables to be set:"
+    echo "${env_vars_to_check[@]}"
+    for env_var in "${env_vars_to_check[@]}"; do
+        if [ -z "${!env_var}" ]; then
+            echo "ENV variable not found: ${env_var} is not set."
+            env_vars_missing+=( "${env_var}" )
+        fi
+    done
+    if (( ${#env_vars_missing[@]} )); then
+        fail "Required environment variables not set: ${env_vars_missing[@]}"
+    fi
+    echo "All required environment variables provided"
+    groupend
+}
+
+install_locally_built_suseconnect()
+{
+    local out_dir="$(readlink -e ${1})" src_dir bin_tools zypp_cmds rc_links systemd_libdir ruby_libdir
+
+    src_dir="$(dirname "${out_dir}")"
+    bin_tools=( suseconnect suse-uptime-tracker suseconnect-mcp )
+    zypp_cmds=( zypper-migration zypper-search-packages )
+    svc_cmds=( suseconnect-keepalive suse-uptime-tracker )
+    systemd_libdir=/usr/lib/systemd/system
+    ruby_libdir=/usr/lib64/ruby/vendor_ruby/3.4.0
+
+    # install binary tools
+    group "Install binary tools"
+    for bt in "${bin_tools[@]}"
+    do
+        cp -pv "${out_dir}/${bt}" "/usr/bin/${bt}"
+    done
+    groupend
+
+    # create binary tools symlinks
+    group "Install binary tools symlinks"
+    ln -fsv suseconnect /usr/bin/SUSEConnect
+    ln -fsv ../bin/suseconnect /usr/sbin/SUSEConnect
+    groupend
+
+    # install zypper commands
+    group "Install zypper commands"
+    for zc in "${zypp_cmds[@]}"
+    do
+        cp -pv "${out_dir}/${zc}" "/usr/lib/zypper/${zc}"
+    done
+    groupend
+
+    # install libsuseconnect
+    group "Install shared libraries"
+    for shlib in libsuseconnect.so
+    do
+        cp -pv "${out_dir}/${shlib}" "/usr/lib64/${shlib}"
+    done
+    groupend
+
+    # install ruby bindings
+    group "Install ruby bindings"
+    mkdir -m 0755 -pv "${ruby_libdir}"
+    cp -apv "${src_dir}/third_party/yast/lib/suse" "${ruby_libdir}/"
+    groupend
+
+    # optionally install service integration
+    if [ -x /usr/sbin/service ]; then
+        group "Install service links"
+        for sc in "${svc_cmds[@]}"
+        do
+            ln -fsv service "/usr/sbin/rc${sc}"
+        done
+        groupend
+    fi
+
+    # optionally install systemd integration
+    if [ -d "${systemd_libdir}" ]; then
+        group "Install systemd integration"
+        for sc in "${svc_cmds[@]}"
+        do
+            for svc_type in service timer
+            do
+                cp -pv "${src_dir}/build/packaging/${sc}.${svc_type}" "${systemd_libdir}"
+            done
+        done
+        groupend
+    fi
+}
+
+cleanup_orphaned_products()
+{
+    local products_to_check_for products_to_remove
+    if (( $# > 0 )); then
+        products_to_check_for=( "${@}" )
+    else
+        products_to_check_for=(
+            sle-module-python3
+            sle-module-server-applications
+            sle-module-basesystem
+        )
+    fi
+    products_to_remove=()
+
+    for p in "${products_to_check_for[@]}"
+    do
+        if zypper --no-refresh info -t product "${p}" >/dev/null; then
+            products_to_remove+=( "${p}" )
+        fi
+    done
+
+    if (( ${#products_to_remove[@]} )); then
+        group "Removing orphaned products: ${products_to_remove[@]}"
+        zypper --no-refresh --non-interactive remove -t product "${products_to_remove[@]}"
+        groupend
+    fi
+}

--- a/build/ci/run-agama-rust-tests
+++ b/build/ci/run-agama-rust-tests
@@ -2,6 +2,8 @@
 
 set -eu
 
+source "$(dirname "$(readlink -e "${BASH_SOURCE[0]}")")/lib.bash"
+
 REQ_PKGS=(
 	clang7-devel
 	dbus-1-devel
@@ -29,32 +31,9 @@ AGAMA_RUST=${AGAMA_SOURCE}/rust
 LIB64_DIR=/usr/lib64
 
 # exported variables we expect to exist to run the tests
-KEYS_TO_CHECK=(REGCODE)
+check_required_env_vars_defined REGCODE
 
-# products to remove when cleaning up container state
-REMOVE_PRODUCTS=(sle-module-python3 sle-module-server-applications sle-module-basesystem)
-
-group() { echo "::group::$1"; }
-groupend() { echo "::groupend::"; }
-fail() { echo "::error::$1"; exit 1; }
-
-group "verify required environment variables defined"
-for name in ${KEYS_TO_CHECK[@]}; do
-if [ "${!name}" == "" ]; then
-  echo "Expect the environment variables to be set:"
-  echo "${KEYS_TO_CHECK[*]}"
-  fail "ENV variable not found: $name is not set."
-fi
-done
-groupend
-
-group "cleanup container release package state"
-for product in ${REMOVE_PRODUCTS[@]}; do
-  if zypper --no-refresh se --installed-only -t product ${product} | grep -q ${product}; then
-    zypper --no-refresh --non-interactive remove -t product ${product}
-  fi
-done
-groupend
+cleanup_orphaned_products
 
 group "fail if the agama repo is not available"
 ls -l ${AGAMA_SOURCE}
@@ -78,10 +57,7 @@ if [[ ! -d ${CONNECT_OUT} ]]; then
 fi
 groupend
 
-group "install libsuseconnect.so"
-mkdir -p ${LIB64_DIR}
-cp ${CONNECT_OUT}/libsuseconnect ${LIB64_DIR}/libsuseconnect.so
-groupend
+install_locally_built_suseconnect ${CONNECT_SOURCE}/out
 
 group "build agama/rust activation example"
 # determine where libstdc++ is located and ensure rust linking looks there

--- a/build/ci/run-feature-tests
+++ b/build/ci/run-feature-tests
@@ -1,39 +1,24 @@
 #!/bin/bash
 set -e
 
+# pull in scripting library definitions
+source "$(dirname "$(readlink -e "${BASH_SOURCE[0]}")")/lib.bash"
+
 # Where the connect-ng source is located within the container
 SOURCE=${SOURCE:-/usr/src/connect-ng}
 
+# Setup GOCOVERDIR
+export GOCOVERDIR="${SOURCE}/coverage/feature"
+
 # exported variables we expect to exist to run the tests
-KEYS_TO_CHECK=(REGCODE EXPIRED_REGCODE HA_REGCODE)
-
-REMOVE_PRODUCTS="sle-module-python3 sle-module-server-applications sle-module-basesystem"
-
-group() { echo "::group::$1"; }
-groupend() { echo "::groupend::"; }
-fail() { echo "::error::$1"; exit 1; }
-
-for name in ${KEYS_TO_CHECK[@]}; do
-if [ "${!name}" == "" ]; then
-  echo "Expect the environment variables to be set:"
-  echo "${KEYS_TO_CHECK[*]}"
-  fail "ENV variable not found: $name is not set."
-fi
-done
-
-group "cleanup test system"
-  SUSEConnect --clean
-  [ -f /etc/SUSEConnect ] && rm /etc/SUSEConnect
-groupend
+check_required_env_vars_defined REGCODE EXPIRED_REGCODE HA_REGCODE
 
 # Remove products so container in a clean state
-group "Clean Container"
-for product in ${REMOVE_PRODUCTS}; do
-    if zypper --no-refresh se --installed-only -t product ${product} | grep -q ${product}; then
-	   zypper --no-refresh --non-interactive remove -t product ${product}
-    fi
-done
-groupend
+cleanup_orphaned_products
+
+install_locally_built_suseconnect "${SOURCE}/out"
+
+cleanup_testing_environment
 
 group "run feature tests"
 pushd "$SOURCE"

--- a/third_party/Dockerfile.yast
+++ b/third_party/Dockerfile.yast
@@ -1,3 +1,13 @@
+# build suseconnect in a SLE BCI golang container
+FROM registry.suse.com/bci/golang:1.24-openssl AS builder
+
+COPY . /connect-ng
+
+WORKDIR /connect-ng
+
+RUN make vendor build
+
+# build a customized yast-ruby container
 FROM registry.opensuse.org/yast/head/containers/yast-ruby:latest
 
 RUN zypper rm -y suseconnect-ng libsuseconnect suseconnect-ruby-bindings
@@ -9,6 +19,7 @@ WORKDIR /yast-registration
 
 RUN git clone --depth 1 https://github.com/yast/yast-registration.git /yast-registration
 
-COPY out/libsuseconnect.so /usr/lib64/libsuseconnect.so
+# copy built libsuseconnect.so from builder image
+COPY --from=builder /connect-ng/out/libsuseconnect.so /usr/lib64/libsuseconnect.so
 COPY third_party/yast/lib /usr/lib64/ruby/vendor_ruby/4.0.0
 CMD ["rake", "test:unit"]

--- a/third_party/Dockerfile.yast
+++ b/third_party/Dockerfile.yast
@@ -9,6 +9,6 @@ WORKDIR /yast-registration
 
 RUN git clone --depth 1 https://github.com/yast/yast-registration.git /yast-registration
 
-COPY out/libsuseconnect /usr/lib64/libsuseconnect.so
+COPY out/libsuseconnect.so /usr/lib64/libsuseconnect.so
 COPY third_party/yast/lib /usr/lib64/ruby/vendor_ruby/4.0.0
 CMD ["rake", "test:unit"]


### PR DESCRIPTION
The existing feature-tests GitHub Actions workflow has been split into two separate workflows:

  * `build-rpm` which builds and installs the RPM package
  * `feature-tests` which builds suseconnect locally and runs the feature tests

This change was required to avoid needing to add support for building the RPM with coverage collection support enabled.

Updated the unit and feature test GitHub Actions workflows to add a final step that outputs the specific test suite's coverage reports.

Running the `test` or `feature-tests` targets will run generate a test suite specific coverage report after a successful run. And there are now additional Makefile targets that will report the specific coverage reports for these test suites:

  * `unit-test-coverage` shows the package and function percentage
  * `feature-tests-coverage` shows the package and function percentage

Split the Makefile `go-tool-covdata` helper routine into separate `go-tool-covdata-merge` and `go-tool-covdata-report` helpers.

The `coverage`, `coverage-func` and `coverage-percent` targets now generate reports based upon the unified coverage data, rather than the unit test specific data.

Added a new `coverage-clean` Makefile target for clearing out existing coverage data so that subsequence tests start with a clean state.

Added a new `run-tests` Makfile target that clears existing coverage data and then runs all the test suites sequentially before finally generated summary package and function level coverage reports of the unified data.

Updated building of `libsuseconnect.so` to call the built library `libsuseconnect.so` rather than `libsuseconnect` to align with how the RPM spec file actually builds the shared library. Updated the existing use cases of `libsuseconnect` to reflect this change.

Added `COVERAGE_BIN` and `COVERAGE_LIB` variables that are used to control whether the tools or libraries are built with support for collecting coverage data.

Added `build/ci/lib.bash` and moved shared scripting functionality from the other `build/ci` scripts into it; the other scripts now source it, and call the functions it provides. This will simplify maintenance of these scripts, minimising duplicated code, as we add more test scenarios in the future.

Minor cleanup to Makefile `dist` and `clean` target recipes and added a `real-clean` target that cleans up everything.

Also added a `fix-ownership` target that fixes the ownership of files and directories that may be created/modified by docker based actions.

Updated README.md to reflect these changes.

Implements: SCC-736

How To Test:
  * Clone this PR branch
  * Exercise the updated `test` and `feature-tests` Makefile targets to verify the run as expected and that they produce test suite specific coverage reporting.
  * Similarly, verify that the new `unit-test-coverage` and `feature-tests-coverage` Makefile targets report matching coverage reports for the most recent runs.
  * Verify that the `coverage`, `coverage-func` and `coverage-percent` Makefile targets report unified (aggregate) testing coverage reports.
  * Verify that the GitHub Actions workflows are being run as expected for this PR.
  * If available, use `act` (or `gh act`) to verify that the new and updated workflows run successfully, and where appropriate, generate coverage reports.
  * If running on Leap 16.0 and trying to use `act` see the new README.md section added in this PR for tips on how to resolve docker-in-docker permissions issues.
