### PR TITLE
Add sub info helpers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,7 +124,7 @@ build: clean out internal/connect/version.txt
 	$(GO) build $(GOFLAGS) $(BINFLAGS) $(call cover-bin-flags) $(OUT) github.com/SUSE/connect-ng/cmd/validate-offline-certificate
 	$(GO) build $(GOFLAGS) $(BINFLAGS) $(call cover-bin-flags) $(OUT) github.com/SUSE/connect-ng/cmd/offline-register-api
 	$(GO) build $(GOFLAGS) $(BINFLAGS) $(call cover-bin-flags) $(OUT) github.com/SUSE/connect-ng/cmd/suseconnect-mcp
-	$(GO) build $(GOFLAGS) $(BINFLAGS) $(OUT) github.com/SUSE/connect-ng/cmd/subscription-info-demo
+	$(GO) build $(GOFLAGS) $(BINFLAGS) $(call cover-bin-flags) $(OUT) github.com/SUSE/connect-ng/cmd/subscription-info-demo
 	$(GO) build $(GOFLAGS) $(SOFLAGS) $(call cover-lib-flags) $(OUT)/libsuseconnect.so github.com/SUSE/connect-ng/third_party/libsuseconnect
 
 bci-build:

--- a/Makefile
+++ b/Makefile
@@ -124,6 +124,7 @@ build: clean out internal/connect/version.txt
 	$(GO) build $(GOFLAGS) $(BINFLAGS) $(call cover-bin-flags) $(OUT) github.com/SUSE/connect-ng/cmd/validate-offline-certificate
 	$(GO) build $(GOFLAGS) $(BINFLAGS) $(call cover-bin-flags) $(OUT) github.com/SUSE/connect-ng/cmd/offline-register-api
 	$(GO) build $(GOFLAGS) $(BINFLAGS) $(call cover-bin-flags) $(OUT) github.com/SUSE/connect-ng/cmd/suseconnect-mcp
+	$(GO) build $(GOFLAGS) $(BINFLAGS) $(OUT) github.com/SUSE/connect-ng/cmd/subscription-info-demo
 	$(GO) build $(GOFLAGS) $(SOFLAGS) $(call cover-lib-flags) $(OUT)/libsuseconnect.so github.com/SUSE/connect-ng/third_party/libsuseconnect
 
 bci-build:

