### PR TITLE
Build package with Go 1.26 toolchain

### DIFF
--- a/.github/workflows/agama.yml
+++ b/.github/workflows/agama.yml
@@ -17,7 +17,7 @@ jobs:
     name: Build SUSE/connect-ng inputs required by Agama
     runs-on: ubuntu-latest
     container:
-      image: registry.suse.com/bci/golang:1.24-openssl
+      image: registry.suse.com/bci/golang:1.26-openssl
       options: --user root --privileged
 
     steps:

--- a/.github/workflows/build-rpm.yml
+++ b/.github/workflows/build-rpm.yml
@@ -12,7 +12,7 @@ jobs:
   build-rpm:
     runs-on: ubuntu-latest
     container:
-      image: registry.suse.com/bci/golang:1.24-openssl
+      image: registry.suse.com/bci/golang:1.26-openssl
       options: --user root --privileged
 
     steps:

--- a/.github/workflows/features.yml
+++ b/.github/workflows/features.yml
@@ -15,7 +15,7 @@ jobs:
   feature-tests:
     runs-on: ubuntu-latest
     container:
-      image: registry.suse.com/bci/golang:1.24-openssl
+      image: registry.suse.com/bci/golang:1.26-openssl
       options: --user root --privileged
 
     steps:

--- a/.github/workflows/lint-unit.yml
+++ b/.github/workflows/lint-unit.yml
@@ -6,7 +6,7 @@ jobs:
   unit-tests:
     runs-on: ubuntu-latest
     container:
-      image: registry.suse.com/bci/golang:1.24-openssl
+      image: registry.suse.com/bci/golang:1.26-openssl
 
     steps:
       - uses: actions/checkout@v4

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ GOFLAGS       = -v -mod=vendor
 BINFLAGS      = -buildmode=pie
 SOFLAGS       = -buildmode=c-shared
 
-GOCONTAINER   = registry.suse.com/bci/golang:1.24-openssl
+GOCONTAINER   = registry.suse.com/bci/golang:1.26-openssl
 RUSTCONTAINER = registry.suse.com/bci/rust:1.95
 CRM           = docker run --rm $(if $(filter true,$(strip $(INTERACTIVE))),-it) --privileged
 ENVFILE       = .env

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ This will create a `out/suseconnect` binary.
 ### Build in a container
 If you don't have a go compiler installed, you can run the build in a container:
 ```
-docker run --rm -v $(pwd):/connect registry.suse.com/bci/golang:1.24-openssl sh -c "git config --global --add safe.directory /connect; cd /connect; make vendor build"
+docker run --rm -v $(pwd):/connect registry.suse.com/bci/golang:1.26-openssl sh -c "git config --global --add safe.directory /connect; cd /connect; make vendor build"
 ```
 Or you can use the `bci-build` Makefile target:
 ```
@@ -366,7 +366,7 @@ specified with the `--workflows` (`-W`) option, e.g.
 ```bash
 $ act -W .github/workflows/agama.yml pull_request
 [agama tests/Build SUSE/connect-ng inputs required by Agama] ⭐ Run Set up job
-[agama tests/Build SUSE/connect-ng inputs required by Agama] 🚀  Start image=registry.suse.com/bci/golang:1.24-openssl
+[agama tests/Build SUSE/connect-ng inputs required by Agama] 🚀  Start image=registry.suse.com/bci/golang:1.26-openssl
 ...
 [agama tests/Run agama rust tests                          ] Cleaning up container for job Run agama rust tests
 [agama tests/Run agama rust tests                          ]   ✅  Success - Complete job
@@ -383,7 +383,7 @@ depends upon, as follows:
 ```bash
 $ gh act -j run-agama-rust-tests
 [agama tests/Build SUSE/connect-ng inputs required by Agama] ⭐ Run Set up job
-[agama tests/Build SUSE/connect-ng inputs required by Agama] 🚀  Start image=registry.suse.com/bci/golang:1.24-openssl
+[agama tests/Build SUSE/connect-ng inputs required by Agama] 🚀  Start image=registry.suse.com/bci/golang:1.26-openssl
 ...
 [agama tests/Run agama rust tests                          ] Cleaning up container for job Run agama rust tests
 [agama tests/Run agama rust tests                          ]   ✅  Success - Complete job

--- a/build/packaging/suseconnect-ng.changes
+++ b/build/packaging/suseconnect-ng.changes
@@ -3,6 +3,9 @@ Mon Jun 15 16:29:05 UTC 2026 - Earl Sampson <esampson@suse.com>
 
 - Update version to 1.23.0 (pre):
   - Use product identifier for product migrations. (bsc#1268596)
+  - Switch to using go1.26-openssl as the default Go version to
+    install to support building the package (jsc#SCC-843).
+
 -------------------------------------------------------------------
 Wed Jun 10 18:43:58 UTC 2026 - Earl Sampson <esampson@suse.com>
 

--- a/build/packaging/suseconnect-ng.spec
+++ b/build/packaging/suseconnect-ng.spec
@@ -30,11 +30,11 @@ Source1:        %{name}-rpmlintrc
 Source2:        vendor.tar.xz
 
 # Build against latest golang in Tumbleweed and
-# go1.24-openssl on all other distributions
+# go1.26-openssl on all other distributions
 %if 0%{?suse_version} == 1699
 BuildRequires:  golang(API)
 %else
-BuildRequires:  go1.24-openssl
+BuildRequires:  go1.26-openssl
 %endif
 
 BuildRequires:  ruby-devel

--- a/features/README.md
+++ b/features/README.md
@@ -18,7 +18,7 @@ If you do not want to run a full RPM build process you can do the following:
 ```
  # Make sure your .env is populated!
  $ cp .env-example .env
- $ docker run --rm --privileged --env-file .env -ti -v $(pwd):/connect registry.suse.com/bci/golang:1.24-openssl
+ $ docker run --rm --privileged --env-file .env -ti -v $(pwd):/connect registry.suse.com/bci/golang:1.26-openssl
  > git config --global --add safe.directory /connect
  > cd /connect
  > make build
@@ -70,7 +70,7 @@ You will need a customised container image which has systemd installed which
 can be accomplished using a Dockerfile like the following:
 
 ```dockerfile
-FROM registry.suse.com/bci/golang:1.24-openssl
+FROM registry.suse.com/bci/golang:1.26-openssl
 
 # Install systemd and make
 RUN zypper -n install \

--- a/third_party/Dockerfile.yast
+++ b/third_party/Dockerfile.yast
@@ -1,5 +1,5 @@
 # build suseconnect in a SLE BCI golang container
-FROM registry.suse.com/bci/golang:1.24-openssl AS builder
+FROM registry.suse.com/bci/golang:1.26-openssl AS builder
 
 COPY . /connect-ng
 


### PR DESCRIPTION
The SUSE/connect-ng project continues to be based upon the Go 1.24 language version, so the version in the go.mod file is not being changed.

Update the build/packaging/suseconnect-ng.spec BuildRequires to use go1.26-openssl as the build toolchain to use when building.

Update all SLE BCI Golang container versions to use go1.26-openssl.

Add a build/packaging/suseconnect-ng.changes entry in the v1.23 block to track this change.