### PR TITLE
Add libsuseconnect error JSON tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -162,7 +162,7 @@ coverage-percent: coverage-check-enabled coverage-dirs
 coverage: coverage-func
 
 test: internal/connect/version.txt coverage-dirs
-	$(GO) test ./internal/* ./cmd/suseconnect ./cmd/suseconnect-mcp ./pkg/* $(call cover-test-flags)
+	$(GO) test ./internal/* ./cmd/suseconnect ./cmd/suseconnect-mcp ./pkg/* ./third_party/libsuseconnect $(call cover-test-flags)
 	$(call go-tool-covdata-report,func,$(COVERAGE_UNIT))
 
 unit-test-coverage: coverage-dirs

--- a/third_party/libsuseconnect/libsuseconnect_test.go
+++ b/third_party/libsuseconnect/libsuseconnect_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/SUSE/connect-ng/internal/connect"
 	cred "github.com/SUSE/connect-ng/internal/credentials"
 	"github.com/SUSE/connect-ng/pkg/connection"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type timeoutError struct{}
@@ -143,14 +145,13 @@ func TestErrorToJSON(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			var got errorResponse
-			if err := json.Unmarshal([]byte(errorToJSON(test.err)), &got); err != nil {
-				t.Fatalf("errorToJSON returned invalid JSON: %v", err)
-			}
+			assert := assert.New(t)
 
-			if got != test.want {
-				t.Fatalf("errorToJSON() = %#v, want %#v", got, test.want)
-			}
+			var got errorResponse
+			err := json.Unmarshal([]byte(errorToJSON(test.err)), &got)
+			require.NoError(t, err, "errorToJSON must return valid JSON")
+
+			assert.Equal(test.want, got)
 		})
 	}
 }

--- a/third_party/libsuseconnect/libsuseconnect_test.go
+++ b/third_party/libsuseconnect/libsuseconnect_test.go
@@ -1,0 +1,156 @@
+package main
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"errors"
+	"net"
+	"net/url"
+	"testing"
+
+	"github.com/SUSE/connect-ng/internal/connect"
+	cred "github.com/SUSE/connect-ng/internal/credentials"
+	"github.com/SUSE/connect-ng/pkg/connection"
+)
+
+type timeoutError struct{}
+
+func (timeoutError) Error() string { return "request timed out" }
+func (timeoutError) Timeout() bool { return true }
+
+type errorResponse struct {
+	ErrType string `json:"err_type"`
+	Message string `json:"message"`
+	Code    int    `json:"code"`
+	Data    string `json:"data,omitempty"`
+}
+
+func certificatePEM(cert *x509.Certificate) string {
+	return string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: cert.Raw}))
+}
+
+func TestErrorToJSON(t *testing.T) {
+	leaf := &x509.Certificate{Raw: []byte("leaf certificate")}
+	issuer := &x509.Certificate{Raw: []byte("issuer certificate")}
+	invalidCertificateError := x509.CertificateInvalidError{
+		Cert:   leaf,
+		Reason: x509.Expired,
+	}
+	unknownAuthorityError := x509.UnknownAuthorityError{Cert: leaf}
+	verificationError := &tls.CertificateVerificationError{
+		UnverifiedCertificates: []*x509.Certificate{leaf, issuer},
+		Err:                    unknownAuthorityError,
+	}
+	hostnameError := x509.HostnameError{Certificate: leaf, Host: "example.invalid"}
+	networkError := &net.OpError{Op: "dial", Net: "tcp", Err: errors.New("connection refused")}
+	plainURLError := &url.Error{Op: "Get", URL: "https://example.invalid", Err: errors.New("unexpected response")}
+	jsonError := connect.JSONError{Err: errors.New("invalid character")}
+	genericError := errors.New("generic failure")
+
+	tests := []struct {
+		name string
+		err  error
+		want errorResponse
+	}{
+		{
+			name: "API error",
+			err:  &connection.ApiError{Code: 422, Message: "invalid product"},
+			want: errorResponse{ErrType: "APIError", Message: "invalid product", Code: 422},
+		},
+		{
+			name: "timeout",
+			err:  &url.Error{Op: "Get", URL: "https://example.invalid", Err: timeoutError{}},
+			want: errorResponse{ErrType: "Timeout", Message: "request timed out"},
+		},
+		{
+			name: "invalid certificate",
+			err:  &url.Error{Op: "Get", URL: "https://example.invalid", Err: invalidCertificateError},
+			want: errorResponse{
+				ErrType: "SSLError",
+				Message: invalidCertificateError.Error(),
+				Code:    10,
+				Data:    certificatePEM(leaf),
+			},
+		},
+		{
+			name: "unknown certificate authority",
+			err:  &url.Error{Op: "Get", URL: "https://example.invalid", Err: unknownAuthorityError},
+			want: errorResponse{
+				ErrType: "SSLError",
+				Message: unknownAuthorityError.Error(),
+				Code:    19,
+				Data:    certificatePEM(leaf),
+			},
+		},
+		{
+			name: "TLS certificate verification",
+			err:  &url.Error{Op: "Get", URL: "https://example.invalid", Err: verificationError},
+			want: errorResponse{
+				ErrType: "SSLError",
+				Message: verificationError.Error(),
+				Code:    19,
+				Data:    certificatePEM(issuer) + certificatePEM(leaf),
+			},
+		},
+		{
+			name: "certificate hostname",
+			err:  &url.Error{Op: "Get", URL: "https://example.invalid", Err: hostnameError},
+			want: errorResponse{
+				ErrType: "SSLError",
+				Message: hostnameError.Error(),
+				Data:    certificatePEM(leaf),
+			},
+		},
+		{
+			name: "network operation",
+			err:  &url.Error{Op: "Get", URL: "https://example.invalid", Err: networkError},
+			want: errorResponse{ErrType: "NetError", Message: networkError.Error()},
+		},
+		{
+			name: "unclassified URL error",
+			err:  plainURLError,
+			want: errorResponse{Message: plainURLError.Error()},
+		},
+		{
+			name: "JSON decoding",
+			err:  jsonError,
+			want: errorResponse{ErrType: "JSONError", Message: "invalid character"},
+		},
+		{
+			name: "malformed SCC credentials",
+			err:  cred.ErrMalformedSccCredFile,
+			want: errorResponse{
+				ErrType: "MalformedSccCredentialsFile",
+				Message: cred.ErrMalformedSccCredFile.Error(),
+			},
+		},
+		{
+			name: "missing credentials file",
+			err:  cred.ErrMissingCredentialsFile,
+			want: errorResponse{
+				ErrType: "MissingCredentialsFile",
+				Message: cred.ErrMissingCredentialsFile.Error(),
+			},
+		},
+		{
+			name: "generic error",
+			err:  genericError,
+			want: errorResponse{Message: genericError.Error()},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var got errorResponse
+			if err := json.Unmarshal([]byte(errorToJSON(test.err)), &got); err != nil {
+				t.Fatalf("errorToJSON returned invalid JSON: %v", err)
+			}
+
+			if got != test.want {
+				t.Fatalf("errorToJSON() = %#v, want %#v", got, test.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

Add table-driven regression coverage for every current `errorToJSON` branch in `libsuseconnect`, including API, timeout, certificate, network, JSON, credentials, and fallback errors. Wire the package into the existing `make test` target so the new coverage runs in CI.

* Related Issue / Ticket / Trello card: Closes #362

## How to test the change

- `go test -count=1 -race ./third_party/libsuseconnect`
- `go vet ./third_party/libsuseconnect`
- `make check-format`
- `make vendor build`
- `go test -coverprofile=libsuseconnect.cover ./third_party/libsuseconnect` reports 100% statement coverage for `errorToJSON`

I also mutation-checked the table locally: changing the API error type mapping made the named API-error case fail, and restoring it returned the suite to green.

The full `make test` target ran every selected package and the new `libsuseconnect` package passed. Its existing `internal/zypper/TestBackupAndRestore` case remains Linux-specific and fails on macOS because the expected parent-directory copy is not created; the upstream Linux job is the authoritative full-suite gate.

## Review

Please check out our [review guidelines](https://github.com/SUSE/scc-docs/blob/master/team/workflow/code_review.md) and get in touch with the author to get a shared understanding of the change.

❤️ Thank you! ❤️
