### PR TITLE
Setup 1.24.0 pre release build

### DIFF
--- a/build/packaging/suseconnect-ng.changes
+++ b/build/packaging/suseconnect-ng.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Thu Aug  6 14:30:46 UTC 2026 - Fergal Mc Carthy <fmccarthy@suse.com>
+
+- Update version to 1.24.0 (pre):
+
+-------------------------------------------------------------------
 Mon Jun 15 16:29:05 UTC 2026 - Earl Sampson <esampson@suse.com>
 
 - Update version to 1.23.0:

--- a/build/packaging/suseconnect-ng.spec
+++ b/build/packaging/suseconnect-ng.spec
@@ -19,7 +19,7 @@
 %global project github.com/SUSE/connect-ng
 
 Name:           suseconnect-ng
-Version:        1.23.0
+Version:        1.24.0
 Release:        0
 URL:            https://github.com/SUSE/connect-ng
 License:        LGPL-3.0-or-later


### PR DESCRIPTION
Add placeholder entry for 1.24.0 release to suseconnect-ng.changes.

Update the version specified in suseconnect-ng.spec to 1.24.0.

Relates: SCC-899