### PR TITLE
Check for unexpected flags or arguments on the command line.

### DIFF
--- a/build/packaging/suseconnect-ng.changes
+++ b/build/packaging/suseconnect-ng.changes
@@ -5,6 +5,8 @@ Mon Jun 15 16:29:05 UTC 2026 - Earl Sampson <esampson@suse.com>
   - Use product identifier for product migrations. (bsc#1268596)
   - Switch to using go1.26-openssl as the default Go version to
     install to support building the package (jsc#SCC-843 bsc#1268900).
+  - Fix flag parsing so that unknown flags or options are flagged as an
+    error and the usage message is displayed. (bsc#1159776).
 
 -------------------------------------------------------------------
 Wed Jun 10 18:43:58 UTC 2026 - Earl Sampson <esampson@suse.com>

--- a/cmd/suseconnect/suseconnect.go
+++ b/cmd/suseconnect/suseconnect.go
@@ -121,6 +121,11 @@ func main() {
 	flag.BoolVar(&info, "i", false, "")
 
 	flag.Parse()
+	if flag.NArg() > 0 {
+		fmt.Fprintf(os.Stderr, "Error: Unexpected argument '%s'\n\n", flag.Arg(0))
+		flag.Usage()
+		os.Exit(1) // Or use your custom exitOnError(err, nil, nil)
+	}
 
 	if version {
 		fmt.Println(connect.GetShortenedVersion())

--- a/cmd/suseconnect/suseconnect.go
+++ b/cmd/suseconnect/suseconnect.go
@@ -124,7 +124,7 @@ func main() {
 	if flag.NArg() > 0 {
 		fmt.Fprintf(os.Stderr, "Error: Unexpected argument '%s'\n\n", flag.Arg(0))
 		flag.Usage()
-		os.Exit(1) // Or use your custom exitOnError(err, nil, nil)
+		os.Exit(1)
 	}
 
 	if version {


### PR DESCRIPTION
Unexpected flags or arguments on the command line should generate an error message and display the command usage.

currently suseconnect ignores improper arguments on the command line so:
$ suseconnect -r REG-CODE sometext
$ suseconnect -d sometext
$ suseconnect --version sometext

all succeed. 

To test:
checkout branch and build suseconnect
$ sudo ./out/suseconnect --version unhandled

Will output the message:
Error: Unexpected argument 'unhandled'

followed by the command usage text

 