### PR TITLE
suseconnect-ng status output not consistently shown in requested format (bsc# 1233147)

### DIFF
--- a/build/packaging/suseconnect-ng.changes
+++ b/build/packaging/suseconnect-ng.changes
@@ -4,6 +4,8 @@ Thu Aug  6 14:30:46 UTC 2026 - Fergal Mc Carthy <fmccarthy@suse.com>
 - Update version to 1.24.0 (pre):
   - Fix misleading message from transactional-update. (bsc#1248824)
   - make --root a single use option (jsc#SCC-973)
+  - suseconnect-ng status output not consistently shown in 
+    requested format (bsc# 1233147)
 
 -------------------------------------------------------------------
 Mon Jun 15 16:29:05 UTC 2026 - Earl Sampson <esampson@suse.com>

--- a/cmd/suseconnect/suseconnect.go
+++ b/cmd/suseconnect/suseconnect.go
@@ -417,10 +417,12 @@ func exitOnError(err error, api connect.WrappedAPI, opts *connect.Options) {
 
 	handleAPIError := func(code int, err error) {
 		if code == http.StatusUnauthorized && api.IsRegistered() {
-			fmt.Print("Error: Invalid system credentials, probably because the ")
-			fmt.Print("registered system was deleted in SUSE Customer Center. ")
-			fmt.Print("Check ", opts.BaseURL, " whether your system appears there. ")
-			fmt.Printf("If it does not, please call %s --cleanup and re-register this system.\n", command_string)
+			errorMsg := fmt.Sprintf("Invalid system credentials, probably because the "+
+				"registered system was deleted in SUSE Customer Center. "+
+				"Check %s whether your system appears there. "+
+				"If it does not, please call %s --cleanup and re-register this system.", opts.BaseURL, command_string)
+			jsonOutput, _ := json.Marshal(map[string]string{"Error": errorMsg})
+			fmt.Println(string(jsonOutput))
 		} else if connect.IsOutdatedRegProxy(api.GetConnection(), opts) {
 			fmt.Println(outdatedRegProxy)
 		} else {


### PR DESCRIPTION
Customer has some tooling in place to query the status of the subscription on their SLE instances, and they expect the output to be consistently shown in json format as indicated on the manpage. 
Currently In case when an error message is output, it is just plain string and not in json format