--- a/cmd/subscription-info-demo/main.go
+++ b/cmd/subscription-info-demo/main.go
@@ -1,0 +1,149 @@
+package main
+
+import (
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/SUSE/connect-ng/pkg/connection"
+	"github.com/SUSE/connect-ng/pkg/registration"
+)
+
+func bold(format string, args ...any) {
+	fmt.Printf("\033[1m"+format+"\033[0m", args...)
+}
+
+func main() {
+	var saveInfoPath string
+	var saveProductsPath string
+
+	flag.StringVar(&saveInfoPath, "save-info", "", "Save subscription info JSON to file")
+	flag.StringVar(&saveProductsPath, "save-products", "", "Save subscription products JSON to file")
+	flag.Parse()
+
+	fmt.Println("subscription-info-demo: Demonstrates FetchSubscriptionInfo and FetchSubscriptionProducts")
+	fmt.Println()
+
+	regcode := os.Getenv("REGCODE")
+	if regcode == "" {
+		fmt.Fprintln(os.Stderr, "Error: REGCODE environment variable is required")
+		fmt.Fprintln(os.Stderr, "Usage: REGCODE=your-reg-code ./subscription-info-demo [flags]")
+		fmt.Fprintln(os.Stderr, "Flags:")
+		flag.PrintDefaults()
+		os.Exit(1)
+	}
+
+	// Setup connection
+	opts := connection.DefaultOptions("subscription-info-demo", "1.0", "US")
+
+	if url := os.Getenv("SCC_HOST"); url != "" {
+		opts.URL = url
+	}
+
+	if disableTokens := os.Getenv("DISABLE_TOKEN_HANDLING"); disableTokens != "" {
+		opts.DisableTokenHandling = true
+	}
+
+	if certificatePath := os.Getenv("API_CERT"); certificatePath != "" {
+		crt, certReadErr := os.ReadFile(certificatePath)
+		if certReadErr != nil {
+			fmt.Fprintf(os.Stderr, "Error reading certificate: %v\n", certReadErr)
+			os.Exit(1)
+		}
+
+		block, _ := pem.Decode(crt)
+		if block == nil {
+			fmt.Fprintln(os.Stderr, "Could not decode the server's certificate")
+			os.Exit(1)
+		}
+
+		cert, parseErr := x509.ParseCertificate(block.Bytes)
+		if parseErr != nil {
+			fmt.Fprintf(os.Stderr, "Error parsing certificate: %v\n", parseErr)
+			os.Exit(1)
+		}
+
+		opts.Certificate = cert
+	}
+
+	conn := connection.New(opts, connection.NoCredentials{})
+
+	// Fetch subscription info
+	bold("=== Fetching Subscription Info ===\n\n")
+	info, infoErr := registration.FetchSubscriptionInfo(conn, regcode)
+	if infoErr != nil {
+		fmt.Fprintf(os.Stderr, "Error fetching subscription info: %v\n", infoErr)
+		os.Exit(1)
+	}
+
+	// Pretty print subscription info
+	infoJSON, _ := json.MarshalIndent(info, "", "  ")
+	fmt.Println(string(infoJSON))
+
+	// Save to file if requested
+	if saveInfoPath != "" {
+		if err := os.WriteFile(saveInfoPath, infoJSON, 0644); err != nil {
+			fmt.Fprintf(os.Stderr, "Error saving info to %s: %v\n", saveInfoPath, err)
+			os.Exit(1)
+		}
+		fmt.Printf("\n✓ Saved subscription info to %s\n", saveInfoPath)
+	}
+
+	fmt.Println()
+	bold("Subscription Details:\n")
+	fmt.Printf("  Kind:          %s\n", info.Kind)
+	fmt.Printf("  Name:          %s\n", info.Name)
+	fmt.Printf("  Starts At:     %s\n", info.StartsAt.Format("2006-01-02 15:04:05"))
+	fmt.Printf("  Expires At:    %s\n", info.ExpiresAt.Format("2006-01-02 15:04:05"))
+	fmt.Printf("  Limit:         %d\n", info.Limit)
+	fmt.Printf("  Notifications: %s\n", info.Notifications)
+	fmt.Println()
+	bold("Product Classes (%d):\n", len(info.ProductClasses))
+	for i, pc := range info.ProductClasses {
+		fmt.Printf("  [%d] %s\n", i+1, pc.Name)
+		fmt.Printf("      %s\n", pc.Description)
+	}
+
+	fmt.Println()
+	fmt.Println()
+
+	// Fetch subscription products
+	bold("=== Fetching Subscription Products ===\n\n")
+	products, productsErr := registration.FetchSubscriptionProducts(conn, regcode)
+	if productsErr != nil {
+		fmt.Fprintf(os.Stderr, "Error fetching subscription products: %v\n", productsErr)
+		os.Exit(1)
+	}
+
+	// Pretty print products
+	productsJSON, _ := json.MarshalIndent(products, "", "  ")
+	fmt.Println(string(productsJSON))
+
+	// Save to file if requested
+	if saveProductsPath != "" {
+		if err := os.WriteFile(saveProductsPath, productsJSON, 0644); err != nil {
+			fmt.Fprintf(os.Stderr, "Error saving products to %s: %v\n", saveProductsPath, err)
+			os.Exit(1)
+		}
+		fmt.Printf("\n✓ Saved subscription products to %s\n", saveProductsPath)
+	}
+
+	fmt.Println()
+	bold("Products Summary (%d total):\n", len(products))
+	for i, product := range products {
+		fmt.Printf("  [%d] %s (%s)\n", i+1, product.Name, product.Identifier)
+		fmt.Printf("      Version: %s, Arch: %s\n", product.Version, product.Arch)
+		if len(product.Repositories) > 0 {
+			fmt.Printf("      Repositories: %d\n", len(product.Repositories))
+		}
+		if len(product.Extensions) > 0 {
+			fmt.Printf("      Extensions: %d\n", len(product.Extensions))
+		}
+		fmt.Println()
+	}
+
+	bold("✓ Demo complete\n")
+}

