### PR TITLE
Fix misleading message from transactional-update

### DIFF
--- a/build/packaging/suseconnect-ng.changes
+++ b/build/packaging/suseconnect-ng.changes
@@ -2,6 +2,7 @@
 Thu Aug  6 14:30:46 UTC 2026 - Fergal Mc Carthy <fmccarthy@suse.com>
 
 - Update version to 1.24.0 (pre):
+  - Fix misleading message from transactional-update. (bsc#1248824)
 
 -------------------------------------------------------------------
 Mon Jun 15 16:29:05 UTC 2026 - Earl Sampson <esampson@suse.com>

--- a/cmd/suseconnect/suseconnect.go
+++ b/cmd/suseconnect/suseconnect.go
@@ -383,6 +383,20 @@ func exitOnError(err error, api connect.WrappedAPI, opts *connect.Options) {
 	if err == nil {
 		return
 	}
+
+	// command in error message should match action user needs to do.
+	// so, if TRANSACTIONAL_UPDATE is active or we are trying update
+	// a transactional file system command should be "transactional-update register"
+
+	command_string := "SUSEConnect"
+	if os.Getenv("TRANSACTIONAL_UPDATE") != "" {
+		command_string = "transactional-update register"
+	} else if err1 := util.ReadOnlyFilesystem(opts.FsRoot); err1 != nil {
+		if strings.Contains(err1.Error(), "transactional-update register") {
+			command_string = "transactional-update register"
+		}
+	}
+
 	if ze, ok := err.(zypper.ZypperError); ok {
 		fmt.Println(ze)
 		os.Exit(ze.ExitCode)
@@ -406,7 +420,7 @@ func exitOnError(err error, api connect.WrappedAPI, opts *connect.Options) {
 			fmt.Print("Error: Invalid system credentials, probably because the ")
 			fmt.Print("registered system was deleted in SUSE Customer Center. ")
 			fmt.Print("Check ", opts.BaseURL, " whether your system appears there. ")
-			fmt.Print("If it does not, please call SUSEConnect --cleanup and re-register this system.\n")
+			fmt.Printf("If it does not, please call %s --cleanup and re-register this system.\n", command_string)
 		} else if connect.IsOutdatedRegProxy(api.GetConnection(), opts) {
 			fmt.Println(outdatedRegProxy)
 		} else {
@@ -430,10 +444,10 @@ func exitOnError(err error, api connect.WrappedAPI, opts *connect.Options) {
 		os.Exit(69)
 	case connect.ErrListExtensionsUnregistered:
 		fmt.Print("To list extensions, you must first register the base product, ")
-		fmt.Print("using: SUSEConnect -r <registration code>\n")
+		fmt.Printf("using: %s -r <registration code>\n", command_string)
 		os.Exit(1)
 	case connect.ErrBaseProductDeactivation:
-		fmt.Print("Can not deregister base product. Use SUSEConnect -d to deactivate ")
+		fmt.Printf("Can not deregister base product. Use %s -d to deactivate ", command_string)
 		fmt.Print("the whole system.\n")
 		os.Exit(70)
 	case connect.ErrPingFromUnregistered:
@@ -441,7 +455,7 @@ func exitOnError(err error, api connect.WrappedAPI, opts *connect.Options) {
 		fmt.Print("System is not registered. Use the --regcode parameter to register it.\n")
 		os.Exit(71)
 	default:
-		fmt.Printf("SUSEConnect error: %s\n", err)
+		fmt.Printf("%s error: %s\n", "SUSEConnect", err)
 		os.Exit(1)
 	}
 }

--- a/internal/util/system.go
+++ b/internal/util/system.go
@@ -142,10 +142,10 @@ func ReadOnlyFilesystem(root string) error {
 		// `transactional-update` binary installed is a transactional server.
 		_, err := os.Stat("/usr/sbin/transactional-update")
 		if statfs.Type == BTRFS_SUPER_MAGIC && err == nil {
-			// The user did not use the 'root' flag from the CLI: this is not
+			// If path is / from either no '--root' or '--root /' then this is not
 			// `transactional-update` calling SUSEConnect but rather a user
 			// directly which is dicouraged.
-			if root == "" {
+			if path == "/" {
 				return errors.New("This is a transactional system, please use `transactional-update register` to manage your product activations")
 			}
 


### PR DESCRIPTION
SUSEConnect may be either directly invoked by the user or indirectly invoked through 'transactional-update register" . If SUSEConnect returns an error sugesting a command to run. The command the use needs to run depends how SUSEConnect was invoked and the context in which it was run. This covered in the table below:
Command Used == the command the user entered,
                SUSEConnect, SUSEConnect --root, or transactional-update register

Transactional Target == yes, if the root used by SUSEConnect is a readonly btrfs
	      	        file system

Command in Error: the command we think the user should run to address the issue.
                  either SUSEConnect or transactional-update register

Command Used        	     	|Transactional  |Command in Error
				|Target		|
------------------------------------------------------------------------------
SUSEConnect        		|yes            |transactional-update register
SUSEConnect	   		|no		|SUSEConnect
transactional-update register   |yes or no      |transactional-update register
SUSEConnect --root /PATH  	|yes or no  	|SUSEConnect
SUSEConnect --root /		|yes  		|transactional-update register
SUSEConnect --root /		|no  		|SUSEConnect

The assumptions here are:
If user entered "transactional-update register" then that is what they meant and directions should respect that.

If user entered "SUSEConnect --root /PATH" then they want to use SUSEConnect on an alternative path and we should respect that.

If user entered "SUSEConnect --root /" on a transactional system, this should error and direct user to "transactional-update register" So, update util.ReadOnlyFilesystem to check 'path == /' instead of 'root == ""'

If user entered "SUSEConnect --root /" on a non transactional system and there is error we should direct user to "SUSEConnect"

How to test:
1:  create SLE  Micro 6.2 based VM
2: build the suseconnect rpm ad copy to VM.
3: make sure system not registeredL
   $ transactional-update register -d
4: uninstall susconnect and install from rpm.
   $ transactional-update pkg rm suseconnect-ng;transactional-update pkg install /tmp/suseconnect-ng-1.24.0-0.x86_64.rpm
5: reboot system on to new snapshot

validate:
 $ transactional-update register  -root /tmp --list-extensions  show error
To list extensions, you must first register the base product, using: transactional-update register -r <registration code>

$ SUSEConnect -r REGCODE  returns
  SUSEConnect error: This is a transactional system, please use `transactional-update register` to manage your product activations


$ SUSEConnect --root / -r REGCODE returns
SUSEConnect error: This is a transactional system, please use `transactional-update register` to manage your product  activations
