### PR TITLE
Add bsc reference to go 1.26 toolchange .changes entry

### DIFF
--- a/build/packaging/suseconnect-ng.changes
+++ b/build/packaging/suseconnect-ng.changes
@@ -4,7 +4,7 @@ Mon Jun 15 16:29:05 UTC 2026 - Earl Sampson <esampson@suse.com>
 - Update version to 1.23.0 (pre):
   - Use product identifier for product migrations. (bsc#1268596)
   - Switch to using go1.26-openssl as the default Go version to
-    install to support building the package (jsc#SCC-843).
+    install to support building the package (jsc#SCC-843 bsc#1268900).
 
 -------------------------------------------------------------------
 Wed Jun 10 18:43:58 UTC 2026 - Earl Sampson <esampson@suse.com>


### PR DESCRIPTION
This will ensure that the bugzilla gets automatically updated when the suseconnect-ng v1.23.x gets released to the various streams.