--- a/pkg/registration/subscription_info.go
+++ b/pkg/registration/subscription_info.go
@@ -1,6 +1,11 @@
 package registration
 
-import "time"
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/SUSE/connect-ng/pkg/connection"
+)
 
 // A subscription used in the offline registration workflow
 type SubscriptionInfo struct {
@@ -18,4 +23,52 @@ type SubscriptionInfo struct {
 type ProductClass struct {
 	Name        string `json:"name"`
 	Description string `json:"description"`
+}
+
+// FetchSubscriptionInfo queries /connect/subscriptions/info to retrieve
+// comprehensive subscription metadata including start/expire times and product classes.
+// Returns a single SubscriptionInfo object with the subscription details.
+func FetchSubscriptionInfo(conn connection.Connection, regcode string) (*SubscriptionInfo, error) {
+	request, buildErr := conn.BuildRequest("GET", "/connect/subscriptions/info", nil)
+	if buildErr != nil {
+		return nil, buildErr
+	}
+
+	connection.AddRegcodeAuth(request, regcode)
+
+	response, doErr := conn.Do(request)
+	if doErr != nil {
+		return nil, doErr
+	}
+
+	var info SubscriptionInfo
+	if err := json.Unmarshal(response, &info); err != nil {
+		return nil, err
+	}
+
+	return &info, nil
+}
+
+// FetchSubscriptionProducts queries /connect/subscriptions/products to retrieve
+// the full product list covered by the subscription. Returns an array of Product objects
+// with complete details (repositories, extensions, etc).
+func FetchSubscriptionProducts(conn connection.Connection, regcode string) ([]Product, error) {
+	request, buildErr := conn.BuildRequest("GET", "/connect/subscriptions/products", nil)
+	if buildErr != nil {
+		return nil, buildErr
+	}
+
+	connection.AddRegcodeAuth(request, regcode)
+
+	response, doErr := conn.Do(request)
+	if doErr != nil {
+		return nil, doErr
+	}
+
+	var products []Product
+	if err := json.Unmarshal(response, &products); err != nil {
+		return nil, err
+	}
+
+	return products, nil
 }

--- a/pkg/registration/subscription_info_test.go
+++ b/pkg/registration/subscription_info_test.go
@@ -1,0 +1,98 @@
+package registration
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/SUSE/connect-ng/pkg/connection"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestFetchSubscriptionInfoSuccess(t *testing.T) {
+	assert := assert.New(t)
+
+	conn, _ := connection.NewMockConnectionWithCredentials()
+
+	payload := fixture(t, "pkg/registration/subscription_info.json")
+	conn.On("Do", mock.Anything).Return(payload, nil).Run(
+		checkAuthByRegcode(t, "test-regcode"),
+	)
+
+	info, err := FetchSubscriptionInfo(conn, "test-regcode")
+	assert.NoError(err)
+	assert.NotNil(info)
+	assert.Equal("full", info.Kind)
+	assert.Equal("SUSE Linux Enterprise Server with Rancher, x86_64, 3-Year Subscription", info.Name)
+	assert.Equal(50, info.Limit)
+	assert.Equal("all", info.Notifications)
+	assert.Len(info.ProductClasses, 2)
+	assert.Equal("RANCHER-X86", info.ProductClasses[0].Name)
+	assert.Equal("SUSE Rancher Manager for x86_64 architecture", info.ProductClasses[0].Description)
+	assert.Equal("7261", info.ProductClasses[1].Name)
+	assert.Equal("SUSE Linux Enterprise Server (x86_64)", info.ProductClasses[1].Description)
+}
+
+func TestFetchSubscriptionInfoAPIError(t *testing.T) {
+	assert := assert.New(t)
+
+	conn, _ := connection.NewMockConnectionWithCredentials()
+	conn.On("Do", mock.Anything).Return([]byte{}, errors.New("Invalid regcode"))
+
+	_, err := FetchSubscriptionInfo(conn, "invalid-regcode")
+	assert.Error(err)
+}
+
+func TestFetchSubscriptionInfoMalformedJSON(t *testing.T) {
+	assert := assert.New(t)
+
+	conn, _ := connection.NewMockConnectionWithCredentials()
+	conn.On("Do", mock.Anything).Return([]byte("{invalid json}"), nil)
+
+	_, err := FetchSubscriptionInfo(conn, "test-regcode")
+	assert.Error(err)
+}
+
+func TestFetchSubscriptionProductsSuccess(t *testing.T) {
+	assert := assert.New(t)
+
+	conn, _ := connection.NewMockConnectionWithCredentials()
+
+	payload := fixture(t, "pkg/registration/subscription_products.json")
+	conn.On("Do", mock.Anything).Return(payload, nil).Run(
+		checkAuthByRegcode(t, "test-regcode"),
+	)
+
+	products, err := FetchSubscriptionProducts(conn, "test-regcode")
+	assert.NoError(err)
+	assert.Len(products, 3)
+	assert.Equal("SUSE_SLES-SP2-migration", products[0].Identifier)
+	assert.Equal("SUSE Linux Enterprise Server", products[0].Name)
+	assert.Equal("i686", products[0].Arch)
+	assert.Len(products[0].Extensions, 1)
+	assert.Len(products[0].Repositories, 8)
+	assert.Equal("rancher", products[1].Identifier)
+	assert.Equal("SUSE Rancher", products[1].Name)
+	assert.Equal("rancher-prime", products[2].Identifier)
+	assert.Equal("SUSE Rancher Prime", products[2].Name)
+}
+
+func TestFetchSubscriptionProductsAPIError(t *testing.T) {
+	assert := assert.New(t)
+
+	conn, _ := connection.NewMockConnectionWithCredentials()
+	conn.On("Do", mock.Anything).Return([]byte{}, errors.New("Invalid regcode"))
+
+	_, err := FetchSubscriptionProducts(conn, "invalid-regcode")
+	assert.Error(err)
+}
+
+func TestFetchSubscriptionProductsMalformedJSON(t *testing.T) {
+	assert := assert.New(t)
+
+	conn, _ := connection.NewMockConnectionWithCredentials()
+	conn.On("Do", mock.Anything).Return([]byte("[{invalid json}]"), nil)
+
+	_, err := FetchSubscriptionProducts(conn, "test-regcode")
+	assert.Error(err)
+}

--- a/testdata/pkg/registration/subscription_info.json
+++ b/testdata/pkg/registration/subscription_info.json
@@ -1,0 +1,18 @@
+{
+  "kind": "full",
+  "name": "SUSE Linux Enterprise Server with Rancher, x86_64, 3-Year Subscription",
+  "starts_at": "2024-01-15T00:00:00.000Z",
+  "expires_at": "2027-01-15T00:00:00.000Z",
+  "limit": 50,
+  "notifications": "all",
+  "product_classes": [
+    {
+      "name": "RANCHER-X86",
+      "description": "SUSE Rancher Manager for x86_64 architecture"
+    },
+    {
+      "name": "7261",
+      "description": "SUSE Linux Enterprise Server (x86_64)"
+    }
+  ]
+}

--- a/testdata/pkg/registration/subscription_products.json
+++ b/testdata/pkg/registration/subscription_products.json
@@ -1,0 +1,200 @@
+[
+  {
+    "id": 756,
+    "identifier": "SUSE_SLES-SP2-migration",
+    "name": "SUSE Linux Enterprise Server",
+    "version": "11.1",
+    "arch": "i686",
+    "isbase": true,
+    "friendly_name": "SUSE Linux Enterprise Server 11 SP1 i686 (Migration)",
+    "available": true,
+    "free": false,
+    "recommended": false,
+    "extensions": [
+      {
+        "id": 1192,
+        "identifier": "sle-smt",
+        "name": "SUSE Linux Enterprise Subscription Management Tool",
+        "version": "11.1",
+        "arch": "",
+        "isbase": false,
+        "friendly_name": "SUSE Linux Enterprise Subscription Management Tool 11 SP1",
+        "available": true,
+        "free": true,
+        "recommended": false,
+        "former_identifier": "sle-smt",
+        "product_type": "extension",
+        "ProductLine": "",
+        "release_stage": "released",
+        "repositories": [
+          {
+            "name": "SLE11-SP1-SMT-Updates",
+            "enabled": true,
+            "url": "https://updates.suse.com/repo/$RCE/SLE11-SP1-SMT-Updates/sle-11-x86_64/?credentials",
+            "distro_target": "sle-11-x86_64",
+            "description": "SLE11-SP1-SMT-Updates for sle-11-x86_64",
+            "autorefresh": true,
+            "installer_updates": false
+          },
+          {
+            "name": "SLE11-SP1-SMT-Pool",
+            "enabled": true,
+            "url": "https://updates.suse.com/repo/$RCE/SLE11-SP1-SMT-Pool/sle-11-s390x/?credentials",
+            "distro_target": "sle-11-s390x",
+            "description": "SLE11-SP1-SMT-Pool for sle-11-s390x",
+            "autorefresh": true,
+            "installer_updates": false
+          },
+          {
+            "name": "SLE11-SP1-SMT-Pool",
+            "enabled": true,
+            "url": "https://updates.suse.com/repo/$RCE/SLE11-SP1-SMT-Pool/sle-11-x86_64/?credentials",
+            "distro_target": "sle-11-x86_64",
+            "description": "SLE11-SP1-SMT-Pool for sle-11-x86_64",
+            "autorefresh": true,
+            "installer_updates": false
+          },
+          {
+            "name": "SLE11-SP1-SMT-Updates",
+            "enabled": true,
+            "url": "https://updates.suse.com/repo/$RCE/SLE11-SP1-SMT-Updates/sle-11-i586/?credentials",
+            "distro_target": "sle-11-i586",
+            "description": "SLE11-SP1-SMT-Updates for sle-11-i586",
+            "autorefresh": true,
+            "installer_updates": false
+          },
+          {
+            "name": "SLE11-SP1-SMT-Pool",
+            "enabled": true,
+            "url": "https://updates.suse.com/repo/$RCE/SLE11-SP1-SMT-Pool/sle-11-i586/?credentials",
+            "distro_target": "sle-11-i586",
+            "description": "SLE11-SP1-SMT-Pool for sle-11-i586",
+            "autorefresh": true,
+            "installer_updates": false
+          },
+          {
+            "name": "SLE11-SP1-SMT-Updates",
+            "enabled": true,
+            "url": "https://updates.suse.com/repo/$RCE/SLE11-SP1-SMT-Updates/sle-11-s390x/?credentials",
+            "distro_target": "sle-11-s390x",
+            "description": "SLE11-SP1-SMT-Updates for sle-11-s390x",
+            "autorefresh": true,
+            "installer_updates": false
+          }
+        ]
+      }
+    ],
+    "former_identifier": "SUSE_SLES-SP2-migration",
+    "product_type": "base",
+    "ProductLine": "",
+    "release_stage": "released",
+    "repositories": [
+      {
+        "name": "SLE11-SP1-Debuginfo-Pool",
+        "enabled": false,
+        "url": "https://updates.suse.com/repo/$RCE/SLE11-SP1-Debuginfo-Pool/sle-11-i586/?credentials",
+        "distro_target": "sle-11-i586",
+        "description": "SLE11-SP1-Debuginfo-Pool for sle-11-i586",
+        "autorefresh": true,
+        "installer_updates": false
+      },
+      {
+        "name": "SLE11-SP1-Debuginfo-Updates",
+        "enabled": false,
+        "url": "https://updates.suse.com/repo/$RCE/SLE11-SP1-Debuginfo-Updates/sle-11-i586/?credentials",
+        "distro_target": "sle-11-i586",
+        "description": "SLE11-SP1-Debuginfo-Updates for sle-11-i586",
+        "autorefresh": true,
+        "installer_updates": false
+      },
+      {
+        "name": "SLE11-SP2-Debuginfo-Core",
+        "enabled": false,
+        "url": "https://updates.suse.com/repo/$RCE/SLE11-SP2-Debuginfo-Core/sle-11-i586/?credentials",
+        "distro_target": "sle-11-i586",
+        "description": "SLE11-SP2-Debuginfo-Core for sle-11-i586",
+        "autorefresh": true,
+        "installer_updates": false
+      },
+      {
+        "name": "SLE11-WebYaST-SP2-Pool",
+        "enabled": false,
+        "url": "https://updates.suse.com/repo/$RCE/SLE11-WebYaST-SP2-Pool/sle-11-i586/?credentials",
+        "distro_target": "sle-11-i586",
+        "description": "SLE11-WebYaST-SP2-Pool for sle-11-i586",
+        "autorefresh": true,
+        "installer_updates": false
+      },
+      {
+        "name": "SLE11-SP2-Debuginfo-Updates",
+        "enabled": false,
+        "url": "https://updates.suse.com/repo/$RCE/SLE11-SP2-Debuginfo-Updates/sle-11-i586/?credentials",
+        "distro_target": "sle-11-i586",
+        "description": "SLE11-SP2-Debuginfo-Updates for sle-11-i586",
+        "autorefresh": true,
+        "installer_updates": false
+      },
+      {
+        "name": "SLES11-SP2-Updates",
+        "enabled": true,
+        "url": "https://updates.suse.com/repo/$RCE/SLES11-SP2-Updates/sle-11-i586/?credentials",
+        "distro_target": "sle-11-i586",
+        "description": "SLES11-SP2-Updates for sle-11-i586",
+        "autorefresh": true,
+        "installer_updates": false
+      },
+      {
+        "name": "SLE11-WebYaST-SP2-Updates",
+        "enabled": false,
+        "url": "https://updates.suse.com/repo/$RCE/SLE11-WebYaST-SP2-Updates/sle-11-i586/?credentials",
+        "distro_target": "sle-11-i586",
+        "description": "SLE11-WebYaST-SP2-Updates for sle-11-i586",
+        "autorefresh": true,
+        "installer_updates": false
+      },
+      {
+        "name": "SLES11-SP2-Core",
+        "enabled": true,
+        "url": "https://updates.suse.com/repo/$RCE/SLES11-SP2-Core/sle-11-i586/?credentials",
+        "distro_target": "sle-11-i586",
+        "description": "SLES11-SP2-Core for sle-11-i586",
+        "autorefresh": true,
+        "installer_updates": false
+      }
+    ]
+  },
+  {
+    "id": 2722,
+    "identifier": "rancher",
+    "name": "SUSE Rancher",
+    "version": "2.8.1",
+    "arch": "",
+    "isbase": true,
+    "friendly_name": "SUSE Rancher 2.8.1",
+    "available": true,
+    "free": false,
+    "recommended": false,
+    "former_identifier": "rancher",
+    "product_type": "base",
+    "ProductLine": "",
+    "shortname": "Rancher",
+    "release_stage": "released"
+  },
+  {
+    "id": 3396,
+    "identifier": "rancher-prime",
+    "name": "SUSE Rancher Prime",
+    "version": "2.12.10",
+    "arch": "",
+    "isbase": true,
+    "friendly_name": "SUSE Rancher Prime 2.12.10",
+    "available": true,
+    "free": false,
+    "recommended": false,
+    "former_identifier": "rancher-prime",
+    "product_type": "base",
+    "ProductLine": "",
+    "shortname": "Rancher Prime",
+    "release_stage": "released"
+  }
+]


### PR DESCRIPTION
This PR is related to a [Rancher focused issue](https://github.com/rancher/scc-operator/issues/29) related to Rancher users inputting RegCodes that doesn't cover Rancher. The users would like more feedback on why the RegCode was invalid.

Similarly in the future other ECM products will be able to register to SCC like Rancher does now. When that time comes if Rancher is able to detect that it is provisioning a downstream cluster with SUSE products which the RegCode for rancher covers then it should be able to "propagate" the RegCode to those downstreams. To do this we will need some awareness of what products a RegCode covers.

---

This PR replaces: https://github.com/SUSE/connect-ng/pull/406