### PR TITLE
Add mcp-server-suseconnect to recomends for suseconnect-ng

### DIFF
--- a/build/packaging/suseconnect-ng.changes
+++ b/build/packaging/suseconnect-ng.changes
@@ -6,6 +6,8 @@ Thu Aug  6 14:30:46 UTC 2026 - Fergal Mc Carthy <fmccarthy@suse.com>
   - make --root a single use option (jsc#SCC-973)
   - suseconnect-ng status output not consistently shown in 
     requested format (bsc# 1233147)
+  - Add mcp-server-suseconnect to recommends for suseconnect-ng
+    for SLE 16.0 and later releases  (jsc#SCC-985)
 
 -------------------------------------------------------------------
 Mon Jun 15 16:29:05 UTC 2026 - Earl Sampson <esampson@suse.com>

--- a/build/packaging/suseconnect-ng.spec
+++ b/build/packaging/suseconnect-ng.spec
@@ -60,6 +60,9 @@ Requires:       coreutils
 Requires:       pciutils
 Requires:       util-linux
 Requires:       zypper
+%if (0%{?suse_version} >= 1600 && 0%{?suse_version} != 1699)
+Recommends:     mcp-server-suseconnect
+%endif
 Recommends:     systemd
 
 %ifarch s390x


### PR DESCRIPTION
Add mcp-server-suseconnect to recommends for suseconnect-ng for the 16.0 and later OS streams. But not tumbleweed.


To Test:
1: set up to build for 16.0  by setting  suse_version to 1601
with the following local change:

```
diff --git a/build/ci/build-rpm b/build/ci/build-rpm
index b4cae6c..398fded 100755
--- a/build/ci/build-rpm
+++ b/build/ci/build-rpm
@@ -72,7 +72,7 @@ groupend
 
 group "build suseconnect-ng-$VERSION.rpm"
 pushd "$BUILD_DIR"
-  rpmbuild -ba --define '_srcdefattr (-,root,root)' --nosignature --undefine _enable_debug_packages SOURCES/suseconnect-ng.spec
+  rpmbuild -ba --define '_srcdefattr (-,root,root)' --nosignature --undefine _enable_debug_packages --define "suse_version 1600" SOURCES/suseconnect-ng.spec
   cp "RPMS/${ARCH}"/*.rpm "$ARTIFACT_DIR"
 popd
 groupend

```
1: build suseconnect RPMs
$ make build-rpm

2: copy staging files to SLE 16.0 or SLE16.1 VM
$ ssh admin1@192.168.122.54 "mkdir /tmp/local_rpms"
$ scp artifacts/*.rpms admin1@192.168.122.54:/tmp/local_rpms/.

On VM:
3: set up zypper repo for rpms:
$ sudo zypper addrepo /tmp/local_rpms local-sle16-repo

4: Install updated suseconnect
$ sudo zypper ref
$ sudo zypper in suseconnect-ng  # may require uninstalling suseconnect-ng

5: validate that mcp-server-suseconnect was installed
$ sudo zypper se mcp-server-suseconnect

Refreshing service 'SUSE_Linux_Enterprise_Server_16.0_x86_64'.
Loading repository data...
Reading installed packages...

S  | Name                   | Summary                    | Type
---+------------------------+----------------------------+--------
i  | mcp-server-suseconnect | MCP server for suseconnect | package
