### PR TITLE
Import GPG keys when installing products

### DIFF
--- a/build/packaging/suseconnect-ng.changes
+++ b/build/packaging/suseconnect-ng.changes
@@ -6,6 +6,8 @@ Thu Aug  6 14:30:46 UTC 2026 - Fergal Mc Carthy <fmccarthy@suse.com>
   - make --root a single use option (jsc#SCC-973)
   - suseconnect-ng status output not consistently shown in 
     requested format (bsc# 1233147)
+  - Fix error on activating sle-we due to nvidia repository
+    (bsc#1219176, bsc#1222028, bsc#1226006)
 
 -------------------------------------------------------------------
 Mon Jun 15 16:29:05 UTC 2026 - Earl Sampson <esampson@suse.com>

--- a/internal/zypper/zypper.go
+++ b/internal/zypper/zypper.go
@@ -259,7 +259,7 @@ func InstallReleasePackage(identifier string, autoImportRepoKeys bool, nonIntera
 	if nonInteractive {
 		args = append(args, "--non-interactive")
 	}
-	args = append(args, []string{"install", "--no-recommends", "--auto-agree-with-product-licenses", "-t", "product", identifier}...)
+	args = append(args, []string{"--gpg-auto-import-keys", "install", "--no-recommends", "--auto-agree-with-product-licenses", "-t", "product", identifier}...)
 
 	if autoImportRepoKeys {
 		args = append([]string{"--gpg-auto-import-keys"}, args...)


### PR DESCRIPTION
Installing products will fail if one of the required repos requires importing a GPG key

to test:
Requires SLE 15 SP  7 installed wothout workstation extension

1: build suseconnect and copy to VM /tmp/
2: if not registered register system
$ /tmp/suseconnect -r $SLES_SUBSCRIPTION

3: get desktop extension
$/tmp/suseconnect -p sle-module-desktop-applications/15.7/x86_64

$ activate sle-we
suseconnect -p sle-we/15.7/x86_64 -r $SLE_DESKTOP_REGCODE