### PR TITLE
Collect metrics to report that requests came in from the mcp-server

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -162,7 +162,7 @@ coverage-percent: coverage-check-enabled coverage-dirs
 coverage: coverage-func
 
 test: internal/connect/version.txt coverage-dirs
-	$(GO) test ./internal/* ./cmd/suseconnect ./pkg/* $(call cover-test-flags)
+	$(GO) test ./internal/* ./cmd/suseconnect ./cmd/suseconnect-mcp ./pkg/* $(call cover-test-flags)
 	$(call go-tool-covdata-report,func,$(COVERAGE_UNIT))
 
 unit-test-coverage: coverage-dirs

--- a/cmd/suseconnect-mcp/suseconnect_mcp.go
+++ b/cmd/suseconnect-mcp/suseconnect_mcp.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -11,6 +12,36 @@ import (
 	"github.com/SUSE/connect-ng/pkg/registration"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
+
+// McpActions handles the file system operations for MCP actions.
+type McpActions struct {
+	actions     []Action
+	osStat      func(string) (os.FileInfo, error)
+	osMkdirAll  func(string, os.FileMode) error
+	osReadFile  func(string) ([]byte, error)
+	osWriteFile func(string, []byte, os.FileMode) error
+	osOpenFile  func(string, int, os.FileMode) (*os.File, error)
+	osRename    func(string, string) error
+	osRemove    func(string) error
+}
+
+// NewMcpActions creates a new McpActions with default file system functions.
+func NewMcpActions() *McpActions {
+	return &McpActions{
+		osStat:      os.Stat,
+		osMkdirAll:  os.MkdirAll,
+		osReadFile:  os.ReadFile,
+		osWriteFile: os.WriteFile,
+		osOpenFile:  os.OpenFile,
+		osRename:    os.Rename,
+		osRemove:    os.Remove,
+	}
+}
+
+type Action struct {
+	Name  string `json:"name"`
+	Count int    `json:"count"`
+}
 
 type ToolInput struct{}
 
@@ -43,9 +74,95 @@ var (
 	_ func(context.Context, *mcp.CallToolRequest, DeactivateInput) (*mcp.CallToolResult, JSONOutput, error) = DeactivateProduct
 )
 
+var mcpDir = "/var/lib/suseconnect-mcp"
+
+// incCount increments the count of a specific action.
+func (m *McpActions) incCount(actionName string) {
+	found := false
+	for i, action := range m.actions {
+		if action.Name == actionName {
+			m.actions[i].Count++
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		m.actions = append(m.actions, Action{Name: actionName, Count: 1})
+	}
+}
+
+func updateActionCountInit(actionName string) error {
+	m := NewMcpActions()
+	return updateActionCount(m, actionName)
+}
+
+func updateActionCount(m *McpActions, actionName string) error {
+	filePath := mcpDir + "/suseconnectmcp"
+
+	if _, err := m.osStat(mcpDir); os.IsNotExist(err) {
+		err = m.osMkdirAll(mcpDir, 0755)
+		if err != nil {
+			return fmt.Errorf("failed to create directory: %w", err)
+		}
+
+	}
+
+	// Ensure that the process has write access to the directory, otherwise fail early
+	testFile := mcpDir + "/.write_test"
+	f, openErr := m.osOpenFile(testFile, os.O_WRONLY|os.O_CREATE, 0664)
+	if openErr != nil {
+		return fmt.Errorf("no write access to %s: %w", mcpDir, openErr)
+	}
+	f.Close()
+
+	err := m.osRemove(testFile)
+	if err != nil {
+		// This shouldn't fail, but if it does, it's not critical
+		slog.Warn("failed to remove temporary file", "file", testFile, "error", err)
+	}
+
+	file, err := m.osReadFile(filePath)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return fmt.Errorf("failed to read file: %w", err)
+		}
+	} else {
+		err = json.Unmarshal(file, &m.actions)
+		if err != nil {
+			// Can be empty file
+		}
+	}
+
+	m.incCount(actionName)
+
+	data, err := json.Marshal(m.actions)
+	if err != nil {
+		return fmt.Errorf("failed to marshal json: %w", err)
+	}
+
+	tempFilePath := fmt.Sprintf("%s.%d.tmp", filePath, os.Getpid())
+	err = m.osWriteFile(tempFilePath, data, 0664)
+	if err != nil {
+		return fmt.Errorf("failed to write to temporary file: %w", err)
+	}
+
+	err = m.osRename(tempFilePath, filePath)
+	if err != nil {
+		m.osRemove(tempFilePath)
+		return fmt.Errorf("failed to rename temporary file: %w", err)
+	}
+
+	return nil
+}
+
 func RegistrationStatus(ctx context.Context, req *mcp.CallToolRequest, input ToolInput) (
 	*mcp.CallToolResult, JSONOutput, error) {
 	slog.Info("RegistrationStatus tool called")
+
+	if err := updateActionCountInit("RegistrationStatus"); err != nil {
+		return nil, JSONOutput{Error: "Failed to update Action Count"}, err
+	}
 
 	opts, err := connect.ReadFromConfiguration(connect.DefaultConfigPath)
 	if err != nil {
@@ -63,6 +180,10 @@ func RegistrationStatus(ctx context.Context, req *mcp.CallToolRequest, input Too
 func ListExtensions(ctx context.Context, req *mcp.CallToolRequest, input ToolInput) (
 	*mcp.CallToolResult, JSONOutput, error) {
 	slog.Info("ListExtensions tool called")
+
+	if err := updateActionCountInit("ListExtensions"); err != nil {
+		return nil, JSONOutput{Error: "Failed to update Action Count"}, err
+	}
 
 	opts, err := connect.ReadFromConfiguration(connect.DefaultConfigPath)
 	if err != nil {
@@ -85,6 +206,10 @@ func RegisterSystem(ctx context.Context, req *mcp.CallToolRequest, input Registe
 	*mcp.CallToolResult, JSONOutput, error) {
 	slog.Info("RegisterSystem tool called")
 
+	if err := updateActionCountInit("RegisterSystem"); err != nil {
+		return nil, JSONOutput{Error: "Failed to update Action Count"}, err
+	}
+
 	opts, err := connect.ReadFromConfiguration(connect.DefaultConfigPath)
 	if err != nil {
 		return nil, JSONOutput{Error: "Failed to read SUSEConnect configuration"}, err
@@ -104,6 +229,10 @@ func RegisterSystem(ctx context.Context, req *mcp.CallToolRequest, input Registe
 func ActivateProduct(ctx context.Context, req *mcp.CallToolRequest, input ActivateInput) (
 	*mcp.CallToolResult, JSONOutput, error) {
 	slog.Info("ActivateProduct tool called")
+
+	if err := updateActionCountInit("ActivateProduct"); err != nil {
+		return nil, JSONOutput{Error: "Failed to update Action Count"}, err
+	}
 
 	opts, err := connect.ReadFromConfiguration(connect.DefaultConfigPath)
 	if err != nil {
@@ -130,6 +259,10 @@ func DeregisterSystem(ctx context.Context, req *mcp.CallToolRequest, input ToolI
 	*mcp.CallToolResult, JSONOutput, error) {
 	slog.Info("DeregisterSystem tool called")
 
+	if err := updateActionCountInit("DeregisterSystem"); err != nil {
+		return nil, JSONOutput{Error: "Failed to update Action Count"}, err
+	}
+
 	opts, err := connect.ReadFromConfiguration(connect.DefaultConfigPath)
 	if err != nil {
 		return nil, JSONOutput{Error: "Failed to read SUSEConnect configuration"}, err
@@ -147,6 +280,10 @@ func DeregisterSystem(ctx context.Context, req *mcp.CallToolRequest, input ToolI
 func DeactivateProduct(ctx context.Context, req *mcp.CallToolRequest, input DeactivateInput) (
 	*mcp.CallToolResult, JSONOutput, error) {
 	slog.Info("DeactivateProduct tool called")
+
+	if err := updateActionCountInit("DeactivateProduct"); err != nil {
+		return nil, JSONOutput{Error: "Failed to update Action Count"}, err
+	}
 
 	opts, err := connect.ReadFromConfiguration(connect.DefaultConfigPath)
 	if err != nil {

--- a/cmd/suseconnect-mcp/suseconnect_mcp_test.go
+++ b/cmd/suseconnect-mcp/suseconnect_mcp_test.go
@@ -2,6 +2,10 @@ package main
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
 	"testing"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -9,6 +13,10 @@ import (
 )
 
 func TestToolExecutionWithInvalidInputs(t *testing.T) {
+	oldMcpDir := mcpDir
+	mcpDir = t.TempDir()
+	defer func() { mcpDir = oldMcpDir }()
+
 	assert := assert.New(t)
 	ctx := context.Background()
 	req := &mcp.CallToolRequest{}
@@ -75,4 +83,219 @@ func TestToolExecutionWithInvalidInputs(t *testing.T) {
 			assert.Contains(output.Error, tt.errorMsg, "Should contain expected error message")
 		})
 	}
+}
+
+func testIncCount(t *testing.T) {
+	m := NewMcpActions()
+
+	m.incCount("action1")
+	assert.Equal(t, 1, len(m.actions))
+	assert.Equal(t, "action1", m.actions[0].Name)
+	assert.Equal(t, 1, m.actions[0].Count)
+
+	m.incCount("action2")
+	assert.Equal(t, 2, len(m.actions))
+
+	m.incCount("action1")
+	assert.Equal(t, 2, len(m.actions))
+	for _, action := range m.actions {
+		if action.Name == "action1" {
+			assert.Equal(t, 2, action.Count)
+		}
+	}
+}
+
+func testCreatesNewFileAndAddsAction(t *testing.T, dir string, filePath string) {
+	// Override global mcpDir for this test
+	oldMcpDir := mcpDir
+	mcpDir = dir
+	defer func() { mcpDir = oldMcpDir }()
+
+	m := NewMcpActions()
+	var writtenData []byte
+	renamed := false
+	removedTestFile := false
+
+	m.osStat = func(name string) (os.FileInfo, error) { return nil, os.ErrNotExist }
+	m.osMkdirAll = func(path string, perm os.FileMode) error { return nil }
+	m.osReadFile = func(name string) ([]byte, error) { return nil, os.ErrNotExist }
+	m.osWriteFile = func(name string, data []byte, perm os.FileMode) error {
+		assert.Equal(t, fmt.Sprintf("%s.%d.tmp", filePath, os.Getpid()), name)
+		writtenData = data
+		return nil
+	}
+	m.osRename = func(oldpath, newpath string) error {
+		assert.Equal(t, fmt.Sprintf("%s.%d.tmp", filePath, os.Getpid()), oldpath)
+		assert.Equal(t, filePath, newpath)
+		renamed = true
+		return nil
+	}
+	m.osRemove = func(name string) error {
+		if name == dir+"/.write_test" {
+			removedTestFile = true
+			return nil
+		}
+		t.Fatalf("osRemove called with unexpected file: %s", name)
+		return nil
+	}
+	m.osOpenFile = func(name string, flag int, perm os.FileMode) (*os.File, error) {
+		// Mock file creation - return a dummy file descriptor
+		return &os.File{}, nil
+	}
+
+	err := updateActionCount(m, "testAction")
+	assert.NoError(t, err)
+	assert.True(t, renamed)
+	assert.True(t, removedTestFile, "osRemove should be called for the test file")
+
+	var actions []Action
+	err = json.Unmarshal(writtenData, &actions)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(actions))
+	assert.Equal(t, "testAction", actions[0].Name)
+	assert.Equal(t, 1, actions[0].Count)
+}
+
+func testAddsToExistingFile(t *testing.T, dir string, filePath string) {
+	// Override global mcpDir for this test
+	oldMcpDir := mcpDir
+	mcpDir = dir
+	defer func() { mcpDir = oldMcpDir }()
+
+	m := NewMcpActions()
+	var writtenData []byte
+	renamed := false
+	removedTestFile := false
+	initialJSON := `[{"name": "existingAction", "count": 5}]`
+
+	m.osStat = func(name string) (os.FileInfo, error) { return nil, nil }
+	m.osMkdirAll = func(path string, perm os.FileMode) error {
+		t.Fatalf("osMkdirAll should not be called when dir exists")
+		return nil
+	}
+	m.osReadFile = func(name string) ([]byte, error) { return []byte(initialJSON), nil }
+	m.osWriteFile = func(name string, data []byte, perm os.FileMode) error {
+		writtenData = data
+		return nil
+	}
+	m.osRename = func(oldpath, newpath string) error {
+		renamed = true
+		return nil
+	}
+	m.osRemove = func(name string) error {
+		if name == dir+"/.write_test" {
+			removedTestFile = true
+			return nil
+		}
+		t.Fatalf("osRemove called with unexpected file: %s", name)
+		return nil
+	}
+	m.osOpenFile = func(name string, flag int, perm os.FileMode) (*os.File, error) {
+		// Mock file creation for write test
+		return &os.File{}, nil
+	}
+
+	err := updateActionCount(m, "newAction")
+	assert.NoError(t, err)
+	assert.True(t, renamed)
+	assert.True(t, removedTestFile, "osRemove should be called for the test file")
+
+	var actions []Action
+	err = json.Unmarshal(writtenData, &actions)
+	assert.NoError(t, err)
+	assert.Equal(t, 2, len(actions))
+}
+
+func testHandlesWriteError(t *testing.T, dir string, filePath string) {
+	// Override global mcpDir for this test
+	oldMcpDir := mcpDir
+	mcpDir = dir
+	defer func() { mcpDir = oldMcpDir }()
+
+	m := NewMcpActions()
+	m.osStat = func(name string) (os.FileInfo, error) { return nil, os.ErrNotExist }
+	m.osMkdirAll = func(path string, perm os.FileMode) error { return nil }
+	m.osReadFile = func(name string) ([]byte, error) { return nil, os.ErrNotExist }
+	m.osWriteFile = func(name string, data []byte, perm os.FileMode) error {
+		return errors.New("disk full")
+	}
+	// Mock osRemove for the .write_test file
+	m.osRemove = func(name string) error { return nil }
+	m.osOpenFile = func(name string, flag int, perm os.FileMode) (*os.File, error) {
+		// Mock file creation - return a dummy file descriptor
+		return &os.File{}, nil
+	}
+
+	err := updateActionCount(m, "testAction")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to write to temporary file: disk full")
+}
+
+func testHandlesRenameError(t *testing.T, dir string, filePath string) {
+	// Override global mcpDir for this test
+	oldMcpDir := mcpDir
+	mcpDir = dir
+	defer func() { mcpDir = oldMcpDir }()
+
+	m := NewMcpActions()
+	removed := false
+	removedTestFile := false
+	m.osStat = func(name string) (os.FileInfo, error) { return nil, nil }
+	m.osMkdirAll = func(path string, perm os.FileMode) error { return nil }
+	m.osReadFile = func(name string) ([]byte, error) { return nil, nil }
+	m.osWriteFile = func(name string, data []byte, perm os.FileMode) error {
+		return nil
+	}
+	m.osRename = func(oldpath, newpath string) error {
+		return errors.New("rename failed")
+	}
+	m.osRemove = func(name string) error {
+		if name == fmt.Sprintf("%s.%d.tmp", filePath, os.Getpid()) {
+			removed = true
+			return nil
+		}
+		if name == dir+"/.write_test" {
+			removedTestFile = true
+			return nil
+		}
+		t.Fatalf("osRemove called with unexpected file: %s", name)
+		return nil
+	}
+	m.osOpenFile = func(name string, flag int, perm os.FileMode) (*os.File, error) {
+		// Mock file creation for write test
+		return &os.File{}, nil
+	}
+
+	err := updateActionCount(m, "testAction")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "rename failed")
+	assert.True(t, removed, "temporary file should be removed on rename failure")
+	assert.True(t, removedTestFile, "test file should be removed")
+}
+
+func TestUpdateActionCount(t *testing.T) {
+	dir, err := os.MkdirTemp("", "suseconnect-mcp-test")
+	assert.NoError(t, err)
+	defer os.RemoveAll(dir)
+	filePath := dir + "/suseconnectmcp"
+
+	t.Run("increment count of specific action", func(t *testing.T) {
+		testIncCount(t)
+	})
+
+	t.Run("creates new file and adds action", func(t *testing.T) {
+		testCreatesNewFileAndAddsAction(t, dir, filePath)
+	})
+
+	t.Run("adds to existing file", func(t *testing.T) {
+		testAddsToExistingFile(t, dir, filePath)
+	})
+
+	t.Run("handles write error", func(t *testing.T) {
+		testHandlesWriteError(t, dir, filePath)
+	})
+
+	t.Run("handles rename error", func(t *testing.T) {
+		testHandlesRenameError(t, dir, filePath)
+	})
 }

--- a/internal/collectors/config.go
+++ b/internal/collectors/config.go
@@ -101,11 +101,14 @@ var collectorsRegistry = map[string]CollectorRegistryEntry{
 		Metadata:  CollectorMetadata{DefaultEnabled: true, Mandatory: true, Type: SystemInfoCollector},
 		Collector: HA{},
 	},
-
 	// Optional collectors
 	"pci_data": {
 		Metadata:         CollectorMetadata{DefaultEnabled: true, Mandatory: false, Type: ProfileCollector},
 		CollectorFactory: func(updateDataIDs bool) Collector { return PCI{UpdateDataIDs: updateDataIDs} },
+	},
+	"mcp_stats": {
+		Metadata:         CollectorMetadata{DefaultEnabled: true, Mandatory: false, Type: ProfileCollector},
+		CollectorFactory: func(updateDataIDs bool) Collector { return MCP{UpdateDataIDs: updateDataIDs} },
 	},
 	"mod_list": {
 		Metadata:         CollectorMetadata{DefaultEnabled: true, Mandatory: false, Type: ProfileCollector},

--- a/internal/collectors/mcp.go
+++ b/internal/collectors/mcp.go
@@ -1,0 +1,45 @@
+package collectors
+
+import (
+	"encoding/json"
+	"os"
+
+	"github.com/SUSE/connect-ng/internal/util"
+	"github.com/SUSE/connect-ng/pkg/profiles"
+)
+
+const mcpChecksumFile = "mcp-profile-id"
+const mcpTag = "mcp_stats"
+const mcpPath = "/var/lib/suseconnect-mcp/suseconnectmcp"
+
+var mcpOsReadfile = os.ReadFile
+
+type Action struct {
+	Name  string `json:"name"`
+	Count int    `json:"count"`
+}
+
+type MCP struct {
+	UpdateDataIDs bool
+}
+
+func getSuseconnectmcpData(inputStream []byte) ([]Action, error) {
+	var actions []Action
+	err := json.Unmarshal(inputStream, &actions)
+	if err != nil {
+		return nil, err
+	}
+	return actions, nil
+}
+
+func (mcp MCP) run(arch string) (Result, error) {
+	util.Debug.Print("mcp.UpdateDataIDs: ", mcp.UpdateDataIDs)
+	output, err := mcpOsReadfile(mcpPath)
+	if err != nil {
+		return Result{}, err
+	}
+	mcpData, _ := getSuseconnectmcpData(output)
+	result, err := profiles.BuildProfile(mcp.UpdateDataIDs, mcpTag, mcpChecksumFile, mcpData)
+
+	return result, err
+}

--- a/internal/collectors/mcp_test.go
+++ b/internal/collectors/mcp_test.go
@@ -1,0 +1,100 @@
+package collectors
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/SUSE/connect-ng/pkg/profiles"
+	"github.com/stretchr/testify/assert"
+)
+
+var mcpDataBlob profiles.Profile
+var mcpTestData string
+
+func setupMcpTestData() {
+	testProfilePath, _ := os.MkdirTemp("", "suseconnect-*")
+	profiles.SetProfileFilePath(testProfilePath + "/")
+
+	mcpTestData = `[{"name":"RegistrationStatus","count":1}]`
+	var actions []Action
+	_ = json.Unmarshal([]byte(mcpTestData), &actions)
+	mcpDataBlob.Data = actions
+
+	jsonBytes, _ := json.Marshal(mcpDataBlob.Data)
+	hash := sha256.Sum256(jsonBytes)
+	mcpDataBlob.Id = hex.EncodeToString(hash[:])
+}
+
+func mockMcpOsReadfile(t *testing.T, expectedPath string, content string, err error) {
+	mcpOsReadfile = func(path string) ([]byte, error) {
+		assert.Equal(t, expectedPath, path)
+		return []byte(content), err
+	}
+	t.Cleanup(func() { mcpOsReadfile = os.ReadFile })
+}
+
+func TestMCPRunSuccessNoUpdate(t *testing.T) {
+	assert := assert.New(t)
+	setupMcpTestData()
+	mockMcpOsReadfile(t, mcpPath, mcpTestData, nil)
+	expected := Result{mcpTag: mcpDataBlob}
+
+	collector := MCP{UpdateDataIDs: false}
+	result, err := collector.run(ARCHITECTURE_X86_64)
+	assert.Equal(expected, result)
+	assert.Nil(err)
+}
+
+func TestMCPRunSuccessUpdate(t *testing.T) {
+	assert := assert.New(t)
+	setupMcpTestData()
+	mockMcpOsReadfile(t, mcpPath, mcpTestData, nil)
+	expected := Result{mcpTag: mcpDataBlob}
+
+	collector := MCP{UpdateDataIDs: true}
+	result, err := collector.run(ARCHITECTURE_X86_64)
+
+	assert.Equal(expected, result)
+	assert.Nil(err)
+}
+
+func TestMCPRunSumsMatch(t *testing.T) {
+	assert := assert.New(t)
+	setupMcpTestData()
+	mockMcpOsReadfile(t, mcpPath, mcpTestData, nil)
+
+	// Prime the cache with the expected ID so that the checksum matches
+	cacheFilePath := filepath.Join(profiles.GetProfileFilePath(), mcpChecksumFile)
+	err := os.WriteFile(cacheFilePath, []byte(mcpDataBlob.Id), 0644)
+	assert.Nil(err)
+
+	collector := MCP{UpdateDataIDs: true}
+	result, err := collector.run(ARCHITECTURE_X86_64)
+	fmt.Println(result)
+
+	var expectedDataBlob profiles.Profile
+	expectedDataBlob.Id = mcpDataBlob.Id
+	expected := Result{mcpTag: expectedDataBlob}
+
+	assert.Equal(expected, result)
+	assert.Nil(err)
+}
+
+func TestMCPRunFail(t *testing.T) {
+	assert := assert.New(t)
+
+	mockMcpOsReadfile(t, mcpPath, "", fmt.Errorf("forced error"))
+	expected := Result{}
+
+	collector := MCP{}
+	result, err := collector.run(ARCHITECTURE_X86_64)
+
+	profiles.DeleteProfileCache("*")
+	assert.Equal(expected, result)
+	assert.ErrorContains(err, "forced error")
+}


### PR DESCRIPTION
https://jira.suse.com/browse/SCC-784

Investigation Spike - Telemetry/instrumentation of MCP-connect

To collect metrics/statistics about how customers are using features in the suseconnect mcp server

- Added a function module in susconnect_mcp.go which creates a suseconnectmcp file in /var/lib/suseconnect-mcp folder and stores mcp action name and count of how many times it is called in a struct .
            type Action struct {
                        Name  string `json:"name"`
                        Count int    `json:"count"`
            }


- Added a new profile mcp_stats which converts the data blob in file /var/lib/suseconnect-mcp/suseconnectmcp to sha256 and stores it in /run/suseconnect/mcp-profile-id

**How to Test**

- Set up the susseconnect-mcp server using the instructions in merged PR https://github.com/SUSE/connect-ng/pull/351

- use the tools for example to answer "What is the registration status of my system" and other Actions. This should create file suseconnectmcp in /var/lib/suseconnect-mcp

- Clone happy-customer and pull PR https://github.com/SUSE/happy-customer/pull/9241 . Start the glue server.
- Now when you execute keepalive command it should create file /run/suseconnect/mcp-profile-id which has the checksum of the data blob stored in /var/lib/suseconnect-mcp/suseconnectmcp