### PR TITLE
zypper-migration support interactive package installation

### DIFF
--- a/build/packaging/suseconnect-ng.changes
+++ b/build/packaging/suseconnect-ng.changes
@@ -5,6 +5,8 @@ Mon Jun 15 16:29:05 UTC 2026 - Earl Sampson <esampson@suse.com>
   - Use product identifier for product migrations. (bsc#1268596)
   - Switch to using go1.26-openssl as the default Go version to
     install to support building the package (jsc#SCC-843 bsc#1268900).
+  - InstallReleasePackage interactive/noninteractive handling should
+    be consistent with DistUpgrade (bsc#1267478).
 
 -------------------------------------------------------------------
 Wed Jun 10 18:43:58 UTC 2026 - Earl Sampson <esampson@suse.com>

--- a/cmd/zypper-migration/migration.go
+++ b/cmd/zypper-migration/migration.go
@@ -77,6 +77,7 @@ func main() {
 		repo                     multiArg
 		download                 multiArg // using multiArg here to make flags simpler to visit
 		autoImportRepoKeys       bool
+		echo                     bool
 	)
 
 	flag.Usage = func() {
@@ -172,7 +173,9 @@ func main() {
 		// reset root (if set) as the update stack can be outside of
 		// the to be updated system
 		opts.FsRoot = ""
-		echo := util.SetSystemEcho(true)
+		if !nonInteractive {
+			echo = util.SetSystemEcho(true)
+		}
 		if pending, err := zypper.PatchCheck(true, quiet, verbose, nonInteractive, false); err != nil {
 			fmt.Printf("patch pre-check failed: %v\n", err)
 			os.Exit(1)
@@ -202,7 +205,9 @@ func main() {
 				os.Exit(1)
 			}
 		}
-		util.SetSystemEcho(echo)
+		if !nonInteractive {
+			util.SetSystemEcho(echo)
+		}
 		// restore root if needed
 		if fsRoot != "" {
 			opts.FsRoot = fsRoot
@@ -211,14 +216,18 @@ func main() {
 	QuietOut.Print("\n")
 
 	// This is only necessary, if we run with --root option
-	echo := util.SetSystemEcho(true)
+	if !nonInteractive {
+		echo = util.SetSystemEcho(true)
+	}
 	if err := zypper.RefreshRepos("", false, quiet, verbose, nonInteractive, autoImportRepoKeys); err != nil {
 		fmt.Println("repository refresh failed, exiting")
 		os.Exit(1)
 	}
-	util.SetSystemEcho(echo)
+	if !nonInteractive {
+		util.SetSystemEcho(echo)
+	}
 
-	systemProducts, err := checkSystemProducts(api, true, autoImportRepoKeys, opts)
+	systemProducts, err := checkSystemProducts(api, true, autoImportRepoKeys, nonInteractive, opts)
 	if err != nil {
 		fmt.Printf("Can't determine the list of installed products: %v\n", err)
 		os.Exit(1)
@@ -364,7 +373,7 @@ func main() {
 
 	// make sure all release packages are installed (bsc#1171652)
 	if err == nil {
-		_, err := checkSystemProducts(api, false, autoImportRepoKeys, opts)
+		_, err := checkSystemProducts(api, false, autoImportRepoKeys, nonInteractive, opts)
 		if err != nil {
 			fmt.Printf("Can't determine the list of installed products after migration: %v\n", err)
 			// the system has been sucessfully upgraded, zypper reported no error so
@@ -391,16 +400,22 @@ func main() {
 	}
 }
 
-func checkSystemProducts(api connect.WrappedAPI, rollbackOnFailure, autoImportRepoKeys bool, opts *connect.Options) ([]registration.Product, error) {
+func checkSystemProducts(api connect.WrappedAPI, rollbackOnFailure, autoImportRepoKeys bool, nonInteractive bool, opts *connect.Options) ([]registration.Product, error) {
+	var echo bool
 	systemProducts, err := connect.SystemProducts(api, opts)
 	if err != nil {
 		return systemProducts, err
 	}
-
 	releasePackageMissing := false
 	for _, p := range systemProducts {
 		// if a release package for registered product is missing -> try install it
-		err := zypper.InstallReleasePackage(p.Identifier, autoImportRepoKeys)
+		if !nonInteractive {
+			echo = util.SetSystemEcho(true)
+		}
+		err := zypper.InstallReleasePackage(p.Identifier, autoImportRepoKeys, nonInteractive)
+		if !nonInteractive {
+			util.SetSystemEcho(echo)
+		}
 		if err != nil {
 			releasePackageMissing = true
 			QuietOut.Printf("Can't install release package for registered product %s\n", p.Name)
@@ -672,6 +687,7 @@ func applyMigration(opts *connect.Options, migration connect.MigrationPath, base
 	quiet, verbose, nonInteractive, insecure, forceDisableRepos, autoAgreeLicenses, autoImportRepoKeys, failDupOnlyOnFatalErrors bool,
 	dupArgs []string) (bool, error) {
 
+	var echo bool
 	fsInconsistent := false
 
 	if err := zypper.Backup(); err != nil {
@@ -702,7 +718,9 @@ func applyMigration(opts *connect.Options, migration connect.MigrationPath, base
 		return fsInconsistent, err
 	}
 
-	echo := util.SetSystemEcho(true)
+	if !nonInteractive {
+		echo = util.SetSystemEcho(true)
+	}
 	if err := zypper.RefreshRepos(baseProductVersion, true, false, false, false, autoImportRepoKeys); err != nil {
 		return fsInconsistent, fmt.Errorf("Refresh of repositories failed: %v", err)
 	}
@@ -711,7 +729,9 @@ func applyMigration(opts *connect.Options, migration connect.MigrationPath, base
 	}
 
 	err = zypper.DistUpgrade(baseProductVersion, quiet, verbose, autoAgreeLicenses, nonInteractive, dupArgs)
-	util.SetSystemEcho(echo)
+	if !nonInteractive {
+		util.SetSystemEcho(echo)
+	}
 	if err != nil {
 		ze := err.(zypper.ZypperError)
 		// TODO: export connect.zypperErrCommit (8)?

--- a/internal/connect/client.go
+++ b/internal/connect/client.go
@@ -132,7 +132,7 @@ func registerProduct(conn connection.Connection, opts *Options, product registra
 	if installReleasePkg && !opts.SkipServiceInstall {
 		opts.Print("-> Installing release package ...")
 
-		if err := localInstallReleasePackage(product.Identifier, opts.AutoImportRepoKeys); err != nil {
+		if err := localInstallReleasePackage(product.Identifier, opts.AutoImportRepoKeys, true); err != nil {
 			return registration.Service{}, err
 		}
 	}

--- a/internal/zypper/zypper.go
+++ b/internal/zypper/zypper.go
@@ -233,7 +233,7 @@ func RefreshAllServices() error {
 }
 
 // InstallReleasePackage ensures the <product-id>-release package is installed.
-func InstallReleasePackage(identifier string, autoImportRepoKeys bool) error {
+func InstallReleasePackage(identifier string, autoImportRepoKeys bool, nonInteractive bool) error {
 	if identifier == "" {
 		return nil
 	}
@@ -255,8 +255,11 @@ func InstallReleasePackage(identifier string, autoImportRepoKeys bool) error {
 		validExitCodes = append(validExitCodes, zypperInfoReposSkipped)
 	}
 
-	args := []string{"--no-refresh", "--non-interactive", "install", "--no-recommends",
-		"--auto-agree-with-product-licenses", "-t", "product", identifier}
+	args := []string{"--no-refresh"}
+	if nonInteractive {
+		args = append(args, "--non-interactive")
+	}
+	args = append(args, []string{"install", "--no-recommends", "--auto-agree-with-product-licenses", "-t", "product", identifier}...)
 
 	if autoImportRepoKeys {
 		args = append([]string{"--gpg-auto-import-keys"}, args...)

--- a/internal/zypper/zypper_test.go
+++ b/internal/zypper/zypper_test.go
@@ -169,7 +169,7 @@ func TestInstallReleasePakage(t *testing.T) {
 		return nil, nil
 	}
 
-	err := InstallReleasePackage(identifier, false)
+	err := InstallReleasePackage(identifier, false, true)
 
 	assert.NoError(t, err)
 }
@@ -190,7 +190,7 @@ func TestInstallReleasePakageRpmFails(t *testing.T) {
 		return nil, nil
 	}
 
-	err := InstallReleasePackage(identifier, true)
+	err := InstallReleasePackage(identifier, true, false)
 
 	assert.NoError(t, err)
 }
@@ -210,7 +210,7 @@ func TestInstallReleasePakageZypperFails(t *testing.T) {
 		return nil, nil
 	}
 
-	err := InstallReleasePackage(identifier, true)
+	err := InstallReleasePackage(identifier, true, true)
 
 	assert.Error(t, err)
 }


### PR DESCRIPTION
zypper-migration while supporting the --non-interactive option, it defaults to interactive mode for number of zypper operations including dist-upgrade. However hardcoded "--non-interactive" when doing package installations.

Change code to support the interactive/non-interactive state in zypper.InstallReleasePackage.

Change is to make zypper.InstallReleasePackage handle  interactive/non-interactive in the same way as zypper. DistUpgrade. Change only effects use through zypper-migration, where the interactive state defaults to true. 
Since suseconnect does not provide a  --non-interactive option, calls from in internal/connect/client.go pass in nonInteractive==true to preserve existing behavior.

To test:
1: create Leap 15.6/16.0/16.1 VM.
2: build suseconnect rpms
3: copy suseconnect-ng and libsuseconnect rpms from ./artifacts
4: on VM:
4.1 install new suseconnect-ng and libsuseconnect (need to use zypper so zypper-migration is correctly installed
4.2: register the VM (sudo suseconnect -r REG_CODE)
4.3 sudo zypper migration
there will be a number of user prompts. notably:
```
Checking for file conflicts: [..error]
Detected 1 file conflict:

File /usr/lib/rpm/gnupg/keys/gpg-pubkey-287a0027-682477e3.asc
  from install of
     PackageHub-release-16.1-160099.11.1.x86_64 (PackageHub-16.1)
  conflicts with file from package
     openSUSE-build-key-1.0-lp161.3.1.x86_64 (@System)

File conflicts happen when two packages attempt to install files with the same name but different contents. If you continue, conflicting files will be replaced losing the previous content.
Continue? [yes/no] (no): 

```
answer yes will allow migration to proceed, no will block the package install and terminate the migration.
This prompt is the change in behavior from the existing code to this code. The existing code will output the message and terminate the migration. The new behavior is consistent with the 15.x "yast migration" behavior.