### PR TITLE
Enhance public-api-demo to support PubCloud RMT dev-env testing

### DIFF
--- a/cmd/public-api-demo/main.go
+++ b/cmd/public-api-demo/main.go
@@ -115,12 +115,13 @@ func runDemo(identifier, version, arch, infoPath, regcode string, systemProfiles
 	}
 
 	extraData := registration.ExtraData{
-		"instance_data":   "<document>{}</document>",
+		"instance_data": `<instance_data product="SUSE"/>
+<document>{}</document>`,
 		"system_profiles": systemProfiles,
 	}
 
 	bold("2) Registering a client to SCC with a registration code\n")
-	id, regErr := registration.Register(conn, regcode, hostname, systemInformation, registration.NoExtraData)
+	id, regErr := registration.Register(conn, regcode, hostname, systemInformation, extraData)
 	if regErr != nil {
 		return regErr
 	}


### PR DESCRIPTION
Update the instance_data XML document to include an instance_data tag that specifies a product attribute with a value of "SUSE". This will ensure that a PubCloud enabled RMT dev-env, relying on the default Example Provider in the PubCloud instance_verification engine, is assigned a meaningful instance identifier, e.g. 1234, allowing basic BYOS registration and keepalive update testing to work correctly.

Also update the registration.Register() call includes the recently constructed extraData containing the instance_data value.

Relates: jsc#SCC-822

Signed-off-by: Fergal Mc Carthy