### PR TITLE
Fix problem where Product Friendly Name passed to zypper insted of internal name

### DIFF
--- a/build/packaging/suseconnect-ng.changes
+++ b/build/packaging/suseconnect-ng.changes
@@ -2,7 +2,7 @@
 Mon Jun 15 16:29:05 UTC 2026 - Earl Sampson <esampson@suse.com>
 
 - Update version to 1.23.0 (pre):
-
+  - Use product identifier for product migrations. (bsc#1268596)
 -------------------------------------------------------------------
 Wed Jun 10 18:43:58 UTC 2026 - Earl Sampson <esampson@suse.com>
 

--- a/cmd/zypper-migration/migration.go
+++ b/cmd/zypper-migration/migration.go
@@ -400,7 +400,7 @@ func checkSystemProducts(api connect.WrappedAPI, rollbackOnFailure, autoImportRe
 	releasePackageMissing := false
 	for _, p := range systemProducts {
 		// if a release package for registered product is missing -> try install it
-		err := zypper.InstallReleasePackage(p.Name, autoImportRepoKeys)
+		err := zypper.InstallReleasePackage(p.Identifier, autoImportRepoKeys)
 		if err != nil {
 			releasePackageMissing = true
 			QuietOut.Printf("Can't install release package for registered product %s\n", p.Name)
@@ -643,7 +643,7 @@ func migrateSystem(opts *connect.Options, migration connect.MigrationPath, baseU
 // containsProduct returns true if given slice of products contains one with given name.
 func containsProduct(products []registration.Product, name string) bool {
 	for _, p := range products {
-		if p.Name == name {
+		if p.Identifier == name {
 			return true
 		}
 	}


### PR DESCRIPTION
Migrations from opensuse leap 16.1 to SLES 16.1 are failing because zypper-migrate wss not updated
to use the product identifier.
  
bsc#1268596


To test:

1. install opensuse leap 16.1
2. git checkout origin/1268596
3. make build
4. copy  out/zypper-migration leap 16.1 system /tmp
5. register system "suseconnect -r XXXXXXXXXXXX"
6. sudo zypper rm openSUSE-build-key-1.0-lp161.2.2.x86_64
7. on leap 16.1 "sudo /tmp/zypper-migration --allow-vendor-change"

With these direction the migrate will pass. openSUSE-build-key-1.0-lp161.2.2.x86_64 has a file conflict with PackageHub-release-16.1-160099.11.1.x86_64 (PackageHub-16.1 file 
/usr/lib/rpm/gnupg/keys/gpg-pubkey-287a0027-682477e3.asc

Not sure how that needs to be handled.




