### PR TITLE
suseconnect does not allow de-register when subscription is expired

### DIFF
--- a/internal/connect/client.go
+++ b/internal/connect/client.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 
 	cred "github.com/SUSE/connect-ng/internal/credentials"
 	"github.com/SUSE/connect-ng/internal/util"
@@ -196,7 +197,7 @@ func Deregister(api WrappedAPI, opts *Options) error {
 	}
 
 	baseMeta, tree, err := registration.Upgrade(conn, base.Identifier, base.Version, base.Arch)
-	if err != nil {
+	if err != nil && !strings.Contains(err.Error(), "expired") {
 		return err
 	}
 
@@ -236,7 +237,7 @@ func Deregister(api WrappedAPI, opts *Options) error {
 		return err
 	}
 
-	if !opts.SkipServiceInstall {
+	if !opts.SkipServiceInstall && baseMeta != nil {
 		if err := localRemoveOrRefreshService(baseMeta.Name, opts); err != nil {
 			return err
 		}


### PR DESCRIPTION
https://jira.suse.com/browse/SCC-865
suseconnect does not allow de-register when subscription is expired

**How to Test**

Register a system using a reg code.
In you setup, bring up the psql console and using sql update the expires_at to an earlier date. For example 
-  UPDATE subscriptions SET expires_at = <earlier date> WHERE id = <subscription_id>;
Try to de-register. It should not fail with the fix.