### PR TITLE
Prepare v1.23.0 release

### DIFF
--- a/build/packaging/suseconnect-ng.changes
+++ b/build/packaging/suseconnect-ng.changes
@@ -1,20 +1,18 @@
 -------------------------------------------------------------------
-Thu Jul 16 13:58:11 UTC 2026 - Gabriel Bueno <gabriel.bueno@suse.com>
-
-- Adds a new optional rpm_packages collector, disabled by default,
-  to collect information on installed RPM packages of SUSE vendor.
-
--------------------------------------------------------------------
 Mon Jun 15 16:29:05 UTC 2026 - Earl Sampson <esampson@suse.com>
 
-- Update version to 1.23.0 (pre):
+- Update version to 1.23.0:
   - Use product identifier for product migrations. (bsc#1268596)
   - Switch to using go1.26-openssl as the default Go version to
     install to support building the package (jsc#SCC-843 bsc#1268900).
   - Fix flag parsing so that unknown flags or options are flagged as an
-    error and the usage message is displayed. (bsc#1159776).
+    error and the usage message is displayed. (bsc#1159776)
   - InstallReleasePackage interactive/noninteractive handling should
     be consistent with DistUpgrade (bsc#1267478).
+  - Add new optional rpm_packages collector, disabled by default, to
+    collect list of installed SUSE vendored RPM packages. (jsc#TEL-298)
+  - Allow deregsiter when subscribed regcode has expired (bsc#1270392
+    jsc#865)
 
 -------------------------------------------------------------------
 Wed Jun 10 18:43:58 UTC 2026 - Earl Sampson <esampson@suse.com>


### PR DESCRIPTION
Cleanup the suseconnect-ng.changes to prepare the v1.23.0 release:
  * Add missing changelog entry for #417 including appropriate bsc and jsc references.
  * Move the changelog entry for TEL-298 into the v1.23.0 version changelog list with some minor simplification to make room for including a jsc# reference.